### PR TITLE
Add Gemini API support for RCA

### DIFF
--- a/ai/config.py
+++ b/ai/config.py
@@ -5,18 +5,28 @@ import os
 # Feature toggle — must be explicitly enabled
 AI_RCA_ENABLED = os.environ.get("AI_RCA_ENABLED", "false").lower() == "true"
 
-# Anthropic API key — retrieved from environment (set via Secrets Manager in Lambda)
+# LLM provider: "claude" or "gemini"
+AI_RCA_PROVIDER = os.environ.get("AI_RCA_PROVIDER", "claude").lower()
+
+# API key secret names in Secrets Manager
 ANTHROPIC_API_KEY_SECRET_NAME = os.environ.get(
     "ANTHROPIC_API_KEY_SECRET_NAME", "failover-orchestrator/anthropic-api-key"
 )
+GEMINI_API_KEY_SECRET_NAME = os.environ.get(
+    "GEMINI_API_KEY_SECRET_NAME", "failover-orchestrator/gemini-api-key"
+)
 
-# Model selection: haiku for cost-sensitive, sonnet for detailed analysis
-AI_RCA_MODEL = os.environ.get("AI_RCA_MODEL", "claude-haiku-4-5-20251001")
+# Model defaults per provider
+_DEFAULT_MODELS = {
+    "claude": "claude-haiku-4-5-20251001",
+    "gemini": "gemini-2.5-flash",
+}
+AI_RCA_MODEL = os.environ.get("AI_RCA_MODEL", _DEFAULT_MODELS.get(AI_RCA_PROVIDER, "claude-haiku-4-5-20251001"))
 
 # Max tokens for the RCA response
 AI_RCA_MAX_TOKENS = int(os.environ.get("AI_RCA_MAX_TOKENS", "1024"))
 
-# Timeout for the Claude API call (seconds). RCA must not delay failover.
+# Timeout for the API call (seconds). RCA must not delay failover.
 AI_RCA_TIMEOUT_SECONDS = int(os.environ.get("AI_RCA_TIMEOUT_SECONDS", "15"))
 
 # How far back to look when collecting logs/events (minutes)

--- a/ai/rca_analyzer.py
+++ b/ai/rca_analyzer.py
@@ -1,5 +1,5 @@
 """
-Root Cause Analysis using Claude API.
+Root Cause Analysis using Claude or Gemini API.
 
 Accepts collected incident context and returns a structured RCA summary
 suitable for SNS notification to operators.
@@ -17,8 +17,10 @@ from botocore.exceptions import ClientError
 from ai.config import (
     AI_RCA_MAX_TOKENS,
     AI_RCA_MODEL,
+    AI_RCA_PROVIDER,
     AI_RCA_TIMEOUT_SECONDS,
     ANTHROPIC_API_KEY_SECRET_NAME,
+    GEMINI_API_KEY_SECRET_NAME,
 )
 
 logger = logging.getLogger(__name__)
@@ -65,87 +67,144 @@ Do NOT add a title or heading — start directly with the Timeline section.
 Use plain text only — no markdown formatting (no **, no #, no tables). Use CAPS for emphasis instead."""
 
 
-def get_api_key(region: Optional[str] = None) -> str:
-    """Retrieve Anthropic API key from Secrets Manager."""
-    # Allow direct env var override for testing
-    key = os.environ.get("ANTHROPIC_API_KEY")
-    if key:
-        return key
-
+def _get_secret(secret_name: str, region: Optional[str] = None) -> str:
+    """Retrieve a secret from Secrets Manager."""
     try:
         sm = boto3.client(
             "secretsmanager",
             region_name=region or os.environ.get("AWS_REGION", "us-east-1"),
         )
-        resp = sm.get_secret_value(SecretId=ANTHROPIC_API_KEY_SECRET_NAME)
+        resp = sm.get_secret_value(SecretId=secret_name)
         return resp["SecretString"]
     except ClientError as e:
-        logger.error(f"Failed to retrieve API key from Secrets Manager: {e}")
+        logger.error(f"Failed to retrieve secret {secret_name}: {e}")
         raise
+
+
+def get_api_key(region: Optional[str] = None) -> str:
+    """Retrieve API key for the configured provider."""
+    # Allow direct env var override for testing
+    if AI_RCA_PROVIDER == "gemini":
+        key = os.environ.get("GEMINI_API_KEY")
+        if key:
+            return key
+        return _get_secret(GEMINI_API_KEY_SECRET_NAME, region)
+    else:
+        key = os.environ.get("ANTHROPIC_API_KEY")
+        if key:
+            return key
+        return _get_secret(ANTHROPIC_API_KEY_SECRET_NAME, region)
+
+
+def _build_prompt(incident_context: dict) -> str:
+    """Build the RCA prompt from incident context."""
+    return RCA_PROMPT_TEMPLATE.format(
+        region=incident_context.get("region", "unknown"),
+        timestamp=incident_context.get("timestamp", "unknown"),
+        window_minutes=incident_context.get("window_minutes", "10"),
+        health_signals=json.dumps(
+            incident_context.get("health_signals", {}), indent=2, default=str
+        ),
+        ecs_events=json.dumps(
+            incident_context.get("ecs_events", {}), indent=2, default=str
+        ),
+        aurora_status=json.dumps(
+            incident_context.get("aurora_status", {}), indent=2, default=str
+        ),
+        alb_health=json.dumps(
+            incident_context.get("alb_health", "N/A"), indent=2, default=str
+        ),
+        application_logs=json.dumps(
+            incident_context.get("application_logs", "N/A"), indent=2, default=str
+        ),
+    )
+
+
+def _call_claude(api_key: str, prompt: str) -> str:
+    """Call the Claude API and return the analysis text."""
+    request_body = json.dumps({
+        "model": AI_RCA_MODEL,
+        "max_tokens": AI_RCA_MAX_TOKENS,
+        "messages": [{"role": "user", "content": prompt}],
+    })
+
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=request_body.encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        },
+        method="POST",
+    )
+
+    with urllib.request.urlopen(req, timeout=AI_RCA_TIMEOUT_SECONDS) as resp:
+        result = json.loads(resp.read().decode("utf-8"))
+
+    content_blocks = result.get("content", [])
+    analysis = "\n".join(
+        block["text"] for block in content_blocks if block.get("type") == "text"
+    )
+
+    if not analysis:
+        return "[RCA] Claude returned empty response"
+    return analysis
+
+
+def _call_gemini(api_key: str, prompt: str) -> str:
+    """Call the Gemini API and return the analysis text."""
+    url = (
+        f"https://generativelanguage.googleapis.com/v1beta/models/"
+        f"{AI_RCA_MODEL}:generateContent?key={api_key}"
+    )
+
+    request_body = json.dumps({
+        "contents": [{"parts": [{"text": prompt}]}],
+        "generationConfig": {
+            "maxOutputTokens": AI_RCA_MAX_TOKENS,
+        },
+    })
+
+    req = urllib.request.Request(
+        url,
+        data=request_body.encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    with urllib.request.urlopen(req, timeout=AI_RCA_TIMEOUT_SECONDS) as resp:
+        result = json.loads(resp.read().decode("utf-8"))
+
+    candidates = result.get("candidates", [])
+    if not candidates:
+        return "[RCA] Gemini returned empty response"
+
+    parts = candidates[0].get("content", {}).get("parts", [])
+    analysis = "\n".join(part["text"] for part in parts if "text" in part)
+
+    if not analysis:
+        return "[RCA] Gemini returned empty response"
+    return analysis
 
 
 def analyze_incident(incident_context: dict, region: Optional[str] = None) -> str:
     """
-    Send incident context to Claude API and return RCA summary.
+    Send incident context to the configured LLM provider and return RCA summary.
 
     Returns the analysis text, or an error message if the API call fails.
     This function must never raise — RCA failure should not block failover.
     """
     try:
         api_key = get_api_key(region)
+        prompt = _build_prompt(incident_context)
 
-        prompt = RCA_PROMPT_TEMPLATE.format(
-            region=incident_context.get("region", "unknown"),
-            timestamp=incident_context.get("timestamp", "unknown"),
-            window_minutes=incident_context.get("window_minutes", "10"),
-            health_signals=json.dumps(
-                incident_context.get("health_signals", {}), indent=2, default=str
-            ),
-            ecs_events=json.dumps(
-                incident_context.get("ecs_events", {}), indent=2, default=str
-            ),
-            aurora_status=json.dumps(
-                incident_context.get("aurora_status", {}), indent=2, default=str
-            ),
-            alb_health=json.dumps(
-                incident_context.get("alb_health", "N/A"), indent=2, default=str
-            ),
-            application_logs=json.dumps(
-                incident_context.get("application_logs", "N/A"), indent=2, default=str
-            ),
-        )
+        logger.info(f"Using provider: {AI_RCA_PROVIDER}, model: {AI_RCA_MODEL}")
 
-        # Use raw HTTP via urllib to avoid adding anthropic SDK as a Lambda dependency
-        request_body = json.dumps({
-            "model": AI_RCA_MODEL,
-            "max_tokens": AI_RCA_MAX_TOKENS,
-            "messages": [{"role": "user", "content": prompt}],
-        })
-
-        req = urllib.request.Request(
-            "https://api.anthropic.com/v1/messages",
-            data=request_body.encode("utf-8"),
-            headers={
-                "Content-Type": "application/json",
-                "x-api-key": api_key,
-                "anthropic-version": "2023-06-01",
-            },
-            method="POST",
-        )
-
-        with urllib.request.urlopen(req, timeout=AI_RCA_TIMEOUT_SECONDS) as resp:
-            result = json.loads(resp.read().decode("utf-8"))
-
-        # Extract text from response
-        content_blocks = result.get("content", [])
-        analysis = "\n".join(
-            block["text"] for block in content_blocks if block.get("type") == "text"
-        )
-
-        if not analysis:
-            return "[RCA] Claude returned empty response"
-
-        return analysis
+        if AI_RCA_PROVIDER == "gemini":
+            return _call_gemini(api_key, prompt)
+        else:
+            return _call_claude(api_key, prompt)
 
     except Exception as e:
         logger.error(f"RCA analysis failed: {type(e).__name__}: {e}")
@@ -155,13 +214,14 @@ def analyze_incident(incident_context: dict, region: Optional[str] = None) -> st
 def format_rca_for_sns(rca_text: str, incident_context: dict) -> str:
     """Format the RCA analysis for inclusion in an SNS notification."""
     separator = "-" * 60
+    provider_label = f"{AI_RCA_PROVIDER.capitalize()}/{AI_RCA_MODEL}"
     return (
         f"\n{separator}\n"
         f"AI ROOT CAUSE ANALYSIS\n"
         f"{separator}\n\n"
         f"{rca_text}\n\n"
         f"{separator}\n"
-        f"Model: {AI_RCA_MODEL} | "
+        f"Model: {provider_label} | "
         f"Region: {incident_context.get('region', 'unknown')} | "
         f"Log window: {incident_context.get('window_minutes', '?')}m\n"
         f"This is an AI-generated analysis. Verify before acting.\n"

--- a/tests/test_rca.py
+++ b/tests/test_rca.py
@@ -426,6 +426,124 @@ class TestRCAAnalyzer:
 
 
 # ===========================================================================
+# Gemini Provider Tests
+# ===========================================================================
+
+
+class TestGeminiProvider:
+    """Tests for Gemini API integration."""
+
+    SAMPLE_CONTEXT = {
+        "region": "us-east-1",
+        "timestamp": "2026-04-02T15:30:00+00:00",
+        "window_minutes": 10,
+        "health_signals": {"http": {"healthy": False}},
+        "ecs_events": {"status": "ACTIVE"},
+        "aurora_status": {"status": "available"},
+    }
+
+    @patch("ai.rca_analyzer.os.environ", {"GEMINI_API_KEY": "gem-key"})
+    @patch("ai.rca_analyzer.AI_RCA_PROVIDER", "gemini")
+    def test_get_api_key_gemini_from_env(self):
+        from ai.rca_analyzer import get_api_key
+        assert get_api_key() == "gem-key"
+
+    @patch("ai.rca_analyzer.os.environ", {})
+    @patch("ai.rca_analyzer.AI_RCA_PROVIDER", "gemini")
+    @patch("ai.rca_analyzer.boto3")
+    def test_get_api_key_gemini_from_secrets_manager(self, mock_boto3):
+        from ai.rca_analyzer import get_api_key
+
+        mock_sm = MagicMock()
+        mock_boto3.client.return_value = mock_sm
+        mock_sm.get_secret_value.return_value = {"SecretString": "gem-secret"}
+
+        key = get_api_key("us-east-1")
+        assert key == "gem-secret"
+
+    @patch("ai.rca_analyzer.urllib.request.urlopen")
+    @patch("ai.rca_analyzer.get_api_key", return_value="gem-key")
+    @patch("ai.rca_analyzer.AI_RCA_PROVIDER", "gemini")
+    @patch("ai.rca_analyzer.AI_RCA_MODEL", "gemini-2.5-flash")
+    def test_gemini_analyze_success(self, mock_key, mock_urlopen):
+        from ai.rca_analyzer import analyze_incident
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "candidates": [{
+                "content": {
+                    "parts": [{"text": "Timeline:\n- 15:28 HTTP failed\n\nRoot Cause:\nECS tasks stopped."}]
+                }
+            }]
+        }).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        result = analyze_incident(self.SAMPLE_CONTEXT)
+        assert "Timeline" in result
+        assert "Root Cause" in result
+
+    @patch("ai.rca_analyzer.urllib.request.urlopen")
+    @patch("ai.rca_analyzer.get_api_key", return_value="gem-key")
+    @patch("ai.rca_analyzer.AI_RCA_PROVIDER", "gemini")
+    @patch("ai.rca_analyzer.AI_RCA_MODEL", "gemini-2.5-flash")
+    def test_gemini_empty_response(self, mock_key, mock_urlopen):
+        from ai.rca_analyzer import analyze_incident
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"candidates": []}).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        result = analyze_incident(self.SAMPLE_CONTEXT)
+        assert "empty response" in result
+
+    @patch("ai.rca_analyzer.urllib.request.urlopen")
+    @patch("ai.rca_analyzer.get_api_key", return_value="gem-key")
+    @patch("ai.rca_analyzer.AI_RCA_PROVIDER", "gemini")
+    @patch("ai.rca_analyzer.AI_RCA_MODEL", "gemini-2.5-flash")
+    def test_gemini_sends_correct_request(self, mock_key, mock_urlopen):
+        from ai.rca_analyzer import analyze_incident
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "candidates": [{"content": {"parts": [{"text": "analysis"}]}}]
+        }).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        analyze_incident(self.SAMPLE_CONTEXT)
+
+        call_args = mock_urlopen.call_args
+        req = call_args[0][0]
+        assert "generativelanguage.googleapis.com" in req.full_url
+        assert "gemini-2.5-flash" in req.full_url
+        assert "key=gem-key" in req.full_url
+
+        body = json.loads(req.data.decode())
+        assert "contents" in body
+        assert "failover" in body["contents"][0]["parts"][0]["text"].lower()
+
+    @patch("ai.rca_analyzer.get_api_key", side_effect=Exception("gemini auth failed"))
+    @patch("ai.rca_analyzer.AI_RCA_PROVIDER", "gemini")
+    def test_gemini_failure_is_non_blocking(self, mock_key):
+        from ai.rca_analyzer import analyze_incident
+
+        result = analyze_incident(self.SAMPLE_CONTEXT)
+        assert "[RCA] Analysis unavailable" in result
+
+    def test_format_rca_shows_provider(self):
+        from ai.rca_analyzer import format_rca_for_sns
+
+        formatted = format_rca_for_sns("Test", self.SAMPLE_CONTEXT)
+        # Should show provider/model in footer
+        assert "AI ROOT CAUSE ANALYSIS" in formatted
+
+
+# ===========================================================================
 # Orchestrator Integration Tests
 # ===========================================================================
 


### PR DESCRIPTION
## Summary
- Add `AI_RCA_PROVIDER` env var to switch between `claude` (default) and `gemini`
- Implement Gemini API integration via urllib (no SDK dependency)
- Refactor `rca_analyzer.py` into `_call_claude()` and `_call_gemini()` with shared prompt/formatting
- Auto-select default model per provider (`claude-haiku-4-5-20251001` / `gemini-2.5-flash`)
- 7 new Gemini-specific tests (32 total passing)

## New environment variables
| Variable | Default | Description |
|----------|---------|-------------|
| `AI_RCA_PROVIDER` | `claude` | LLM provider: `claude` or `gemini` |
| `GEMINI_API_KEY_SECRET_NAME` | `failover-orchestrator/gemini-api-key` | Secrets Manager key for Gemini |

## Test plan
- [x] `python3 -m pytest tests/test_rca.py -v` — 32 passed, 1 skipped
- [ ] Deploy with `AI_RCA_PROVIDER=gemini` and test live failover
- [ ] Verify Gemini RCA output quality matches Claude

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)