### PR TITLE
Multi-scenario demo environment management

### DIFF
--- a/cfn/failover.yaml
+++ b/cfn/failover.yaml
@@ -58,11 +58,11 @@ Resources:
   AlertTopic:
     Type: AWS::SNS::Topic
     Properties:
-      TopicName: !Sub 'fo-${Env}-alerts'
+      TopicName: !Sub '${Env}-alerts'
       DisplayName: !Sub 'FO Demo Alerts (${AWS::Region})'
       Tags:
         - Key: Name
-          Value: !Sub 'fo-${Env}-alerts'
+          Value: !Sub '${Env}-alerts'
 
   AlertSubscription:
     Type: AWS::SNS::Subscription
@@ -75,7 +75,7 @@ Resources:
   LambdaRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub 'fo-${Env}-lambda-role-${AWS::Region}'
+      RoleName: !Sub '${Env}-lambda-role-${AWS::Region}'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -149,13 +149,13 @@ Resources:
                 Resource: '*'
       Tags:
         - Key: Name
-          Value: !Sub 'fo-${Env}-lambda-role'
+          Value: !Sub '${Env}-lambda-role'
 
   # ── Failover Orchestrator Lambda ───────────────────────────────────────────
   OrchestratorLambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub 'fo-${Env}-orchestrator'
+      FunctionName: !Sub '${Env}-orchestrator'
       Runtime: python3.12
       Handler: failover_orchestrator_v3.lambda_handler
       Role: !GetAtt LambdaRole.Arn
@@ -198,16 +198,16 @@ Resources:
           CONSECUTIVE_FAILURES_THRESHOLD: !Ref ConsecutiveFailuresThreshold
           HEALTH_EVALUATION_WINDOW_MINUTES: '5'
           MIN_HEALTHY_HOST_COUNT: '1'
-          APP_NAME: !Sub 'fo-${Env}'
+          APP_NAME: !Sub '${Env}'
       Tags:
         - Key: Name
-          Value: !Sub 'fo-${Env}-orchestrator'
+          Value: !Sub '${Env}-orchestrator'
 
   # ── Failback Lambda ────────────────────────────────────────────────────────
   FailbackLambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub 'fo-${Env}-failback'
+      FunctionName: !Sub '${Env}-failback'
       Runtime: python3.12
       Handler: manual_failback_v2.lambda_handler
       Role: !GetAtt LambdaRole.Arn
@@ -241,16 +241,16 @@ Resources:
           AURORA_GLOBAL_CLUSTER_ID: !Ref AuroraGlobalClusterId
           ECS_CLUSTER_NAME: !Ref EcsClusterName
           ECS_SERVICE_NAME: !Ref EcsServiceName
-          APP_NAME: !Sub 'fo-${Env}'
+          APP_NAME: !Sub '${Env}'
       Tags:
         - Key: Name
-          Value: !Sub 'fo-${Env}-failback'
+          Value: !Sub '${Env}-failback'
 
   # ── EventBridge Rule (1-minute schedule) ──────────────────────────────────
   OrchestratorSchedule:
     Type: AWS::Events::Rule
     Properties:
-      Name: !Sub 'fo-${Env}-orchestrator-schedule'
+      Name: !Sub '${Env}-orchestrator-schedule'
       Description: 'Trigger failover orchestrator every minute'
       ScheduleExpression: 'rate(1 minute)'
       State: ENABLED
@@ -271,7 +271,7 @@ Resources:
   RegionActiveAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub 'fo-${Env}-region-inactive-${AWS::Region}'
+      AlarmName: !Sub '${Env}-region-inactive-${AWS::Region}'
       AlarmDescription: !Sub 'Region ${AWS::Region} RegionActiveStatus is 0 or missing'
       Namespace: 'Custom/FoDemo'
       MetricName: 'RegionActiveStatus'
@@ -302,7 +302,7 @@ Resources:
         InsufficientDataHealthStatus: Unhealthy
       HealthCheckTags:
         - Key: Name
-          Value: !Sub 'fo-${Env}-hc-${AWS::Region}'
+          Value: !Sub '${Env}-hc-${AWS::Region}'
         - Key: Region
           Value: !Ref AWS::Region
 

--- a/cfn/failover.yaml
+++ b/cfn/failover.yaml
@@ -157,7 +157,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${Env}-orchestrator'
       Runtime: python3.12
-      Handler: failover_orchestrator_v3.lambda_handler
+      Handler: failover_orchestrator_v3.handler
       Role: !GetAtt LambdaRole.Arn
       Timeout: 55
       MemorySize: 256
@@ -209,7 +209,7 @@ Resources:
     Properties:
       FunctionName: !Sub '${Env}-failback'
       Runtime: python3.12
-      Handler: manual_failback_v2.lambda_handler
+      Handler: manual_failback_v2.handler
       Role: !GetAtt LambdaRole.Arn
       Timeout: 120
       MemorySize: 256

--- a/cfn/scenario-app.yaml
+++ b/cfn/scenario-app.yaml
@@ -1,0 +1,357 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  FO Demo - Per-Scenario App Stack.
+  Creates ALB, ECS service, SGs, and IAM roles for a single scenario,
+  referencing shared infrastructure (ECS cluster, VPC endpoints) from
+  the fo-demo-app and fo-demo-network stacks.
+
+Parameters:
+  Env:
+    Type: String
+    Description: Scenario name (e.g. fo-v10-s1)
+  NetworkStack:
+    Type: String
+    Description: Name of the network CloudFormation stack (fo-demo-network)
+  SharedAppStack:
+    Type: String
+    Description: Name of the shared app stack that owns the ECS cluster and VPC endpoints (fo-demo-app)
+  ContainerImage:
+    Type: String
+    Description: Full ECR image URI (e.g. 123456.dkr.ecr.us-west-1.amazonaws.com/fo-demo-app:latest)
+    Default: 'placeholder'
+  AuroraEndpoint:
+    Type: String
+    Description: Aurora writer/reader cluster endpoint for this region
+    Default: 'placeholder'
+  AuroraPort:
+    Type: String
+    Default: '5432'
+  AuroraDb:
+    Type: String
+    Default: 'appdb'
+  AuroraUser:
+    Type: String
+    Default: 'appuser'
+  AuroraPassword:
+    Type: String
+    NoEcho: true
+    Default: 'changeme'
+  RegionName:
+    Type: String
+    Description: Logical name of the region (e.g. us-west-1 or us-west-2)
+  DesiredCount:
+    Type: Number
+    Default: 0
+    Description: Number of Fargate tasks (0 = parked / cold standby)
+
+Resources:
+
+  # ── Security Groups ────────────────────────────────────────────────────────
+
+  # Internal ALB SG — accept from shared VPC Link NLB and shared Lambda
+  AlbSG:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub '${Env} - Internal ALB'
+      VpcId: !ImportValue
+        Fn::Sub: '${NetworkStack}-VpcId'
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          SourceSecurityGroupId: !ImportValue
+            Fn::Sub: '${SharedAppStack}-VpcLinkNlbSGId'
+          Description: 'From shared VPC Link NLB'
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          SourceSecurityGroupId: !ImportValue
+            Fn::Sub: '${SharedAppStack}-LambdaSGId'
+          Description: 'From shared failover Lambda health check'
+      SecurityGroupEgress:
+        - IpProtocol: '-1'
+          CidrIp: '0.0.0.0/0'
+      Tags:
+        - Key: Name
+          Value: !Sub '${Env}-alb-sg'
+
+  # Fargate SG — accept from this scenario's ALB only
+  FargateSG:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub '${Env} - Fargate tasks'
+      VpcId: !ImportValue
+        Fn::Sub: '${NetworkStack}-VpcId'
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 8000
+          ToPort: 8000
+          SourceSecurityGroupId: !Ref AlbSG
+          Description: 'From ALB'
+      SecurityGroupEgress:
+        - IpProtocol: '-1'
+          CidrIp: '0.0.0.0/0'
+      Tags:
+        - Key: Name
+          Value: !Sub '${Env}-fargate-sg'
+
+  # Aurora SG — accept from this scenario's Fargate and shared Lambda
+  AuroraSG:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub '${Env} - Aurora PostgreSQL'
+      VpcId: !ImportValue
+        Fn::Sub: '${NetworkStack}-VpcId'
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 5432
+          ToPort: 5432
+          SourceSecurityGroupId: !Ref FargateSG
+          Description: 'From Fargate'
+        - IpProtocol: tcp
+          FromPort: 5432
+          ToPort: 5432
+          SourceSecurityGroupId: !ImportValue
+            Fn::Sub: '${SharedAppStack}-LambdaSGId'
+          Description: 'From shared Lambda'
+      SecurityGroupEgress:
+        - IpProtocol: '-1'
+          CidrIp: '0.0.0.0/0'
+      Tags:
+        - Key: Name
+          Value: !Sub '${Env}-aurora-sg'
+
+  # ── IAM for ECS ────────────────────────────────────────────────────────────
+
+  EcsTaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${Env}-ecs-exec-role-${AWS::Region}'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: 'sts:AssumeRole'
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      Tags:
+        - Key: Name
+          Value: !Sub '${Env}-ecs-exec-role'
+
+  EcsTaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${Env}-ecs-task-role-${AWS::Region}'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Policies:
+        - PolicyName: app-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'cloudwatch:PutMetricData'
+                  - 'logs:CreateLogGroup'
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+                Resource: '*'
+      Tags:
+        - Key: Name
+          Value: !Sub '${Env}-ecs-task-role'
+
+  # ── CloudWatch Log Group ───────────────────────────────────────────────────
+
+  AppLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/${Env}/app'
+      RetentionInDays: 7
+
+  # ── Internal ALB ───────────────────────────────────────────────────────────
+
+  InternalAlb:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: !Sub '${Env}-int-alb'
+      Scheme: internal
+      Type: application
+      Subnets:
+        - !ImportValue
+          Fn::Sub: '${NetworkStack}-PrivateSubnet1Id'
+        - !ImportValue
+          Fn::Sub: '${NetworkStack}-PrivateSubnet2Id'
+      SecurityGroups:
+        - !Ref AlbSG
+      Tags:
+        - Key: Name
+          Value: !Sub '${Env}-int-alb'
+
+  AlbTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub '${Env}-fargate-tg'
+      Protocol: HTTP
+      Port: 8000
+      VpcId: !ImportValue
+        Fn::Sub: '${NetworkStack}-VpcId'
+      TargetType: ip
+      HealthCheckPath: /healthcheck
+      HealthCheckIntervalSeconds: 15
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 3
+      Matcher:
+        HttpCode: '200'
+      Tags:
+        - Key: Name
+          Value: !Sub '${Env}-fargate-tg'
+
+  AlbListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref InternalAlb
+      Protocol: HTTP
+      Port: 80
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref AlbTargetGroup
+
+  # ── ECS Task Definition ────────────────────────────────────────────────────
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Sub '${Env}-app'
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      Cpu: '256'
+      Memory: '512'
+      ExecutionRoleArn: !GetAtt EcsTaskExecutionRole.Arn
+      TaskRoleArn: !GetAtt EcsTaskRole.Arn
+      ContainerDefinitions:
+        - Name: app
+          Image: !Ref ContainerImage
+          Essential: true
+          PortMappings:
+            - ContainerPort: 8000
+              Protocol: tcp
+          Environment:
+            - Name: DB_HOST
+              Value: !Ref AuroraEndpoint
+            - Name: DB_PORT
+              Value: !Ref AuroraPort
+            - Name: DB_NAME
+              Value: !Ref AuroraDb
+            - Name: DB_USER
+              Value: !Ref AuroraUser
+            - Name: DB_PASS
+              Value: !Ref AuroraPassword
+            - Name: REGION
+              Value: !Ref RegionName
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref AppLogGroup
+              awslogs-region: !Ref 'AWS::Region'
+              awslogs-stream-prefix: app
+          HealthCheck:
+            Command:
+              - CMD-SHELL
+              - 'curl -f http://localhost:8000/healthcheck || exit 1'
+            Interval: 15
+            Timeout: 5
+            Retries: 3
+            StartPeriod: 30
+
+  # ── ECS Fargate Service (in SHARED cluster) ───────────────────────────────
+
+  EcsService:
+    Type: AWS::ECS::Service
+    DependsOn: AlbListener
+    Properties:
+      ServiceName: !Sub '${Env}-app-svc'
+      Cluster: !ImportValue
+        Fn::Sub: '${SharedAppStack}-EcsClusterName'
+      TaskDefinition: !Ref TaskDefinition
+      LaunchType: FARGATE
+      DesiredCount: !Ref DesiredCount
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          Subnets:
+            - !ImportValue
+              Fn::Sub: '${NetworkStack}-PrivateSubnet1Id'
+            - !ImportValue
+              Fn::Sub: '${NetworkStack}-PrivateSubnet2Id'
+          SecurityGroups:
+            - !Ref FargateSG
+      LoadBalancers:
+        - ContainerName: app
+          ContainerPort: 8000
+          TargetGroupArn: !Ref AlbTargetGroup
+      DeploymentConfiguration:
+        MinimumHealthyPercent: 50
+        MaximumPercent: 200
+      HealthCheckGracePeriodSeconds: 60
+      Tags:
+        - Key: Name
+          Value: !Sub '${Env}-app-svc'
+
+Outputs:
+  InternalAlbDns:
+    Value: !GetAtt InternalAlb.DNSName
+    Export:
+      Name: !Sub '${AWS::StackName}-InternalAlbDns'
+  InternalAlbArn:
+    Value: !Ref InternalAlb
+    Export:
+      Name: !Sub '${AWS::StackName}-InternalAlbArn'
+  AlbTargetGroupArn:
+    Value: !Ref AlbTargetGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-AlbTargetGroupArn'
+  EcsClusterName:
+    Value: !ImportValue
+      Fn::Sub: '${SharedAppStack}-EcsClusterName'
+    Export:
+      Name: !Sub '${AWS::StackName}-EcsClusterName'
+  EcsServiceName:
+    Value: !GetAtt EcsService.Name
+    Export:
+      Name: !Sub '${AWS::StackName}-EcsServiceName'
+  AlbSGId:
+    Value: !Ref AlbSG
+    Export:
+      Name: !Sub '${AWS::StackName}-AlbSGId'
+  FargateSGId:
+    Value: !Ref FargateSG
+    Export:
+      Name: !Sub '${AWS::StackName}-FargateSGId'
+  AuroraSGId:
+    Value: !Ref AuroraSG
+    Export:
+      Name: !Sub '${AWS::StackName}-AuroraSGId'
+  LambdaSGId:
+    Value: !ImportValue
+      Fn::Sub: '${SharedAppStack}-LambdaSGId'
+    Export:
+      Name: !Sub '${AWS::StackName}-LambdaSGId'
+  PrivateSubnet1Id:
+    Value: !ImportValue
+      Fn::Sub: '${NetworkStack}-PrivateSubnet1Id'
+    Export:
+      Name: !Sub '${AWS::StackName}-PrivateSubnet1Id'
+  PrivateSubnet2Id:
+    Value: !ImportValue
+      Fn::Sub: '${NetworkStack}-PrivateSubnet2Id'
+    Export:
+      Name: !Sub '${AWS::StackName}-PrivateSubnet2Id'

--- a/tools/demo_manager.py
+++ b/tools/demo_manager.py
@@ -166,7 +166,7 @@ SCENARIOS = {
 
 
 def ecs_service_name(env):
-    return "{}-svc".format(env)
+    return "{}-app-svc".format(env)
 
 
 def orchestrator_lambda_name(env):

--- a/tools/demo_manager.py
+++ b/tools/demo_manager.py
@@ -39,7 +39,7 @@ ACCOUNT_ID = "597088043823"
 ECS_CLUSTER = "fo-demo-cluster"
 AURORA_ENGINE = "aurora-postgresql"
 AURORA_ENGINE_VERSION = "16.4"
-AURORA_INSTANCE_CLASS = "db.t3.medium"
+AURORA_INSTANCE_CLASS = "db.r5.large"  # Minimum for Aurora Global Database
 AURORA_MASTER_USER = "appuser"
 AURORA_MASTER_PASSWORD = "changeme"  # Demo only
 AURORA_DB_NAME = "appdb"
@@ -405,42 +405,53 @@ def aurora_instance_status(env, region):
 
 
 def get_aurora_subnet_group(env, region):
-    """Find the Aurora DB subnet group created by the app CFN stack."""
-    # The app stack creates an Aurora SG but the subnet group needs to exist.
-    # Look for one matching the env or the shared demo subnet group.
+    """Find or create the Aurora DB subnet group for this scenario."""
     rds = client("rds", region)
-    # Try env-specific first
-    for name in ["{}-aurora-subnet".format(env), "fo-demo-aurora-subnet", "default"]:
-        try:
-            resp = rds.describe_db_subnet_groups(DBSubnetGroupName=name)
-            if resp.get("DBSubnetGroups"):
-                return name
-        except ClientError:
-            continue
+    name = "{}-aurora-subnet".format(env)
+
+    # Check if it already exists
+    try:
+        resp = rds.describe_db_subnet_groups(DBSubnetGroupName=name)
+        if resp.get("DBSubnetGroups"):
+            return name
+    except ClientError:
+        pass
+
+    # Create it using subnets from the scenario app stack
+    try:
+        cfn = client("cloudformation", region)
+        stack_name = "{}-app".format(env)
+        resp = cfn.describe_stacks(StackName=stack_name)
+        outputs = {o["OutputKey"]: o["OutputValue"] for o in resp["Stacks"][0].get("Outputs", [])}
+        subnet1 = outputs.get("PrivateSubnet1Id")
+        subnet2 = outputs.get("PrivateSubnet2Id")
+        if subnet1 and subnet2:
+            rds.create_db_subnet_group(
+                DBSubnetGroupName=name,
+                DBSubnetGroupDescription="Aurora subnet group for {}".format(env),
+                SubnetIds=[subnet1, subnet2],
+                Tags=[{"Key": "Name", "Value": name}, {"Key": "env", "Value": env}],
+            )
+            print("  Created DB subnet group {}.".format(name))
+            return name
+    except ClientError as e:
+        print("  Warning: failed to create subnet group: {}".format(e))
+
     return None
 
 
 def get_aurora_security_group(env, region):
-    """Find the Aurora security group from the app stack."""
-    ec2 = client("ec2", region)
-    # Look for the Aurora SG by tag name pattern
-    resp = ec2.describe_security_groups(
-        Filters=[
-            {"Name": "tag:Name", "Values": ["{}-aurora-sg".format(env)]},
-        ]
-    )
-    sgs = resp.get("SecurityGroups", [])
-    if sgs:
-        return sgs[0]["GroupId"]
-    # Fall back to a broader search
-    resp = ec2.describe_security_groups(
-        Filters=[
-            {"Name": "tag:Name", "Values": ["fo-*-aurora-sg"]},
-        ]
-    )
-    sgs = resp.get("SecurityGroups", [])
-    if sgs:
-        return sgs[0]["GroupId"]
+    """Find the Aurora security group from the scenario app stack outputs."""
+    try:
+        cfn = client("cloudformation", region)
+        stack_name = "{}-app".format(env)
+        resp = cfn.describe_stacks(StackName=stack_name)
+        outputs = {o["OutputKey"]: o["OutputValue"] for o in resp["Stacks"][0].get("Outputs", [])}
+        sg = outputs.get("AuroraSGId")
+        if sg:
+            return sg
+    except ClientError:
+        pass
     return None
 
 
@@ -515,12 +526,18 @@ def create_aurora_secondary(env):
 
     if not aurora_cluster_exists(env, region):
         print("  Creating Aurora cluster {} in {} (joining global)...".format(cid, region))
+        # Get the default AWS managed RDS KMS key in the secondary region
+        kms = client("kms", region)
+        kms_resp = kms.describe_key(KeyId="alias/aws/rds")
+        kms_key_id = kms_resp["KeyMetadata"]["Arn"]
+
         kwargs = dict(
             DBClusterIdentifier=cid,
             GlobalClusterIdentifier=gid,
             Engine=AURORA_ENGINE,
             EngineVersion=AURORA_ENGINE_VERSION,
             StorageEncrypted=True,
+            KmsKeyId=kms_key_id,
             Tags=[{"Key": "Name", "Value": cid}, {"Key": "env", "Value": env}],
         )
         if subnet_group:
@@ -724,10 +741,10 @@ def reset_dynamo_state(env, state="PRIMARY_ACTIVE", active_region=None):
                 "state": {"S": state},
                 "latch_engaged": {"BOOL": False},
                 "consecutive_failures": {"N": "0"},
-                "last_failover_ts": {"S": ""},
+                "last_failover_ts": {"S": "1970-01-01T00:00:00Z"},
                 "last_updated": {"S": now},
                 "cooldown_reset": {"BOOL": False},
-                "warning_throttle_ts": {"S": ""},
+                "last_warning_notification_ts": {"S": "1970-01-01T00:00:00Z"},
             },
         )
     except ClientError as e:
@@ -747,13 +764,13 @@ def reset_cooldown_in_dynamo(env):
             Key={"pk": {"S": "REGION_STATE"}},
             UpdateExpression=(
                 "SET consecutive_failures = :zero, "
-                "last_failover_ts = :empty, "
+                "last_failover_ts = :epoch, "
                 "cooldown_reset = :t, "
-                "warning_throttle_ts = :empty"
+                "last_warning_notification_ts = :epoch"
             ),
             ExpressionAttributeValues={
                 ":zero": {"N": "0"},
-                ":empty": {"S": ""},
+                ":epoch": {"S": "1970-01-01T00:00:00Z"},
                 ":t": {"BOOL": True},
             },
         )

--- a/tools/demo_manager.py
+++ b/tools/demo_manager.py
@@ -612,10 +612,16 @@ def delete_aurora_instance(env, region):
         print(dim("  Aurora instance {} not found, skipping.".format(iid)))
         return
     print("  Deleting Aurora instance {} in {}...".format(iid, region))
-    client("rds", region).delete_db_instance(
-        DBInstanceIdentifier=iid,
-        SkipFinalSnapshot=True,
-    )
+    try:
+        client("rds", region).delete_db_instance(
+            DBInstanceIdentifier=iid,
+            SkipFinalSnapshot=True,
+        )
+    except ClientError as e:
+        if "is already being deleted" in str(e):
+            print(dim("  Instance already being deleted, will wait for completion."))
+        else:
+            raise
 
 
 def wait_aurora_instance_deleted(env, region, timeout_minutes=15):
@@ -689,7 +695,7 @@ def wait_aurora_cluster_deleted(env, region, timeout_minutes=10):
 
 
 def remove_from_global_cluster(env, region):
-    """Remove a regional cluster from the global cluster."""
+    """Remove a regional cluster from the global cluster and wait for detach."""
     cid = aurora_cluster_id(env, region)
     cluster_arn = "arn:aws:rds:{}:{}:cluster:{}".format(region, ACCOUNT_ID, cid)
     gid = aurora_global_cluster_id(env)
@@ -702,8 +708,51 @@ def remove_from_global_cluster(env, region):
     except ClientError as e:
         if "is not a member" in str(e) or "is not found" in str(e):
             print(dim("  Cluster not a member of global, skipping."))
+            return
         else:
             raise
+    # Wait for the cluster to fully detach (status transitions from
+    # "removing-from-global-cluster" back to "available" as standalone)
+    wait_cluster_detached_from_global(env, region)
+
+
+def wait_cluster_detached_from_global(env, region, timeout_minutes=10):
+    """Wait for a cluster to finish detaching from its global cluster."""
+    cid = aurora_cluster_id(env, region)
+    start = time.time()
+    deadline = start + timeout_minutes * 60
+    spinner = ["|", "/", "-", "\\"]
+    tick = 0
+
+    while time.time() < deadline:
+        try:
+            resp = client("rds", region).describe_db_clusters(DBClusterIdentifier=cid)
+            clusters = resp.get("DBClusters", [])
+            if not clusters:
+                print(green("  Cluster {} gone.".format(cid)))
+                return True
+            status = clusters[0].get("Status", "unknown")
+            # Once status is "available" (not "removing-from-global-cluster"), it's detached
+            if status == "available":
+                elapsed = int(time.time() - start)
+                print(green("  Cluster {} detached from global ({:d}s).".format(cid, elapsed)))
+                return True
+            elapsed = int(time.time() - start)
+            sys.stdout.write(
+                "\r  {} Waiting for {} detach ({:d}s) — status: {}   ".format(
+                    spinner[tick % len(spinner)], cid, elapsed, yellow(status)
+                )
+            )
+            sys.stdout.flush()
+        except ClientError:
+            print(green("  Cluster {} gone.".format(cid)))
+            return True
+        time.sleep(10)
+        tick += 1
+
+    sys.stdout.write("\n")
+    print(red("  TIMEOUT waiting for cluster detach."))
+    return False
 
 
 def delete_aurora_global(env):
@@ -1001,36 +1050,33 @@ def cmd_deactivate(args):
         else:
             print(dim("  ECS service not found in {}, skipping.".format(region)))
 
-    # Step 3: Delete Aurora instances
+    # Step 3: Remove secondary from global cluster and tear down secondary Aurora
+    # AWS requires the replica cluster to be fully removed before the master's
+    # last instance can be deleted, so we must handle secondary first end-to-end.
     print()
-    print(bold("[3/5] Deleting Aurora Instances"))
-    for region in [SECONDARY_REGION, PRIMARY_REGION]:
-        delete_aurora_instance(env, region)
-
-    # Wait for instances to be deleted before removing clusters
-    print()
-    print(bold("[4/5] Waiting for Aurora Instance Deletion"))
-    for region in [SECONDARY_REGION, PRIMARY_REGION]:
-        if aurora_instance_exists(env, region):
-            wait_aurora_instance_deleted(env, region)
-
-    # Step 5: Remove from global, delete clusters, delete global
-    print()
-    print(bold("[5/5] Deleting Aurora Clusters & Global"))
-
-    # Remove secondary from global first
+    print(bold("[3/5] Removing Secondary Aurora (replica must go before master)"))
+    if aurora_instance_exists(env, SECONDARY_REGION):
+        delete_aurora_instance(env, SECONDARY_REGION)
+        wait_aurora_instance_deleted(env, SECONDARY_REGION)
     if aurora_cluster_exists(env, SECONDARY_REGION):
         remove_from_global_cluster(env, SECONDARY_REGION)
         delete_aurora_cluster(env, SECONDARY_REGION)
         wait_aurora_cluster_deleted(env, SECONDARY_REGION)
 
-    # Remove primary from global
+    # Step 4: Tear down primary Aurora
+    print()
+    print(bold("[4/5] Removing Primary Aurora"))
+    if aurora_instance_exists(env, PRIMARY_REGION):
+        delete_aurora_instance(env, PRIMARY_REGION)
+        wait_aurora_instance_deleted(env, PRIMARY_REGION)
     if aurora_cluster_exists(env, PRIMARY_REGION):
         remove_from_global_cluster(env, PRIMARY_REGION)
         delete_aurora_cluster(env, PRIMARY_REGION)
         wait_aurora_cluster_deleted(env, PRIMARY_REGION)
 
-    # Delete global cluster
+    # Step 5: Delete global cluster
+    print()
+    print(bold("[5/5] Deleting Aurora Global Cluster"))
     delete_aurora_global(env)
 
     print()

--- a/tools/demo_manager.py
+++ b/tools/demo_manager.py
@@ -1,0 +1,1359 @@
+#!/usr/bin/env python3
+"""
+Demo Manager CLI — manages 9 failover orchestrator demo environments.
+
+Each environment is a combination of version (v1.0, v1.1-claude, v1.1-gemini)
+and use case (active/passive, zero-container, active/active).
+
+Usage:
+    python3 tools/demo_manager.py status
+    python3 tools/demo_manager.py activate fo-v10-s1
+    python3 tools/demo_manager.py deactivate fo-v10-s1
+    python3 tools/demo_manager.py trigger fo-v10-s1 [--watch]
+    python3 tools/demo_manager.py reset fo-v10-s1
+    python3 tools/demo_manager.py activate-all
+    python3 tools/demo_manager.py deactivate-all
+"""
+
+import argparse
+import sys
+import time
+import json
+import os
+import traceback
+from datetime import datetime, timezone
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+except ImportError:
+    print("ERROR: boto3 is required. Install with: pip install boto3")
+    sys.exit(1)
+
+# ── Constants ───────────────────────────────────────────────────────────────────
+
+PRIMARY_REGION = "us-west-1"
+SECONDARY_REGION = "us-west-2"
+ACCOUNT_ID = "597088043823"
+ECS_CLUSTER = "fo-demo-cluster"
+AURORA_ENGINE = "aurora-postgresql"
+AURORA_ENGINE_VERSION = "16.4"
+AURORA_INSTANCE_CLASS = "db.t3.medium"
+AURORA_MASTER_USER = "appuser"
+AURORA_MASTER_PASSWORD = "changeme"  # Demo only
+AURORA_DB_NAME = "appdb"
+ECS_DESIRED_COUNT = 2
+
+REGION_SUFFIX = {
+    "us-west-1": "w1",
+    "us-west-2": "w2",
+}
+
+# ── ANSI Color Helpers ──────────────────────────────────────────────────────────
+
+_COLOR_ENABLED = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+
+
+def _c(code, text):
+    if _COLOR_ENABLED:
+        return "\033[{}m{}\033[0m".format(code, text)
+    return str(text)
+
+
+def green(t):
+    return _c("32", t)
+
+
+def red(t):
+    return _c("31", t)
+
+
+def yellow(t):
+    return _c("33", t)
+
+
+def cyan(t):
+    return _c("36", t)
+
+
+def bold(t):
+    return _c("1", t)
+
+
+def dim(t):
+    return _c("2", t)
+
+
+# ── Scenario Definitions ───────────────────────────────────────────────────────
+
+SCENARIOS = {
+    "fo-v10-s1": {
+        "description": "v1.0 - Active/Passive",
+        "version": "v1.0",
+        "routing_mode": "failover",
+        "passive_publish_zero": False,
+        "ai_rca_enabled": False,
+        "ai_rca_provider": None,
+    },
+    "fo-v10-s2": {
+        "description": "v1.0 - Active/Passive Zero-Container",
+        "version": "v1.0",
+        "routing_mode": "failover",
+        "passive_publish_zero": True,
+        "ai_rca_enabled": False,
+        "ai_rca_provider": None,
+    },
+    "fo-v10-s3": {
+        "description": "v1.0 - Active/Active",
+        "version": "v1.0",
+        "routing_mode": "active-active",
+        "passive_publish_zero": False,
+        "ai_rca_enabled": False,
+        "ai_rca_provider": None,
+    },
+    "fo-v11c-s1": {
+        "description": "v1.1 Claude - Active/Passive",
+        "version": "v1.1",
+        "routing_mode": "failover",
+        "passive_publish_zero": False,
+        "ai_rca_enabled": True,
+        "ai_rca_provider": "claude",
+    },
+    "fo-v11c-s2": {
+        "description": "v1.1 Claude - Active/Passive Zero-Container",
+        "version": "v1.1",
+        "routing_mode": "failover",
+        "passive_publish_zero": True,
+        "ai_rca_enabled": True,
+        "ai_rca_provider": "claude",
+    },
+    "fo-v11c-s3": {
+        "description": "v1.1 Claude - Active/Active",
+        "version": "v1.1",
+        "routing_mode": "active-active",
+        "passive_publish_zero": False,
+        "ai_rca_enabled": True,
+        "ai_rca_provider": "claude",
+    },
+    "fo-v11g-s1": {
+        "description": "v1.1 Gemini - Active/Passive",
+        "version": "v1.1",
+        "routing_mode": "failover",
+        "passive_publish_zero": False,
+        "ai_rca_enabled": True,
+        "ai_rca_provider": "gemini",
+    },
+    "fo-v11g-s2": {
+        "description": "v1.1 Gemini - Active/Passive Zero-Container",
+        "version": "v1.1",
+        "routing_mode": "failover",
+        "passive_publish_zero": True,
+        "ai_rca_enabled": True,
+        "ai_rca_provider": "gemini",
+    },
+    "fo-v11g-s3": {
+        "description": "v1.1 Gemini - Active/Active",
+        "version": "v1.1",
+        "routing_mode": "active-active",
+        "passive_publish_zero": False,
+        "ai_rca_enabled": True,
+        "ai_rca_provider": "gemini",
+    },
+}
+
+# ── Resource Naming ─────────────────────────────────────────────────────────────
+
+
+def ecs_service_name(env):
+    return "{}-svc".format(env)
+
+
+def orchestrator_lambda_name(env):
+    return "{}-orchestrator".format(env)
+
+
+def failback_lambda_name(env):
+    return "{}-failback".format(env)
+
+
+def sns_topic_name(env):
+    return "{}-alerts".format(env)
+
+
+def state_table_name(env):
+    return "{}-state".format(env)
+
+
+def aurora_global_cluster_id(env):
+    return "{}-aurora-global".format(env)
+
+
+def aurora_cluster_id(env, region):
+    return "{}-aurora-{}".format(env, REGION_SUFFIX[region])
+
+
+def aurora_instance_id(env, region):
+    return "{}-aurora-{}-inst".format(env, REGION_SUFFIX[region])
+
+
+def cw_namespace(env):
+    return "Custom/{}".format(env)
+
+
+def cw_alarm_name(env, region):
+    return "{}-region-inactive-{}".format(env, region)
+
+
+def eventbridge_rule_name(env):
+    # From CFN: fo-${Env}-orchestrator-schedule but env already has fo- prefix
+    # The user spec says {env}-schedule-{region} but CFN says {env}-orchestrator-schedule
+    # CFN is deployed, so use the CFN naming pattern
+    return "{}-orchestrator-schedule".format(env)
+
+
+# ── AWS Client Cache ───────────────────────────────────────────────────────────
+
+_clients = {}
+
+
+def client(service, region=PRIMARY_REGION):
+    key = (service, region)
+    if key not in _clients:
+        _clients[key] = boto3.client(service, region_name=region)
+    return _clients[key]
+
+
+# ── Helper: Get DynamoDB State ──────────────────────────────────────────────────
+
+
+def get_dynamo_state(env):
+    """Read the failover state from DynamoDB. Returns dict or None."""
+    table = state_table_name(env)
+    try:
+        resp = client("dynamodb", PRIMARY_REGION).get_item(
+            TableName=table,
+            Key={"pk": {"S": "REGION_STATE"}},
+            ConsistentRead=True,
+        )
+        item = resp.get("Item")
+        if not item:
+            return None
+        result = {}
+        for k, v in item.items():
+            if "S" in v:
+                result[k] = v["S"]
+            elif "N" in v:
+                result[k] = v["N"]
+            elif "BOOL" in v:
+                result[k] = v["BOOL"]
+            else:
+                result[k] = str(v)
+        return result
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code == "ResourceNotFoundException":
+            return None
+        raise
+
+
+def dynamo_table_exists(env):
+    """Check if the DynamoDB table exists."""
+    try:
+        client("dynamodb", PRIMARY_REGION).describe_table(
+            TableName=state_table_name(env)
+        )
+        return True
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ResourceNotFoundException":
+            return False
+        raise
+
+
+# ── Helper: ECS Status ──────────────────────────────────────────────────────────
+
+
+def get_ecs_status(env, region):
+    """Return (running, desired) task counts, or (None, None) if service missing."""
+    svc = ecs_service_name(env)
+    try:
+        resp = client("ecs", region).describe_services(
+            cluster=ECS_CLUSTER, services=[svc]
+        )
+        services = resp.get("services", [])
+        if not services or services[0].get("status") == "INACTIVE":
+            return (None, None)
+        s = services[0]
+        return (s.get("runningCount", 0), s.get("desiredCount", 0))
+    except ClientError:
+        return (None, None)
+
+
+def ecs_service_exists(env, region):
+    """Check if the ECS service exists and is ACTIVE."""
+    running, desired = get_ecs_status(env, region)
+    return running is not None
+
+
+def scale_ecs(env, region, desired):
+    """Update ECS service desired count."""
+    svc = ecs_service_name(env)
+    print("  Scaling ECS {}/{} to {} in {}...".format(ECS_CLUSTER, svc, desired, region))
+    try:
+        client("ecs", region).update_service(
+            cluster=ECS_CLUSTER,
+            service=svc,
+            desiredCount=desired,
+        )
+    except ClientError as e:
+        print(red("  ERROR scaling ECS: {}".format(e)))
+        raise
+
+
+# ── Helper: EventBridge ─────────────────────────────────────────────────────────
+
+
+def get_eventbridge_state(env, region):
+    """Return rule state string or None if missing."""
+    rule = eventbridge_rule_name(env)
+    try:
+        resp = client("events", region).describe_rule(Name=rule)
+        return resp.get("State", "UNKNOWN")
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ResourceNotFoundException":
+            return None
+        raise
+
+
+def enable_eventbridge(env, region):
+    rule = eventbridge_rule_name(env)
+    print("  Enabling EventBridge rule {} in {}...".format(rule, region))
+    try:
+        client("events", region).enable_rule(Name=rule)
+    except ClientError as e:
+        print(red("  ERROR enabling rule: {}".format(e)))
+        raise
+
+
+def disable_eventbridge(env, region):
+    rule = eventbridge_rule_name(env)
+    print("  Disabling EventBridge rule {} in {}...".format(rule, region))
+    try:
+        client("events", region).disable_rule(Name=rule)
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ResourceNotFoundException":
+            print(dim("  Rule {} not found in {}, skipping.".format(rule, region)))
+        else:
+            raise
+
+
+# ── Helper: Aurora ──────────────────────────────────────────────────────────────
+
+
+def aurora_global_exists(env):
+    """Check if the Aurora global cluster exists."""
+    gid = aurora_global_cluster_id(env)
+    try:
+        resp = client("rds", PRIMARY_REGION).describe_global_clusters(
+            GlobalClusterIdentifier=gid
+        )
+        clusters = resp.get("GlobalClusters", [])
+        return len(clusters) > 0
+    except ClientError as e:
+        if "GlobalClusterNotFoundFault" in str(e):
+            return False
+        raise
+
+
+def aurora_cluster_exists(env, region):
+    """Check if the Aurora regional cluster exists."""
+    cid = aurora_cluster_id(env, region)
+    try:
+        resp = client("rds", region).describe_db_clusters(DBClusterIdentifier=cid)
+        clusters = resp.get("DBClusters", [])
+        return len(clusters) > 0
+    except ClientError as e:
+        if "DBClusterNotFoundFault" in str(e):
+            return False
+        raise
+
+
+def aurora_instance_exists(env, region):
+    """Check if the Aurora instance exists."""
+    iid = aurora_instance_id(env, region)
+    try:
+        resp = client("rds", region).describe_db_instances(DBInstanceIdentifier=iid)
+        instances = resp.get("DBInstances", [])
+        return len(instances) > 0
+    except ClientError as e:
+        if "DBInstanceNotFoundFault" in str(e) or "DBInstanceNotFound" in str(e):
+            return False
+        raise
+
+
+def aurora_instance_status(env, region):
+    """Return the instance status string or None."""
+    iid = aurora_instance_id(env, region)
+    try:
+        resp = client("rds", region).describe_db_instances(DBInstanceIdentifier=iid)
+        instances = resp.get("DBInstances", [])
+        if instances:
+            return instances[0].get("DBInstanceStatus", "unknown")
+        return None
+    except ClientError:
+        return None
+
+
+def get_aurora_subnet_group(env, region):
+    """Find the Aurora DB subnet group created by the app CFN stack."""
+    # The app stack creates an Aurora SG but the subnet group needs to exist.
+    # Look for one matching the env or the shared demo subnet group.
+    rds = client("rds", region)
+    # Try env-specific first
+    for name in ["{}-aurora-subnet".format(env), "fo-demo-aurora-subnet", "default"]:
+        try:
+            resp = rds.describe_db_subnet_groups(DBSubnetGroupName=name)
+            if resp.get("DBSubnetGroups"):
+                return name
+        except ClientError:
+            continue
+    return None
+
+
+def get_aurora_security_group(env, region):
+    """Find the Aurora security group from the app stack."""
+    ec2 = client("ec2", region)
+    # Look for the Aurora SG by tag name pattern
+    resp = ec2.describe_security_groups(
+        Filters=[
+            {"Name": "tag:Name", "Values": ["{}-aurora-sg".format(env)]},
+        ]
+    )
+    sgs = resp.get("SecurityGroups", [])
+    if sgs:
+        return sgs[0]["GroupId"]
+    # Fall back to a broader search
+    resp = ec2.describe_security_groups(
+        Filters=[
+            {"Name": "tag:Name", "Values": ["fo-*-aurora-sg"]},
+        ]
+    )
+    sgs = resp.get("SecurityGroups", [])
+    if sgs:
+        return sgs[0]["GroupId"]
+    return None
+
+
+def create_aurora_global(env):
+    """Create the Aurora global cluster."""
+    gid = aurora_global_cluster_id(env)
+    print("  Creating Aurora global cluster {}...".format(gid))
+    client("rds", PRIMARY_REGION).create_global_cluster(
+        GlobalClusterIdentifier=gid,
+        Engine=AURORA_ENGINE,
+        EngineVersion=AURORA_ENGINE_VERSION,
+        DatabaseName=AURORA_DB_NAME,
+        StorageEncrypted=True,
+    )
+
+
+def create_aurora_primary(env):
+    """Create Aurora cluster + instance in primary region (writer)."""
+    cid = aurora_cluster_id(env, PRIMARY_REGION)
+    iid = aurora_instance_id(env, PRIMARY_REGION)
+    gid = aurora_global_cluster_id(env)
+    region = PRIMARY_REGION
+    rds = client("rds", region)
+
+    subnet_group = get_aurora_subnet_group(env, region)
+    sg_id = get_aurora_security_group(env, region)
+
+    if not aurora_cluster_exists(env, region):
+        print("  Creating Aurora cluster {} in {}...".format(cid, region))
+        kwargs = dict(
+            DBClusterIdentifier=cid,
+            GlobalClusterIdentifier=gid,
+            Engine=AURORA_ENGINE,
+            EngineVersion=AURORA_ENGINE_VERSION,
+            MasterUsername=AURORA_MASTER_USER,
+            MasterUserPassword=AURORA_MASTER_PASSWORD,
+            DatabaseName=AURORA_DB_NAME,
+            StorageEncrypted=True,
+            Tags=[{"Key": "Name", "Value": cid}, {"Key": "env", "Value": env}],
+        )
+        if subnet_group:
+            kwargs["DBSubnetGroupName"] = subnet_group
+        if sg_id:
+            kwargs["VpcSecurityGroupIds"] = [sg_id]
+        rds.create_db_cluster(**kwargs)
+    else:
+        print(dim("  Aurora cluster {} already exists.".format(cid)))
+
+    if not aurora_instance_exists(env, region):
+        print("  Creating Aurora instance {} in {}...".format(iid, region))
+        rds.create_db_instance(
+            DBInstanceIdentifier=iid,
+            DBClusterIdentifier=cid,
+            DBInstanceClass=AURORA_INSTANCE_CLASS,
+            Engine=AURORA_ENGINE,
+            Tags=[{"Key": "Name", "Value": iid}, {"Key": "env", "Value": env}],
+        )
+    else:
+        print(dim("  Aurora instance {} already exists.".format(iid)))
+
+
+def create_aurora_secondary(env):
+    """Create Aurora cluster + instance in secondary region (reader, joins global)."""
+    cid = aurora_cluster_id(env, SECONDARY_REGION)
+    iid = aurora_instance_id(env, SECONDARY_REGION)
+    gid = aurora_global_cluster_id(env)
+    region = SECONDARY_REGION
+    rds = client("rds", region)
+
+    subnet_group = get_aurora_subnet_group(env, region)
+    sg_id = get_aurora_security_group(env, region)
+
+    if not aurora_cluster_exists(env, region):
+        print("  Creating Aurora cluster {} in {} (joining global)...".format(cid, region))
+        kwargs = dict(
+            DBClusterIdentifier=cid,
+            GlobalClusterIdentifier=gid,
+            Engine=AURORA_ENGINE,
+            EngineVersion=AURORA_ENGINE_VERSION,
+            StorageEncrypted=True,
+            Tags=[{"Key": "Name", "Value": cid}, {"Key": "env", "Value": env}],
+        )
+        if subnet_group:
+            kwargs["DBSubnetGroupName"] = subnet_group
+        if sg_id:
+            kwargs["VpcSecurityGroupIds"] = [sg_id]
+        rds.create_db_cluster(**kwargs)
+    else:
+        print(dim("  Aurora cluster {} already exists.".format(cid)))
+
+    if not aurora_instance_exists(env, region):
+        print("  Creating Aurora instance {} in {}...".format(iid, region))
+        rds.create_db_instance(
+            DBInstanceIdentifier=iid,
+            DBClusterIdentifier=cid,
+            DBInstanceClass=AURORA_INSTANCE_CLASS,
+            Engine=AURORA_ENGINE,
+            Tags=[{"Key": "Name", "Value": iid}, {"Key": "env", "Value": env}],
+        )
+    else:
+        print(dim("  Aurora instance {} already exists.".format(iid)))
+
+
+def wait_aurora_instances(env, timeout_minutes=15):
+    """Wait for Aurora instances in both regions to become available."""
+    instances = [
+        (env, PRIMARY_REGION),
+        (env, SECONDARY_REGION),
+    ]
+    start = time.time()
+    deadline = start + timeout_minutes * 60
+    spinner = ["|", "/", "-", "\\"]
+    tick = 0
+
+    while time.time() < deadline:
+        all_ready = True
+        statuses = []
+        for e, region in instances:
+            status = aurora_instance_status(e, region)
+            statuses.append((aurora_instance_id(e, region), region, status))
+            if status != "available":
+                all_ready = False
+
+        elapsed = int(time.time() - start)
+        status_str = "  {} Waiting for Aurora ({:d}s) — ".format(
+            spinner[tick % len(spinner)], elapsed
+        )
+        parts = []
+        for iid, region, st in statuses:
+            color_fn = green if st == "available" else yellow
+            parts.append("{}: {}".format(iid, color_fn(st or "pending")))
+        sys.stdout.write("\r" + status_str + ", ".join(parts) + "   ")
+        sys.stdout.flush()
+
+        if all_ready:
+            sys.stdout.write("\n")
+            print(green("  All Aurora instances are available."))
+            return True
+
+        time.sleep(15)
+        tick += 1
+
+    sys.stdout.write("\n")
+    print(red("  TIMEOUT waiting for Aurora after {} minutes.".format(timeout_minutes)))
+    return False
+
+
+def delete_aurora_instance(env, region):
+    """Delete Aurora instance (skip final snapshot)."""
+    iid = aurora_instance_id(env, region)
+    if not aurora_instance_exists(env, region):
+        print(dim("  Aurora instance {} not found, skipping.".format(iid)))
+        return
+    print("  Deleting Aurora instance {} in {}...".format(iid, region))
+    client("rds", region).delete_db_instance(
+        DBInstanceIdentifier=iid,
+        SkipFinalSnapshot=True,
+    )
+
+
+def wait_aurora_instance_deleted(env, region, timeout_minutes=15):
+    """Wait for Aurora instance to be fully deleted."""
+    iid = aurora_instance_id(env, region)
+    start = time.time()
+    deadline = start + timeout_minutes * 60
+    spinner = ["|", "/", "-", "\\"]
+    tick = 0
+
+    while time.time() < deadline:
+        status = aurora_instance_status(env, region)
+        if status is None:
+            sys.stdout.write("\n")
+            print(green("  Aurora instance {} deleted.".format(iid)))
+            return True
+        elapsed = int(time.time() - start)
+        sys.stdout.write(
+            "\r  {} Waiting for {} deletion ({:d}s) — status: {}   ".format(
+                spinner[tick % len(spinner)], iid, elapsed, yellow(status)
+            )
+        )
+        sys.stdout.flush()
+        time.sleep(15)
+        tick += 1
+
+    sys.stdout.write("\n")
+    print(red("  TIMEOUT waiting for instance deletion."))
+    return False
+
+
+def delete_aurora_cluster(env, region):
+    """Delete Aurora regional cluster (no final snapshot)."""
+    cid = aurora_cluster_id(env, region)
+    if not aurora_cluster_exists(env, region):
+        print(dim("  Aurora cluster {} not found, skipping.".format(cid)))
+        return
+    print("  Deleting Aurora cluster {} in {}...".format(cid, region))
+    client("rds", region).delete_db_cluster(
+        DBClusterIdentifier=cid,
+        SkipFinalSnapshot=True,
+    )
+
+
+def wait_aurora_cluster_deleted(env, region, timeout_minutes=10):
+    """Wait for Aurora cluster to be fully deleted."""
+    cid = aurora_cluster_id(env, region)
+    start = time.time()
+    deadline = start + timeout_minutes * 60
+    spinner = ["|", "/", "-", "\\"]
+    tick = 0
+
+    while time.time() < deadline:
+        if not aurora_cluster_exists(env, region):
+            sys.stdout.write("\n")
+            print(green("  Aurora cluster {} deleted.".format(cid)))
+            return True
+        elapsed = int(time.time() - start)
+        sys.stdout.write(
+            "\r  {} Waiting for {} deletion ({:d}s)   ".format(
+                spinner[tick % len(spinner)], cid, elapsed
+            )
+        )
+        sys.stdout.flush()
+        time.sleep(15)
+        tick += 1
+
+    sys.stdout.write("\n")
+    print(red("  TIMEOUT waiting for cluster deletion."))
+    return False
+
+
+def remove_from_global_cluster(env, region):
+    """Remove a regional cluster from the global cluster."""
+    cid = aurora_cluster_id(env, region)
+    cluster_arn = "arn:aws:rds:{}:{}:cluster:{}".format(region, ACCOUNT_ID, cid)
+    gid = aurora_global_cluster_id(env)
+    print("  Removing {} from global cluster {}...".format(cid, gid))
+    try:
+        client("rds", region).remove_from_global_cluster(
+            GlobalClusterIdentifier=gid,
+            DbClusterIdentifier=cluster_arn,
+        )
+    except ClientError as e:
+        if "is not a member" in str(e) or "is not found" in str(e):
+            print(dim("  Cluster not a member of global, skipping."))
+        else:
+            raise
+
+
+def delete_aurora_global(env):
+    """Delete the global cluster (must be empty first)."""
+    gid = aurora_global_cluster_id(env)
+    if not aurora_global_exists(env):
+        print(dim("  Global cluster {} not found, skipping.".format(gid)))
+        return
+    print("  Deleting Aurora global cluster {}...".format(gid))
+    try:
+        client("rds", PRIMARY_REGION).delete_global_cluster(
+            GlobalClusterIdentifier=gid
+        )
+    except ClientError as e:
+        print(red("  ERROR deleting global cluster: {}".format(e)))
+        raise
+
+
+# ── Helper: DynamoDB State Management ──────────────────────────────────────────
+
+
+def reset_dynamo_state(env, state="PRIMARY_ACTIVE", active_region=None):
+    """Reset DynamoDB state to the given state."""
+    if active_region is None:
+        active_region = PRIMARY_REGION
+    table = state_table_name(env)
+    now = datetime.now(timezone.utc).isoformat()
+    print("  Resetting DynamoDB state to {}...".format(state))
+    try:
+        client("dynamodb", PRIMARY_REGION).put_item(
+            TableName=table,
+            Item={
+                "pk": {"S": "REGION_STATE"},
+                "active_region": {"S": active_region},
+                "state": {"S": state},
+                "latch_engaged": {"BOOL": False},
+                "consecutive_failures": {"N": "0"},
+                "last_failover_ts": {"S": ""},
+                "last_updated": {"S": now},
+                "cooldown_reset": {"BOOL": False},
+                "warning_throttle_ts": {"S": ""},
+            },
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ResourceNotFoundException":
+            print(yellow("  DynamoDB table {} does not exist, skipping state reset.".format(table)))
+        else:
+            raise
+
+
+def reset_cooldown_in_dynamo(env):
+    """Reset cooldown and failure counters to allow immediate failover."""
+    table = state_table_name(env)
+    print("  Resetting cooldown and failure counters...")
+    try:
+        client("dynamodb", PRIMARY_REGION).update_item(
+            TableName=table,
+            Key={"pk": {"S": "REGION_STATE"}},
+            UpdateExpression=(
+                "SET consecutive_failures = :zero, "
+                "last_failover_ts = :empty, "
+                "cooldown_reset = :t, "
+                "warning_throttle_ts = :empty"
+            ),
+            ExpressionAttributeValues={
+                ":zero": {"N": "0"},
+                ":empty": {"S": ""},
+                ":t": {"BOOL": True},
+            },
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ResourceNotFoundException":
+            print(yellow("  DynamoDB table not found, skipping."))
+        else:
+            raise
+
+
+# ── Command: status ─────────────────────────────────────────────────────────────
+
+
+def cmd_status(args):
+    """Show status table for all 9 scenarios."""
+    print()
+    print(bold("Failover Orchestrator Demo Environments"))
+    print(bold("=" * 95))
+    print()
+
+    # Header
+    header = "{:<14s} {:<42s} {:<6s} {:<10s} {:<14s} {:<12s}".format(
+        "ENV", "DESCRIPTION", "VER", "STATE", "ACTIVE REGION", "ECS (pri)"
+    )
+    print(bold(header))
+    print("-" * 95)
+
+    for env, scen in SCENARIOS.items():
+        desc = scen["description"]
+        ver = scen["version"]
+
+        # Determine state
+        ecs_running, ecs_desired = get_ecs_status(env, PRIMARY_REGION)
+        eb_state = get_eventbridge_state(env, PRIMARY_REGION)
+
+        if ecs_running is None and eb_state is None:
+            # Check if any resources exist at all
+            if not ecs_service_exists(env, PRIMARY_REGION):
+                state_str = dim("UNDEPLOYED")
+                active_region = dim("N/A")
+                ecs_str = dim("N/A")
+            else:
+                state_str = dim("UNKNOWN")
+                active_region = dim("N/A")
+                ecs_str = dim("N/A")
+        else:
+            # Read DynamoDB state
+            ddb = get_dynamo_state(env)
+            if ddb:
+                active_region = ddb.get("active_region", "N/A")
+                ddb_state = ddb.get("state", "UNKNOWN")
+            else:
+                active_region = dim("N/A")
+                ddb_state = None
+
+            if ecs_running is not None and ecs_desired is not None:
+                ecs_str = "{}/{}".format(ecs_running, ecs_desired)
+            else:
+                ecs_str = dim("N/A")
+
+            # Determine high-level state
+            if ecs_desired == 0 and (eb_state == "DISABLED" or eb_state is None):
+                state_str = yellow("PARKED")
+                active_region = dim("N/A")
+            elif ddb_state in ("WAITING_AURORA_PROMOTION", "FAILBACK_IN_PROGRESS"):
+                state_str = red("TRIGGERED")
+            elif ddb_state == "SECONDARY_ACTIVE":
+                state_str = red("TRIGGERED")
+            elif ecs_running is not None and ecs_running > 0:
+                state_str = green("ACTIVE")
+            elif ecs_desired is not None and ecs_desired > 0 and (ecs_running == 0):
+                state_str = yellow("STARTING")
+            else:
+                state_str = yellow("PARKED")
+                active_region = dim("N/A")
+
+        row = "{:<14s} {:<42s} {:<6s} {:<10s} {:<14s} {:<12s}".format(
+            cyan(env), desc, ver, state_str, str(active_region), ecs_str
+        )
+        print(row)
+
+    print()
+
+
+# ── Command: activate ──────────────────────────────────────────────────────────
+
+
+def cmd_activate(args):
+    """Activate a demo scenario."""
+    env = args.env
+    if env not in SCENARIOS:
+        print(red("Unknown scenario: {}".format(env)))
+        sys.exit(1)
+
+    scen = SCENARIOS[env]
+    print()
+    print(bold("Activating: {} ({})".format(env, scen["description"])))
+    print("=" * 60)
+
+    is_active_active = scen["routing_mode"] == "active-active"
+    is_zero_container = scen["passive_publish_zero"]
+
+    # Step 1: Aurora global cluster
+    print()
+    print(bold("[1/7] Aurora Global Cluster"))
+    if not aurora_global_exists(env):
+        create_aurora_global(env)
+    else:
+        print(dim("  Global cluster already exists."))
+
+    # Step 2: Aurora primary cluster + instance
+    print()
+    print(bold("[2/7] Aurora Primary Cluster ({})" .format(PRIMARY_REGION)))
+    create_aurora_primary(env)
+
+    # Step 3: Wait for primary to be available before creating secondary
+    print()
+    print(bold("[3/7] Waiting for Primary Aurora to be Available"))
+    primary_status = aurora_instance_status(env, PRIMARY_REGION)
+    if primary_status != "available":
+        start = time.time()
+        deadline = start + 900  # 15 min
+        spinner = ["|", "/", "-", "\\"]
+        tick = 0
+        while time.time() < deadline:
+            status = aurora_instance_status(env, PRIMARY_REGION)
+            if status == "available":
+                sys.stdout.write("\n")
+                print(green("  Primary Aurora instance available."))
+                break
+            elapsed = int(time.time() - start)
+            sys.stdout.write(
+                "\r  {} Waiting for primary ({:d}s) — {}   ".format(
+                    spinner[tick % len(spinner)], elapsed, yellow(status or "creating")
+                )
+            )
+            sys.stdout.flush()
+            time.sleep(15)
+            tick += 1
+        else:
+            sys.stdout.write("\n")
+            print(red("  TIMEOUT waiting for primary Aurora."))
+            print(red("  Manual cleanup may be needed for: {}".format(env)))
+            sys.exit(1)
+    else:
+        print(green("  Primary Aurora already available."))
+
+    # Step 4: Aurora secondary cluster + instance
+    print()
+    print(bold("[4/7] Aurora Secondary Cluster ({})".format(SECONDARY_REGION)))
+    create_aurora_secondary(env)
+
+    # Step 5: Wait for all Aurora instances
+    print()
+    print(bold("[5/7] Waiting for All Aurora Instances"))
+    if not wait_aurora_instances(env):
+        print(red("  Aurora setup incomplete. Manual cleanup may be needed."))
+        print(red("  Resources to check:"))
+        print(red("    - Global: {}".format(aurora_global_cluster_id(env))))
+        print(red("    - Primary: {}".format(aurora_cluster_id(env, PRIMARY_REGION))))
+        print(red("    - Secondary: {}".format(aurora_cluster_id(env, SECONDARY_REGION))))
+        sys.exit(1)
+
+    # Step 6: Scale ECS
+    print()
+    print(bold("[6/7] Scaling ECS Services"))
+    if ecs_service_exists(env, PRIMARY_REGION):
+        scale_ecs(env, PRIMARY_REGION, ECS_DESIRED_COUNT)
+    else:
+        print(yellow("  ECS service not found in {}. Deploy CFN stack first.".format(PRIMARY_REGION)))
+
+    if is_active_active or not is_zero_container:
+        if ecs_service_exists(env, SECONDARY_REGION):
+            scale_ecs(env, SECONDARY_REGION, ECS_DESIRED_COUNT)
+        else:
+            print(yellow("  ECS service not found in {}. Deploy CFN stack first.".format(SECONDARY_REGION)))
+    else:
+        # Zero-container: keep secondary at 0
+        if ecs_service_exists(env, SECONDARY_REGION):
+            scale_ecs(env, SECONDARY_REGION, 0)
+            print(dim("  (Zero-container mode: secondary stays at 0)"))
+
+    # Step 7: EventBridge + state
+    print()
+    print(bold("[7/7] EventBridge Rules & State"))
+    for region in [PRIMARY_REGION, SECONDARY_REGION]:
+        eb = get_eventbridge_state(env, region)
+        if eb is not None:
+            enable_eventbridge(env, region)
+        else:
+            print(yellow("  EventBridge rule not found in {}. Deploy CFN stack first.".format(region)))
+
+    reset_dynamo_state(env)
+
+    print()
+    print(green("Scenario {} activated successfully.".format(bold(env))))
+    print("  Aurora provisioning took ~10 min. ECS tasks should be running in ~2 min.")
+    print()
+
+
+# ── Command: deactivate ────────────────────────────────────────────────────────
+
+
+def cmd_deactivate(args):
+    """Deactivate (park) a demo scenario."""
+    env = args.env
+    if env not in SCENARIOS:
+        print(red("Unknown scenario: {}".format(env)))
+        sys.exit(1)
+
+    scen = SCENARIOS[env]
+    print()
+    print(bold("Deactivating: {} ({})".format(env, scen["description"])))
+    print("=" * 60)
+
+    # Step 1: Disable EventBridge
+    print()
+    print(bold("[1/5] Disabling EventBridge Rules"))
+    for region in [PRIMARY_REGION, SECONDARY_REGION]:
+        disable_eventbridge(env, region)
+
+    # Step 2: Scale ECS to 0
+    print()
+    print(bold("[2/5] Scaling ECS to 0"))
+    for region in [PRIMARY_REGION, SECONDARY_REGION]:
+        if ecs_service_exists(env, region):
+            scale_ecs(env, region, 0)
+        else:
+            print(dim("  ECS service not found in {}, skipping.".format(region)))
+
+    # Step 3: Delete Aurora instances
+    print()
+    print(bold("[3/5] Deleting Aurora Instances"))
+    for region in [SECONDARY_REGION, PRIMARY_REGION]:
+        delete_aurora_instance(env, region)
+
+    # Wait for instances to be deleted before removing clusters
+    print()
+    print(bold("[4/5] Waiting for Aurora Instance Deletion"))
+    for region in [SECONDARY_REGION, PRIMARY_REGION]:
+        if aurora_instance_exists(env, region):
+            wait_aurora_instance_deleted(env, region)
+
+    # Step 5: Remove from global, delete clusters, delete global
+    print()
+    print(bold("[5/5] Deleting Aurora Clusters & Global"))
+
+    # Remove secondary from global first
+    if aurora_cluster_exists(env, SECONDARY_REGION):
+        remove_from_global_cluster(env, SECONDARY_REGION)
+        delete_aurora_cluster(env, SECONDARY_REGION)
+        wait_aurora_cluster_deleted(env, SECONDARY_REGION)
+
+    # Remove primary from global
+    if aurora_cluster_exists(env, PRIMARY_REGION):
+        remove_from_global_cluster(env, PRIMARY_REGION)
+        delete_aurora_cluster(env, PRIMARY_REGION)
+        wait_aurora_cluster_deleted(env, PRIMARY_REGION)
+
+    # Delete global cluster
+    delete_aurora_global(env)
+
+    print()
+    print(green("Scenario {} deactivated (parked).".format(bold(env))))
+    print()
+
+
+# ── Command: trigger ────────────────────────────────────────────────────────────
+
+
+def cmd_trigger(args):
+    """Inject a failure to trigger failover."""
+    env = args.env
+    if env not in SCENARIOS:
+        print(red("Unknown scenario: {}".format(env)))
+        sys.exit(1)
+
+    scen = SCENARIOS[env]
+    print()
+    print(bold("Triggering failover for: {} ({})".format(env, scen["description"])))
+    print("=" * 60)
+
+    # Verify scenario is active
+    running, desired = get_ecs_status(env, PRIMARY_REGION)
+    if running is None or running == 0:
+        print(red("  Scenario is not active (ECS running={}).".format(running)))
+        print(red("  Activate it first: python3 tools/demo_manager.py activate {}".format(env)))
+        sys.exit(1)
+
+    # Reset cooldown so failover fires immediately
+    print()
+    reset_cooldown_in_dynamo(env)
+
+    # Scale ECS to 0 in primary
+    print()
+    print(bold("Injecting failure: scaling ECS to 0 in {}".format(PRIMARY_REGION)))
+    scale_ecs(env, PRIMARY_REGION, 0)
+
+    print()
+    print(green("Failure injected for {}.".format(bold(env))))
+    print("  Failover will trigger in ~3 minutes (consecutive failure threshold).")
+    print()
+
+    if args.watch:
+        print(bold("Tailing orchestrator logs (Ctrl+C to stop)..."))
+        print()
+        _tail_lambda_logs(env)
+
+
+def _tail_lambda_logs(env):
+    """Tail CloudWatch logs for the orchestrator Lambda."""
+    log_group = "/aws/lambda/{}".format(orchestrator_lambda_name(env))
+    logs = client("logs", PRIMARY_REGION)
+
+    # Start from now
+    start_time = int(time.time() * 1000) - 60000  # 1 min ago
+    seen_events = set()
+
+    try:
+        while True:
+            try:
+                resp = logs.filter_log_events(
+                    logGroupName=log_group,
+                    startTime=start_time,
+                    interleaved=True,
+                    limit=50,
+                )
+                for event in resp.get("events", []):
+                    eid = event["eventId"]
+                    if eid not in seen_events:
+                        seen_events.add(eid)
+                        ts = datetime.fromtimestamp(
+                            event["timestamp"] / 1000, tz=timezone.utc
+                        ).strftime("%H:%M:%S")
+                        msg = event["message"].rstrip()
+                        print("{} {}".format(dim(ts), msg))
+                        start_time = event["timestamp"] + 1
+            except ClientError as e:
+                if "ResourceNotFoundException" in str(e):
+                    print(dim("  Log group not found yet, waiting..."))
+                else:
+                    print(yellow("  Log error: {}".format(e)))
+            time.sleep(5)
+    except KeyboardInterrupt:
+        print()
+        print(dim("Stopped tailing logs."))
+
+
+# ── Command: reset ──────────────────────────────────────────────────────────────
+
+
+def cmd_reset(args):
+    """Reset a scenario back to PRIMARY_ACTIVE after a triggered failover."""
+    env = args.env
+    if env not in SCENARIOS:
+        print(red("Unknown scenario: {}".format(env)))
+        sys.exit(1)
+
+    scen = SCENARIOS[env]
+    print()
+    print(bold("Resetting: {} ({})".format(env, scen["description"])))
+    print("=" * 60)
+
+    # Step 1: Scale ECS back up in primary
+    print()
+    print(bold("[1/4] Scaling ECS in primary region"))
+    if ecs_service_exists(env, PRIMARY_REGION):
+        scale_ecs(env, PRIMARY_REGION, ECS_DESIRED_COUNT)
+    else:
+        print(red("  ECS service not found in primary. Cannot reset."))
+        sys.exit(1)
+
+    # Step 2: Wait for ECS tasks to be running
+    print()
+    print(bold("[2/4] Waiting for ECS tasks"))
+    start = time.time()
+    deadline = start + 300  # 5 min
+    spinner = ["|", "/", "-", "\\"]
+    tick = 0
+    while time.time() < deadline:
+        running, desired = get_ecs_status(env, PRIMARY_REGION)
+        if running is not None and running >= ECS_DESIRED_COUNT:
+            sys.stdout.write("\n")
+            print(green("  ECS has {}/{} tasks running.".format(running, desired)))
+            break
+        elapsed = int(time.time() - start)
+        sys.stdout.write(
+            "\r  {} Waiting for ECS ({:d}s) — running: {}   ".format(
+                spinner[tick % len(spinner)], elapsed, running
+            )
+        )
+        sys.stdout.flush()
+        time.sleep(10)
+        tick += 1
+    else:
+        sys.stdout.write("\n")
+        print(yellow("  TIMEOUT waiting for ECS. Proceeding with reset anyway."))
+
+    # Step 3: Invoke failback Lambda
+    print()
+    print(bold("[3/4] Invoking failback Lambda"))
+    fb_name = failback_lambda_name(env)
+    try:
+        resp = client("lambda", PRIMARY_REGION).invoke(
+            FunctionName=fb_name,
+            InvocationType="RequestResponse",
+            Payload=json.dumps({
+                "aurora_confirmed": True,
+                "skip_health_check": True,
+            }).encode(),
+        )
+        status_code = resp.get("StatusCode", 0)
+        payload = resp.get("Payload")
+        if payload:
+            body = json.loads(payload.read().decode())
+            print("  Failback response (HTTP {}): {}".format(status_code, json.dumps(body, indent=2)))
+        else:
+            print("  Failback invoked (HTTP {})".format(status_code))
+    except ClientError as e:
+        print(yellow("  Could not invoke failback Lambda: {}".format(e)))
+        print(yellow("  Proceeding with DynamoDB reset."))
+
+    # Step 4: Reset DynamoDB state
+    print()
+    print(bold("[4/4] Resetting DynamoDB state"))
+    reset_dynamo_state(env)
+
+    print()
+    print(green("Scenario {} reset to PRIMARY_ACTIVE.".format(bold(env))))
+    print()
+
+
+# ── Command: activate-all / deactivate-all ──────────────────────────────────────
+
+
+def cmd_activate_all(args):
+    """Activate all 9 scenarios."""
+    print()
+    print(bold("Activating ALL 9 demo scenarios"))
+    print(bold("=" * 60))
+    print()
+    print(yellow("This will create 9 Aurora global clusters and scale up 9 ECS services."))
+    print(yellow("Estimated time: ~15 minutes (Aurora creation is the bottleneck)."))
+    print()
+
+    confirm = input("Continue? [y/N] ").strip().lower()
+    if confirm != "y":
+        print("Aborted.")
+        return
+
+    errors = {}
+    for env in SCENARIOS:
+        try:
+            # Create a namespace for the args
+            ns = argparse.Namespace(env=env)
+            cmd_activate(ns)
+        except Exception as e:
+            print(red("ERROR activating {}: {}".format(env, e)))
+            errors[env] = str(e)
+
+    print()
+    if errors:
+        print(red("The following scenarios had errors:"))
+        for env, err in errors.items():
+            print(red("  {}: {}".format(env, err)))
+    else:
+        print(green("All 9 scenarios activated successfully."))
+    print()
+
+
+def cmd_deactivate_all(args):
+    """Deactivate all 9 scenarios."""
+    print()
+    print(bold("Deactivating ALL 9 demo scenarios"))
+    print(bold("=" * 60))
+    print()
+    print(yellow("This will delete all Aurora clusters and scale ECS to 0."))
+    print()
+
+    confirm = input("Continue? [y/N] ").strip().lower()
+    if confirm != "y":
+        print("Aborted.")
+        return
+
+    errors = {}
+    for env in SCENARIOS:
+        try:
+            ns = argparse.Namespace(env=env)
+            cmd_deactivate(ns)
+        except Exception as e:
+            print(red("ERROR deactivating {}: {}".format(env, e)))
+            errors[env] = str(e)
+
+    print()
+    if errors:
+        print(red("The following scenarios had errors:"))
+        for env, err in errors.items():
+            print(red("  {}: {}".format(env, err)))
+    else:
+        print(green("All 9 scenarios deactivated (parked)."))
+    print()
+
+
+# ── CLI Entry Point ─────────────────────────────────────────────────────────────
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="Failover Orchestrator Demo Manager — manage 9 demo environments",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Scenarios:
+  fo-v10-s1    v1.0 - Active/Passive
+  fo-v10-s2    v1.0 - Active/Passive Zero-Container
+  fo-v10-s3    v1.0 - Active/Active
+  fo-v11c-s1   v1.1 Claude - Active/Passive
+  fo-v11c-s2   v1.1 Claude - Active/Passive Zero-Container
+  fo-v11c-s3   v1.1 Claude - Active/Active
+  fo-v11g-s1   v1.1 Gemini - Active/Passive
+  fo-v11g-s2   v1.1 Gemini - Active/Passive Zero-Container
+  fo-v11g-s3   v1.1 Gemini - Active/Active
+
+Examples:
+  %(prog)s status
+  %(prog)s activate fo-v10-s1
+  %(prog)s trigger fo-v10-s1 --watch
+  %(prog)s reset fo-v10-s1
+  %(prog)s deactivate fo-v10-s1
+  %(prog)s activate-all
+  %(prog)s deactivate-all
+""",
+    )
+    sub = parser.add_subparsers(dest="command", help="Command to run")
+    sub.required = True
+
+    # status
+    sub.add_parser("status", help="Show status of all 9 demo environments")
+
+    # activate
+    p_act = sub.add_parser("activate", help="Activate a demo scenario")
+    p_act.add_argument("env", choices=list(SCENARIOS.keys()), help="Scenario env name")
+
+    # deactivate
+    p_deact = sub.add_parser("deactivate", help="Deactivate (park) a demo scenario")
+    p_deact.add_argument("env", choices=list(SCENARIOS.keys()), help="Scenario env name")
+
+    # trigger
+    p_trig = sub.add_parser("trigger", help="Inject failure to trigger failover")
+    p_trig.add_argument("env", choices=list(SCENARIOS.keys()), help="Scenario env name")
+    p_trig.add_argument("--watch", action="store_true", help="Tail orchestrator logs after triggering")
+
+    # reset
+    p_reset = sub.add_parser("reset", help="Reset scenario to PRIMARY_ACTIVE")
+    p_reset.add_argument("env", choices=list(SCENARIOS.keys()), help="Scenario env name")
+
+    # activate-all
+    sub.add_parser("activate-all", help="Activate all 9 scenarios")
+
+    # deactivate-all
+    sub.add_parser("deactivate-all", help="Deactivate all 9 scenarios")
+
+    return parser
+
+
+COMMAND_MAP = {
+    "status": cmd_status,
+    "activate": cmd_activate,
+    "deactivate": cmd_deactivate,
+    "trigger": cmd_trigger,
+    "reset": cmd_reset,
+    "activate-all": cmd_activate_all,
+    "deactivate-all": cmd_deactivate_all,
+}
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+
+    handler = COMMAND_MAP.get(args.command)
+    if handler is None:
+        parser.print_help()
+        sys.exit(1)
+
+    try:
+        handler(args)
+    except KeyboardInterrupt:
+        print()
+        print(dim("Interrupted."))
+        sys.exit(130)
+    except ClientError as e:
+        print()
+        print(red("AWS Error: {}".format(e)))
+        sys.exit(1)
+    except Exception as e:
+        print()
+        print(red("Error: {}".format(e)))
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/deploy_scenarios.py
+++ b/tools/deploy_scenarios.py
@@ -542,6 +542,15 @@ def upload_lambda_code(function_name, zip_path, region):
 
     # Wait for update to complete
     _wait_for_lambda_update(function_name, region)
+
+    # Ensure handler name matches the actual function (not the CFN placeholder)
+    handler = "failover_orchestrator_v3.handler" if "orchestrator" in function_name else "manual_failback_v2.handler"
+    lam.update_function_configuration(
+        FunctionName=function_name,
+        Handler=handler,
+    )
+    _wait_for_lambda_update(function_name, region)
+
     return True
 
 

--- a/tools/deploy_scenarios.py
+++ b/tools/deploy_scenarios.py
@@ -1,0 +1,1297 @@
+#!/usr/bin/env python3
+"""
+Deploy Scenarios — deploys CloudFormation stacks for all 9 failover demo scenarios.
+
+Each scenario gets its own app stack (ALB, ECS, SGs) and failover stack (Lambda,
+EventBridge, SNS, CloudWatch alarms, Route 53 health checks) in both regions.
+
+The network stack (fo-demo-network) must already be deployed in both regions.
+
+Usage:
+    python3 tools/deploy_scenarios.py deploy fo-v10-s1
+    python3 tools/deploy_scenarios.py deploy fo-v10-s1 --region us-west-1
+    python3 tools/deploy_scenarios.py deploy-all
+    python3 tools/deploy_scenarios.py teardown fo-v10-s1
+    python3 tools/deploy_scenarios.py teardown-all
+    python3 tools/deploy_scenarios.py list
+    python3 tools/deploy_scenarios.py status fo-v10-s1
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import tempfile
+import zipfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+
+try:
+    import boto3
+    from botocore.exceptions import ClientError, WaiterError
+except ImportError:
+    print("ERROR: boto3 is required. Install with: pip install boto3")
+    sys.exit(1)
+
+# ── Constants ────────────────────────────────────────────────────────────────────
+
+PRIMARY_REGION = "us-west-1"
+SECONDARY_REGION = "us-west-2"
+BOTH_REGIONS = [PRIMARY_REGION, SECONDARY_REGION]
+NETWORK_STACK = "fo-demo-network"
+NOTIFICATION_EMAIL = "ranohep@gmail.com"
+
+# Paths relative to this script
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.dirname(SCRIPT_DIR)
+CFN_DIR = os.path.join(PROJECT_ROOT, "cfn")
+APP_TEMPLATE = os.path.join(CFN_DIR, "app.yaml")
+FAILOVER_TEMPLATE = os.path.join(CFN_DIR, "failover.yaml")
+
+# Lambda source files
+ORCHESTRATOR_SRC = os.path.join(PROJECT_ROOT, "failover_orchestrator_v3.py")
+FAILBACK_SRC = os.path.join(PROJECT_ROOT, "manual_failback_v2.py")
+STATE_BACKEND_SRC = os.path.join(PROJECT_ROOT, "state_backend.py")
+AI_DIR = os.path.join(PROJECT_ROOT, "ai")
+
+REGION_SUFFIX = {
+    "us-west-1": "w1",
+    "us-west-2": "w2",
+}
+
+# ── Scenario Definitions (mirrored from demo_manager.py) ─────────────────────
+
+SCENARIOS = {
+    "fo-v10-s1": {
+        "description": "v1.0 - Active/Passive",
+        "version": "v1.0",
+        "routing_mode": "failover",
+        "passive_publish_zero": False,
+        "ai_rca_enabled": False,
+        "ai_rca_provider": None,
+    },
+    "fo-v10-s2": {
+        "description": "v1.0 - Active/Passive Zero-Container",
+        "version": "v1.0",
+        "routing_mode": "failover",
+        "passive_publish_zero": True,
+        "ai_rca_enabled": False,
+        "ai_rca_provider": None,
+    },
+    "fo-v10-s3": {
+        "description": "v1.0 - Active/Active",
+        "version": "v1.0",
+        "routing_mode": "active-active",
+        "passive_publish_zero": False,
+        "ai_rca_enabled": False,
+        "ai_rca_provider": None,
+    },
+    "fo-v11c-s1": {
+        "description": "v1.1 Claude - Active/Passive",
+        "version": "v1.1",
+        "routing_mode": "failover",
+        "passive_publish_zero": False,
+        "ai_rca_enabled": True,
+        "ai_rca_provider": "claude",
+    },
+    "fo-v11c-s2": {
+        "description": "v1.1 Claude - Active/Passive Zero-Container",
+        "version": "v1.1",
+        "routing_mode": "failover",
+        "passive_publish_zero": True,
+        "ai_rca_enabled": True,
+        "ai_rca_provider": "claude",
+    },
+    "fo-v11c-s3": {
+        "description": "v1.1 Claude - Active/Active",
+        "version": "v1.1",
+        "routing_mode": "active-active",
+        "passive_publish_zero": False,
+        "ai_rca_enabled": True,
+        "ai_rca_provider": "claude",
+    },
+    "fo-v11g-s1": {
+        "description": "v1.1 Gemini - Active/Passive",
+        "version": "v1.1",
+        "routing_mode": "failover",
+        "passive_publish_zero": False,
+        "ai_rca_enabled": True,
+        "ai_rca_provider": "gemini",
+    },
+    "fo-v11g-s2": {
+        "description": "v1.1 Gemini - Active/Passive Zero-Container",
+        "version": "v1.1",
+        "routing_mode": "failover",
+        "passive_publish_zero": True,
+        "ai_rca_enabled": True,
+        "ai_rca_provider": "gemini",
+    },
+    "fo-v11g-s3": {
+        "description": "v1.1 Gemini - Active/Active",
+        "version": "v1.1",
+        "routing_mode": "active-active",
+        "passive_publish_zero": False,
+        "ai_rca_enabled": True,
+        "ai_rca_provider": "gemini",
+    },
+}
+
+# ── ANSI Color Helpers ────────────────────────────────────────────────────────
+
+_COLOR_ENABLED = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+
+
+def _c(code, text):
+    if _COLOR_ENABLED:
+        return "\033[{}m{}\033[0m".format(code, text)
+    return str(text)
+
+
+def green(t):
+    return _c("32", t)
+
+
+def red(t):
+    return _c("31", t)
+
+
+def yellow(t):
+    return _c("33", t)
+
+
+def cyan(t):
+    return _c("36", t)
+
+
+def bold(t):
+    return _c("1", t)
+
+
+def dim(t):
+    return _c("2", t)
+
+
+# ── AWS Client Cache ─────────────────────────────────────────────────────────
+
+_clients = {}
+
+
+def client(service, region=PRIMARY_REGION):
+    key = (service, region)
+    if key not in _clients:
+        _clients[key] = boto3.client(service, region_name=region)
+    return _clients[key]
+
+
+# ── Resource Naming (consistent with demo_manager.py) ─────────────────────────
+
+
+def app_stack_name(env):
+    return "{}-app".format(env)
+
+
+def failover_stack_name(env):
+    return "{}-failover".format(env)
+
+
+def state_table_name(env):
+    return "{}-state".format(env)
+
+
+def aurora_global_cluster_id(env):
+    return "{}-aurora-global".format(env)
+
+
+def aurora_cluster_id(env, region):
+    return "{}-aurora-{}".format(env, REGION_SUFFIX[region])
+
+
+def orchestrator_lambda_name(env):
+    return "fo-{}-orchestrator".format(env)
+
+
+def failback_lambda_name(env):
+    return "fo-{}-failback".format(env)
+
+
+def eventbridge_rule_name(env):
+    return "fo-{}-orchestrator-schedule".format(env)
+
+
+# ── Template Reading ──────────────────────────────────────────────────────────
+
+
+def read_template(path):
+    """Read a CloudFormation template file and return its contents."""
+    with open(path, "r") as f:
+        return f.read()
+
+
+# ── Lambda Zip Building ──────────────────────────────────────────────────────
+
+
+def build_orchestrator_zip(version):
+    """Build the orchestrator Lambda deployment zip.
+
+    For v1.0, includes only the orchestrator and state backend.
+    For v1.1, also includes the ai/ module.
+    """
+    tmp = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
+    tmp.close()
+
+    with zipfile.ZipFile(tmp.name, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.write(ORCHESTRATOR_SRC, "failover_orchestrator_v3.py")
+        zf.write(STATE_BACKEND_SRC, "state_backend.py")
+
+        if version == "v1.1" and os.path.isdir(AI_DIR):
+            for root, _dirs, files in os.walk(AI_DIR):
+                for fname in files:
+                    if fname.endswith(".py"):
+                        full_path = os.path.join(root, fname)
+                        arc_name = os.path.relpath(full_path, PROJECT_ROOT)
+                        zf.write(full_path, arc_name)
+
+    return tmp.name
+
+
+def build_failback_zip():
+    """Build the failback Lambda deployment zip."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
+    tmp.close()
+
+    with zipfile.ZipFile(tmp.name, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.write(FAILBACK_SRC, "manual_failback_v2.py")
+        zf.write(STATE_BACKEND_SRC, "state_backend.py")
+
+    return tmp.name
+
+
+# ── CloudFormation Helpers ────────────────────────────────────────────────────
+
+
+def stack_exists(stack_name, region):
+    """Check if a CFN stack exists and is not in a deleted state."""
+    cfn = client("cloudformation", region)
+    try:
+        resp = cfn.describe_stacks(StackName=stack_name)
+        stacks = resp.get("Stacks", [])
+        if not stacks:
+            return False
+        status = stacks[0].get("StackStatus", "")
+        # Consider DELETE_COMPLETE as non-existent
+        if status == "DELETE_COMPLETE":
+            return False
+        return True
+    except ClientError as e:
+        msg = str(e)
+        if "does not exist" in msg:
+            return False
+        raise
+
+
+def get_stack_status(stack_name, region):
+    """Get the current status of a CFN stack."""
+    cfn = client("cloudformation", region)
+    try:
+        resp = cfn.describe_stacks(StackName=stack_name)
+        stacks = resp.get("Stacks", [])
+        if not stacks:
+            return None
+        return stacks[0].get("StackStatus")
+    except ClientError as e:
+        if "does not exist" in str(e):
+            return None
+        raise
+
+
+def get_stack_outputs(stack_name, region):
+    """Get the outputs of a CFN stack as a dict."""
+    cfn = client("cloudformation", region)
+    try:
+        resp = cfn.describe_stacks(StackName=stack_name)
+        stacks = resp.get("Stacks", [])
+        if not stacks:
+            return {}
+        outputs = stacks[0].get("Outputs", [])
+        return {o["OutputKey"]: o["OutputValue"] for o in outputs}
+    except ClientError as e:
+        if "does not exist" in str(e):
+            return {}
+        raise
+
+
+def deploy_stack(stack_name, template_body, parameters, region, capabilities=None):
+    """Create or update a CloudFormation stack and wait for completion.
+
+    Returns True on success, False on no-op (no update needed).
+    Raises on failure.
+    """
+    cfn = client("cloudformation", region)
+    caps = capabilities or ["CAPABILITY_NAMED_IAM"]
+
+    params_list = [
+        {"ParameterKey": k, "ParameterValue": v}
+        for k, v in parameters.items()
+    ]
+
+    exists = stack_exists(stack_name, region)
+
+    if exists:
+        # Check if stack is in a failed state that needs cleanup
+        status = get_stack_status(stack_name, region)
+        if status in (
+            "ROLLBACK_COMPLETE",
+            "ROLLBACK_FAILED",
+            "CREATE_FAILED",
+            "DELETE_FAILED",
+        ):
+            print("    Stack {} is in {} state — deleting first...".format(
+                stack_name, status))
+            delete_stack(stack_name, region)
+            exists = False
+
+    if exists:
+        # Check for in-progress operations
+        status = get_stack_status(stack_name, region)
+        if status and "IN_PROGRESS" in status:
+            print("    Stack {} is {} — waiting for completion...".format(
+                stack_name, status))
+            _wait_for_stack(stack_name, region, status)
+
+        # Update
+        print("    Updating stack {} in {}...".format(stack_name, region))
+        try:
+            cfn.update_stack(
+                StackName=stack_name,
+                TemplateBody=template_body,
+                Parameters=params_list,
+                Capabilities=caps,
+                Tags=[
+                    {"Key": "Project", "Value": "fo-demo"},
+                    {"Key": "ManagedBy", "Value": "deploy_scenarios.py"},
+                ],
+            )
+        except ClientError as e:
+            if "No updates are to be performed" in str(e):
+                print("    No changes needed for {} in {}.".format(
+                    stack_name, region))
+                return False
+            raise
+
+        _wait_for_stack(stack_name, region, "UPDATE_IN_PROGRESS")
+        print(green("    Stack {} updated in {}.".format(stack_name, region)))
+        return True
+    else:
+        # Create
+        print("    Creating stack {} in {}...".format(stack_name, region))
+        cfn.create_stack(
+            StackName=stack_name,
+            TemplateBody=template_body,
+            Parameters=params_list,
+            Capabilities=caps,
+            Tags=[
+                {"Key": "Project", "Value": "fo-demo"},
+                {"Key": "ManagedBy", "Value": "deploy_scenarios.py"},
+            ],
+            OnFailure="DELETE",
+        )
+
+        _wait_for_stack(stack_name, region, "CREATE_IN_PROGRESS")
+        print(green("    Stack {} created in {}.".format(stack_name, region)))
+        return True
+
+
+def _wait_for_stack(stack_name, region, current_status):
+    """Wait for a stack operation to complete. Polls every 15 seconds."""
+    cfn = client("cloudformation", region)
+    spinner = ["|", "/", "-", "\\"]
+    tick = 0
+    start = time.time()
+    timeout = 1200  # 20 minutes
+
+    while time.time() - start < timeout:
+        time.sleep(15)
+        status = get_stack_status(stack_name, region)
+        elapsed = int(time.time() - start)
+
+        if status is None:
+            # Stack was deleted (CREATE failed with OnFailure=DELETE)
+            raise RuntimeError(
+                "Stack {} was deleted during creation (likely a template error). "
+                "Check CloudFormation events in {} for details.".format(
+                    stack_name, region))
+
+        sys.stdout.write(
+            "\r    {} {} in {} ({:d}s) — {}   ".format(
+                spinner[tick % len(spinner)], stack_name, region, elapsed, status
+            )
+        )
+        sys.stdout.flush()
+        tick += 1
+
+        if status.endswith("_COMPLETE"):
+            sys.stdout.write("\n")
+            if "ROLLBACK" in status:
+                raise RuntimeError(
+                    "Stack {} rolled back in {} (status: {}). "
+                    "Check CloudFormation events for details.".format(
+                        stack_name, region, status))
+            return
+        elif status.endswith("_FAILED"):
+            sys.stdout.write("\n")
+            raise RuntimeError(
+                "Stack {} failed in {} (status: {}). "
+                "Check CloudFormation events for details.".format(
+                    stack_name, region, status))
+
+    sys.stdout.write("\n")
+    raise RuntimeError(
+        "Timeout waiting for stack {} in {} (last status: {}).".format(
+            stack_name, region, status))
+
+
+def delete_stack(stack_name, region):
+    """Delete a CFN stack and wait for completion."""
+    cfn = client("cloudformation", region)
+
+    if not stack_exists(stack_name, region):
+        print("    Stack {} does not exist in {}, skipping.".format(
+            stack_name, region))
+        return
+
+    # Check for in-progress operations first
+    status = get_stack_status(stack_name, region)
+    if status and "IN_PROGRESS" in status:
+        print("    Stack {} is {} — waiting before delete...".format(
+            stack_name, status))
+        try:
+            _wait_for_stack(stack_name, region, status)
+        except RuntimeError:
+            pass  # Proceed with delete even if the prior operation failed
+
+    print("    Deleting stack {} in {}...".format(stack_name, region))
+    try:
+        cfn.delete_stack(StackName=stack_name)
+    except ClientError as e:
+        if "does not exist" in str(e):
+            return
+        raise
+
+    # Wait for deletion
+    spinner = ["|", "/", "-", "\\"]
+    tick = 0
+    start = time.time()
+    timeout = 600  # 10 minutes
+
+    while time.time() - start < timeout:
+        time.sleep(15)
+        status = get_stack_status(stack_name, region)
+        elapsed = int(time.time() - start)
+
+        if status is None or status == "DELETE_COMPLETE":
+            sys.stdout.write("\n")
+            print(green("    Stack {} deleted in {}.".format(stack_name, region)))
+            return
+
+        sys.stdout.write(
+            "\r    {} Deleting {} in {} ({:d}s) — {}   ".format(
+                spinner[tick % len(spinner)], stack_name, region, elapsed, status
+            )
+        )
+        sys.stdout.flush()
+        tick += 1
+
+        if status == "DELETE_FAILED":
+            sys.stdout.write("\n")
+            raise RuntimeError(
+                "Failed to delete stack {} in {}. "
+                "Check for resources with DeletionPolicy=Retain or "
+                "dependencies from other stacks.".format(stack_name, region))
+
+    sys.stdout.write("\n")
+    print(yellow("    Timeout waiting for deletion of {} in {}.".format(
+        stack_name, region)))
+
+
+# ── Lambda Code Deployment ────────────────────────────────────────────────────
+
+
+def upload_lambda_code(function_name, zip_path, region):
+    """Upload a zip file as Lambda function code."""
+    lam = client("lambda", region)
+
+    with open(zip_path, "rb") as f:
+        zip_bytes = f.read()
+
+    print("    Uploading code to {} in {} ({:.1f} KB)...".format(
+        function_name, region, len(zip_bytes) / 1024))
+
+    try:
+        lam.update_function_code(
+            FunctionName=function_name,
+            ZipFile=zip_bytes,
+        )
+    except ClientError as e:
+        if "ResourceNotFoundException" in str(e):
+            print(yellow("    Lambda {} not found in {}, skipping code upload.".format(
+                function_name, region)))
+            return False
+        raise
+
+    # Wait for update to complete
+    _wait_for_lambda_update(function_name, region)
+    return True
+
+
+def _wait_for_lambda_update(function_name, region):
+    """Wait for Lambda function update to complete."""
+    lam = client("lambda", region)
+    start = time.time()
+    timeout = 120
+
+    while time.time() - start < timeout:
+        try:
+            resp = lam.get_function(FunctionName=function_name)
+            config = resp.get("Configuration", {})
+            state = config.get("State", "Unknown")
+            last_update = config.get("LastUpdateStatus", "Unknown")
+
+            if state == "Active" and last_update in ("Successful", "InProgress"):
+                if last_update == "Successful":
+                    return
+            elif state == "Failed":
+                raise RuntimeError(
+                    "Lambda {} update failed: {}".format(
+                        function_name,
+                        config.get("LastUpdateStatusReasonCode", "unknown")))
+        except ClientError:
+            pass
+
+        time.sleep(5)
+
+    print(yellow("    Timeout waiting for Lambda {} update.".format(function_name)))
+
+
+def set_lambda_env_vars(function_name, env_vars, region):
+    """Update Lambda environment variables (merges with existing)."""
+    lam = client("lambda", region)
+
+    try:
+        resp = lam.get_function_configuration(FunctionName=function_name)
+        existing = resp.get("Environment", {}).get("Variables", {})
+    except ClientError as e:
+        if "ResourceNotFoundException" in str(e):
+            print(yellow("    Lambda {} not found in {}, skipping env var update.".format(
+                function_name, region)))
+            return False
+        raise
+
+    # Merge: new vars override existing
+    merged = dict(existing)
+    merged.update(env_vars)
+
+    print("    Setting env vars on {} in {} ({} vars)...".format(
+        function_name, region, len(env_vars)))
+
+    _wait_for_lambda_update(function_name, region)
+
+    lam.update_function_configuration(
+        FunctionName=function_name,
+        Environment={"Variables": merged},
+    )
+
+    _wait_for_lambda_update(function_name, region)
+    return True
+
+
+# ── EventBridge Helpers ───────────────────────────────────────────────────────
+
+
+def disable_eventbridge_rule(env, region):
+    """Disable the EventBridge rule for a scenario."""
+    rule = eventbridge_rule_name(env)
+    try:
+        client("events", region).disable_rule(Name=rule)
+        print("    Disabled EventBridge rule {} in {}.".format(rule, region))
+    except ClientError as e:
+        if "ResourceNotFoundException" in str(e):
+            print(dim("    EventBridge rule {} not found in {}, skipping.".format(
+                rule, region)))
+        else:
+            raise
+
+
+# ── ECS Helpers ───────────────────────────────────────────────────────────────
+
+
+def scale_ecs_to_zero(env, region):
+    """Scale ECS service to 0 tasks."""
+    # The ECS service name from CFN is fo-{env}-app-svc
+    svc_name = "fo-{}-app-svc".format(env)
+    # The cluster name from CFN is fo-{env}-cluster
+    cluster = "fo-{}-cluster".format(env)
+
+    try:
+        client("ecs", region).update_service(
+            cluster=cluster,
+            service=svc_name,
+            desiredCount=0,
+        )
+        print("    Scaled {}/{} to 0 in {}.".format(cluster, svc_name, region))
+    except ClientError as e:
+        if "ServiceNotFoundException" in str(e) or "ClusterNotFoundException" in str(e):
+            print(dim("    ECS service not found in {}, skipping.".format(region)))
+        else:
+            raise
+
+
+# ── DynamoDB Helpers ──────────────────────────────────────────────────────────
+
+
+def create_state_table(env, region):
+    """Create the DynamoDB state table if it does not exist."""
+    table = state_table_name(env)
+    ddb = client("dynamodb", region)
+
+    try:
+        ddb.describe_table(TableName=table)
+        print(dim("    DynamoDB table {} already exists in {}.".format(table, region)))
+        return
+    except ClientError as e:
+        if e.response["Error"]["Code"] != "ResourceNotFoundException":
+            raise
+
+    print("    Creating DynamoDB table {} in {}...".format(table, region))
+    ddb.create_table(
+        TableName=table,
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+        Tags=[
+            {"Key": "Project", "Value": "fo-demo"},
+            {"Key": "ManagedBy", "Value": "deploy_scenarios.py"},
+        ],
+    )
+
+    # Wait for table to become active
+    waiter = ddb.get_waiter("table_exists")
+    waiter.wait(TableName=table, WaiterConfig={"Delay": 5, "MaxAttempts": 30})
+    print(green("    DynamoDB table {} created in {}.".format(table, region)))
+
+
+def delete_state_table(env, region):
+    """Delete the DynamoDB state table."""
+    table = state_table_name(env)
+    ddb = client("dynamodb", region)
+
+    try:
+        ddb.delete_table(TableName=table)
+        print("    Deleted DynamoDB table {} in {}.".format(table, region))
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ResourceNotFoundException":
+            print(dim("    DynamoDB table {} not found in {}, skipping.".format(
+                table, region)))
+        else:
+            raise
+
+
+# ── Container Image Discovery ─────────────────────────────────────────────────
+
+
+def discover_container_image(region):
+    """Find the container image URI from the existing fo-demo-app stack or ECR."""
+    # Try the existing fo-demo-app stack first
+    outputs = get_stack_outputs("fo-demo-app", region)
+    if outputs:
+        # Some stacks expose the image as a parameter, not an output.
+        # Fall through to ECR discovery.
+        pass
+
+    # Try to find a repo matching fo-demo in ECR
+    ecr = client("ecr", region)
+    try:
+        repos = ecr.describe_repositories()
+        for repo in repos.get("repositories", []):
+            name = repo.get("repositoryName", "")
+            if "fo-demo" in name or "fo-" in name:
+                uri = repo.get("repositoryUri", "")
+                # Get latest tag
+                try:
+                    images = ecr.list_images(
+                        repositoryName=name,
+                        filter={"tagStatus": "TAGGED"},
+                        maxResults=10,
+                    )
+                    tags = [
+                        img["imageTag"]
+                        for img in images.get("imageIds", [])
+                        if "imageTag" in img
+                    ]
+                    if "latest" in tags:
+                        return "{}:latest".format(uri)
+                    elif tags:
+                        return "{}:{}".format(uri, tags[0])
+                    else:
+                        return "{}:latest".format(uri)
+                except ClientError:
+                    return "{}:latest".format(uri)
+    except ClientError:
+        pass
+
+    return "placeholder"
+
+
+# ── ALB ARN Suffix Extraction ─────────────────────────────────────────────────
+
+
+def extract_alb_arn_suffix(outputs):
+    """Extract the ALB ARN suffix from stack outputs.
+
+    The ALB ARN looks like:
+        arn:aws:elasticloadbalancing:region:acct:loadbalancer/app/name/hex
+    The suffix for CloudWatch metrics is:
+        app/name/hex
+    """
+    alb_arn = outputs.get("InternalAlbArn", "")
+    if "/app/" in alb_arn:
+        idx = alb_arn.index("/app/")
+        return alb_arn[idx + 1:]  # "app/name/hex"
+    return ""
+
+
+# ── Deploy a Single Scenario ─────────────────────────────────────────────────
+
+
+def deploy_scenario(env, regions=None):
+    """Deploy all stacks for a single scenario."""
+    if env not in SCENARIOS:
+        print(red("Unknown scenario: {}".format(env)))
+        return False
+
+    scen = SCENARIOS[env]
+    if regions is None:
+        regions = BOTH_REGIONS
+
+    print()
+    print(bold("=" * 70))
+    print(bold("Deploying: {} ({})".format(env, scen["description"])))
+    print(bold("=" * 70))
+    print()
+
+    # Read templates
+    app_template = read_template(APP_TEMPLATE)
+    failover_template = read_template(FAILOVER_TEMPLATE)
+
+    # Discover container image from primary region
+    print(bold("[1/7] Discovering container image..."))
+    container_image = discover_container_image(PRIMARY_REGION)
+    print("    Container image: {}".format(container_image))
+    print()
+
+    # Deploy app stacks in both regions (parallel)
+    print(bold("[2/7] Deploying app stacks..."))
+    app_errors = {}
+
+    def _deploy_app(region):
+        params = {
+            "Env": env,
+            "NetworkStack": NETWORK_STACK,
+            "ContainerImage": container_image,
+            "AuroraEndpoint": "placeholder",
+            "AuroraPort": "5432",
+            "AuroraDb": "appdb",
+            "AuroraUser": "appuser",
+            "AuroraPassword": "changeme",
+            "RegionName": region,
+        }
+        deploy_stack(app_stack_name(env), app_template, params, region)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = {}
+        for region in regions:
+            f = pool.submit(_deploy_app, region)
+            futures[f] = region
+
+        for f in as_completed(futures):
+            region = futures[f]
+            try:
+                f.result()
+            except Exception as e:
+                app_errors[region] = str(e)
+                print(red("    ERROR deploying app stack in {}: {}".format(region, e)))
+
+    if app_errors:
+        print(red("App stack deployment failed. Cannot proceed with failover stacks."))
+        return False
+
+    print()
+
+    # Get app stack outputs (needed for failover stack params)
+    print(bold("[3/7] Reading app stack outputs..."))
+    app_outputs = {}
+    for region in regions:
+        outputs = get_stack_outputs(app_stack_name(env), region)
+        app_outputs[region] = outputs
+        print("    {}: ALB DNS = {}".format(
+            region, outputs.get("InternalAlbDns", "N/A")))
+    print()
+
+    # Create DynamoDB state tables
+    print(bold("[4/7] Creating DynamoDB state tables..."))
+    for region in regions:
+        create_state_table(env, region)
+    print()
+
+    # Deploy failover stacks (sequential — depends on app outputs)
+    print(bold("[5/7] Deploying failover stacks..."))
+    for region in regions:
+        outputs = app_outputs.get(region, {})
+        alb_dns = outputs.get("InternalAlbDns", "placeholder")
+        alb_arn_suffix = extract_alb_arn_suffix(outputs)
+        ecs_cluster = outputs.get("EcsClusterName", "fo-{}-cluster".format(env))
+        ecs_service = outputs.get("EcsServiceName", "fo-{}-app-svc".format(env))
+
+        params = {
+            "Env": env,
+            "AppStack": app_stack_name(env),
+            "NetworkStack": NETWORK_STACK,
+            "PrimaryRegion": PRIMARY_REGION,
+            "SecondaryRegion": SECONDARY_REGION,
+            "StateTable": state_table_name(env),
+            "InternalAlbDns": alb_dns,
+            "AlbArnSuffix": alb_arn_suffix,
+            "EcsClusterName": ecs_cluster,
+            "EcsServiceName": ecs_service,
+            "AuroraClusterId": aurora_cluster_id(env, region),
+            "AuroraGlobalClusterId": aurora_global_cluster_id(env),
+            "NotificationEmail": NOTIFICATION_EMAIL,
+            "FailoverMode": "auto",
+            "CooldownMinutes": "5",
+            "ConsecutiveFailuresThreshold": "3",
+        }
+
+        try:
+            deploy_stack(failover_stack_name(env), failover_template, params, region)
+        except Exception as e:
+            print(red("    ERROR deploying failover stack in {}: {}".format(region, e)))
+            return False
+    print()
+
+    # Upload Lambda code
+    print(bold("[6/7] Uploading Lambda code..."))
+    version = scen["version"]
+
+    orchestrator_zip = build_orchestrator_zip(version)
+    failback_zip = build_failback_zip()
+
+    try:
+        for region in regions:
+            # The Lambda names come from the CFN template: fo-{Env}-orchestrator
+            orch_name = "fo-{}-orchestrator".format(env)
+            fb_name = "fo-{}-failback".format(env)
+
+            upload_lambda_code(orch_name, orchestrator_zip, region)
+            upload_lambda_code(fb_name, failback_zip, region)
+    finally:
+        # Clean up temp files
+        try:
+            os.unlink(orchestrator_zip)
+        except OSError:
+            pass
+        try:
+            os.unlink(failback_zip)
+        except OSError:
+            pass
+
+    # Set scenario-specific env vars on Lambda
+    print()
+    print("    Setting scenario-specific environment variables...")
+    extra_env = {
+        "ROUTING_MODE": scen["routing_mode"],
+        "PASSIVE_PUBLISH_ZERO": str(scen["passive_publish_zero"]).lower(),
+    }
+    if scen["ai_rca_enabled"]:
+        extra_env["AI_RCA_ENABLED"] = "true"
+        extra_env["AI_RCA_PROVIDER"] = scen["ai_rca_provider"] or ""
+    else:
+        extra_env["AI_RCA_ENABLED"] = "false"
+
+    # Set CW_NAMESPACE to scenario-specific namespace
+    extra_env["CW_NAMESPACE"] = "Custom/{}".format(env)
+
+    for region in regions:
+        orch_name = "fo-{}-orchestrator".format(env)
+        set_lambda_env_vars(orch_name, extra_env, region)
+    print()
+
+    # Park the scenario: disable EventBridge, scale ECS to 0
+    print(bold("[7/7] Parking scenario (disable EventBridge, scale ECS to 0)..."))
+    for region in regions:
+        disable_eventbridge_rule(env, region)
+        scale_ecs_to_zero(env, region)
+    print()
+
+    print(green("Scenario {} deployed and parked successfully.".format(bold(env))))
+    print("  Use 'python3 tools/demo_manager.py activate {}' to start it.".format(env))
+    print()
+    return True
+
+
+# ── Teardown a Single Scenario ────────────────────────────────────────────────
+
+
+def teardown_scenario(env, regions=None):
+    """Delete all stacks for a single scenario."""
+    if env not in SCENARIOS:
+        print(red("Unknown scenario: {}".format(env)))
+        return False
+
+    scen = SCENARIOS[env]
+    if regions is None:
+        regions = BOTH_REGIONS
+
+    print()
+    print(bold("=" * 70))
+    print(bold("Tearing down: {} ({})".format(env, scen["description"])))
+    print(bold("=" * 70))
+    print()
+
+    # Step 1: Delete failover stacks first (they depend on app stack exports)
+    print(bold("[1/3] Deleting failover stacks..."))
+    for region in regions:
+        try:
+            delete_stack(failover_stack_name(env), region)
+        except Exception as e:
+            print(red("    ERROR deleting failover stack in {}: {}".format(region, e)))
+    print()
+
+    # Step 2: Delete app stacks
+    print(bold("[2/3] Deleting app stacks..."))
+    for region in regions:
+        try:
+            delete_stack(app_stack_name(env), region)
+        except Exception as e:
+            print(red("    ERROR deleting app stack in {}: {}".format(region, e)))
+    print()
+
+    # Step 3: Clean up DynamoDB state tables
+    print(bold("[3/3] Cleaning up DynamoDB state tables..."))
+    for region in regions:
+        delete_state_table(env, region)
+    print()
+
+    print(green("Scenario {} torn down.".format(bold(env))))
+    print()
+    return True
+
+
+# ── Status for a Scenario ─────────────────────────────────────────────────────
+
+
+def show_scenario_status(env):
+    """Show detailed status of a scenario's stacks."""
+    if env not in SCENARIOS:
+        print(red("Unknown scenario: {}".format(env)))
+        return
+
+    scen = SCENARIOS[env]
+    print()
+    print(bold("{} ({})".format(env, scen["description"])))
+    print("-" * 60)
+
+    for region in BOTH_REGIONS:
+        print()
+        print(bold("  Region: {}".format(region)))
+
+        # App stack
+        app_status = get_stack_status(app_stack_name(env), region)
+        if app_status:
+            color = green if "COMPLETE" in app_status and "ROLLBACK" not in app_status else yellow
+            print("    App stack ({}): {}".format(
+                app_stack_name(env), color(app_status)))
+        else:
+            print("    App stack ({}): {}".format(
+                app_stack_name(env), dim("NOT DEPLOYED")))
+
+        # Failover stack
+        fo_status = get_stack_status(failover_stack_name(env), region)
+        if fo_status:
+            color = green if "COMPLETE" in fo_status and "ROLLBACK" not in fo_status else yellow
+            print("    Failover stack ({}): {}".format(
+                failover_stack_name(env), color(fo_status)))
+        else:
+            print("    Failover stack ({}): {}".format(
+                failover_stack_name(env), dim("NOT DEPLOYED")))
+
+        # DynamoDB
+        table = state_table_name(env)
+        try:
+            client("dynamodb", region).describe_table(TableName=table)
+            print("    DynamoDB table ({}): {}".format(table, green("EXISTS")))
+        except ClientError:
+            print("    DynamoDB table ({}): {}".format(table, dim("NOT FOUND")))
+
+    print()
+
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+
+def cmd_deploy(args):
+    """Deploy a single scenario."""
+    env = args.env
+    regions = [args.region] if args.region else None
+    if not deploy_scenario(env, regions):
+        sys.exit(1)
+
+
+def cmd_deploy_all(args):
+    """Deploy all 9 scenarios."""
+    print()
+    print(bold("Deploying ALL 9 demo scenarios"))
+    print(bold("=" * 70))
+    print()
+    print(yellow("This will create 18 app stacks (9 scenarios x 2 regions)"))
+    print(yellow("and 18 failover stacks. Each scenario gets:"))
+    print(yellow("  - ALB, ECS cluster, ECS service, security groups"))
+    print(yellow("  - Lambda functions, EventBridge rule, SNS topic"))
+    print(yellow("  - CloudWatch alarm, Route 53 health check"))
+    print()
+    print(yellow("Estimated time: ~30-45 minutes"))
+    print()
+
+    if not args.yes:
+        confirm = input("Continue? [y/N] ").strip().lower()
+        if confirm != "y":
+            print("Aborted.")
+            return
+
+    errors = {}
+    for env in SCENARIOS:
+        try:
+            if not deploy_scenario(env):
+                errors[env] = "Deployment returned failure"
+        except Exception as e:
+            print(red("ERROR deploying {}: {}".format(env, e)))
+            errors[env] = str(e)
+
+    print()
+    print(bold("=" * 70))
+    if errors:
+        print(red("The following scenarios had errors:"))
+        for env, err in errors.items():
+            print(red("  {}: {}".format(env, err)))
+        sys.exit(1)
+    else:
+        print(green("All 9 scenarios deployed and parked successfully."))
+    print()
+
+
+def cmd_teardown(args):
+    """Teardown a single scenario."""
+    env = args.env
+
+    if not args.yes:
+        confirm = input(
+            "Delete all stacks for {}? This cannot be undone. [y/N] ".format(env)
+        ).strip().lower()
+        if confirm != "y":
+            print("Aborted.")
+            return
+
+    if not teardown_scenario(env):
+        sys.exit(1)
+
+
+def cmd_teardown_all(args):
+    """Teardown all 9 scenarios."""
+    print()
+    print(bold("Tearing down ALL 9 demo scenarios"))
+    print(bold("=" * 70))
+    print()
+    print(red("This will DELETE all CloudFormation stacks and DynamoDB tables"))
+    print(red("for all 9 scenarios in both regions."))
+    print()
+
+    if not args.yes:
+        confirm = input("Type 'DELETE ALL' to confirm: ").strip()
+        if confirm != "DELETE ALL":
+            print("Aborted.")
+            return
+
+    errors = {}
+    for env in SCENARIOS:
+        try:
+            if not teardown_scenario(env):
+                errors[env] = "Teardown returned failure"
+        except Exception as e:
+            print(red("ERROR tearing down {}: {}".format(env, e)))
+            errors[env] = str(e)
+
+    print()
+    print(bold("=" * 70))
+    if errors:
+        print(red("The following scenarios had errors:"))
+        for env, err in errors.items():
+            print(red("  {}: {}".format(env, err)))
+        sys.exit(1)
+    else:
+        print(green("All 9 scenarios torn down."))
+    print()
+
+
+def cmd_list(args):
+    """List all scenarios."""
+    print()
+    print(bold("Failover Orchestrator Demo Scenarios"))
+    print(bold("=" * 80))
+    print()
+
+    header = "{:<14s} {:<45s} {:<8s} {:<15s}".format(
+        "ENV", "DESCRIPTION", "VERSION", "ROUTING MODE"
+    )
+    print(bold(header))
+    print("-" * 80)
+
+    for env, scen in SCENARIOS.items():
+        ai_tag = ""
+        if scen["ai_rca_enabled"]:
+            ai_tag = " +AI({})".format(scen["ai_rca_provider"])
+        if scen["passive_publish_zero"]:
+            ai_tag += " +ZeroCont"
+
+        print("{:<14s} {:<45s} {:<8s} {:<15s}{}".format(
+            cyan(env),
+            scen["description"],
+            scen["version"],
+            scen["routing_mode"],
+            dim(ai_tag) if ai_tag else "",
+        ))
+
+    print()
+    print("Stack naming convention:")
+    print("  App stack:      {env}-app")
+    print("  Failover stack: {env}-failover")
+    print("  State table:    {env}-state")
+    print("  Network stack:  {} (shared)".format(NETWORK_STACK))
+    print()
+
+
+def cmd_status(args):
+    """Show status of a scenario or all scenarios."""
+    if args.env:
+        show_scenario_status(args.env)
+    else:
+        for env in SCENARIOS:
+            show_scenario_status(env)
+
+
+# ── CLI Entry Point ──────────────────────────────────────────────────────────
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="Deploy CloudFormation stacks for failover demo scenarios",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s deploy fo-v10-s1                 Deploy one scenario to both regions
+  %(prog)s deploy fo-v10-s1 --region us-west-1  Deploy to one region only
+  %(prog)s deploy-all                       Deploy all 9 scenarios
+  %(prog)s deploy-all --yes                 Deploy all without confirmation
+  %(prog)s teardown fo-v10-s1               Teardown one scenario
+  %(prog)s teardown-all                     Teardown all 9 scenarios
+  %(prog)s list                             List all scenario definitions
+  %(prog)s status fo-v10-s1                 Show stack status for one scenario
+  %(prog)s status                           Show stack status for all scenarios
+""",
+    )
+    sub = parser.add_subparsers(dest="command", help="Command to run")
+    sub.required = True
+
+    # deploy
+    p_deploy = sub.add_parser("deploy", help="Deploy a single scenario")
+    p_deploy.add_argument(
+        "env", choices=list(SCENARIOS.keys()), help="Scenario env name")
+    p_deploy.add_argument(
+        "--region", choices=BOTH_REGIONS,
+        help="Deploy to one region only (default: both)")
+    p_deploy.add_argument(
+        "--yes", "-y", action="store_true",
+        help="Skip confirmation prompts")
+
+    # deploy-all
+    p_deploy_all = sub.add_parser("deploy-all", help="Deploy all 9 scenarios")
+    p_deploy_all.add_argument(
+        "--yes", "-y", action="store_true",
+        help="Skip confirmation prompts")
+
+    # teardown
+    p_td = sub.add_parser("teardown", help="Teardown a single scenario")
+    p_td.add_argument(
+        "env", choices=list(SCENARIOS.keys()), help="Scenario env name")
+    p_td.add_argument(
+        "--yes", "-y", action="store_true",
+        help="Skip confirmation prompts")
+
+    # teardown-all
+    p_td_all = sub.add_parser("teardown-all", help="Teardown all 9 scenarios")
+    p_td_all.add_argument(
+        "--yes", "-y", action="store_true",
+        help="Skip confirmation prompts")
+
+    # list
+    sub.add_parser("list", help="List all scenario definitions")
+
+    # status
+    p_status = sub.add_parser("status", help="Show stack status for scenarios")
+    p_status.add_argument(
+        "env", nargs="?", choices=list(SCENARIOS.keys()),
+        help="Scenario env name (omit for all)")
+
+    return parser
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+
+    # Validate that CFN templates exist
+    for path, name in [
+        (APP_TEMPLATE, "app.yaml"),
+        (FAILOVER_TEMPLATE, "failover.yaml"),
+    ]:
+        if not os.path.isfile(path):
+            print(red("ERROR: CFN template not found: {}".format(path)))
+            sys.exit(1)
+
+    # Validate Lambda source files exist (only for deploy commands)
+    if args.command in ("deploy", "deploy-all"):
+        for path, name in [
+            (ORCHESTRATOR_SRC, "failover_orchestrator_v3.py"),
+            (FAILBACK_SRC, "manual_failback_v2.py"),
+            (STATE_BACKEND_SRC, "state_backend.py"),
+        ]:
+            if not os.path.isfile(path):
+                print(red("ERROR: Lambda source not found: {}".format(path)))
+                sys.exit(1)
+
+    dispatch = {
+        "deploy": cmd_deploy,
+        "deploy-all": cmd_deploy_all,
+        "teardown": cmd_teardown,
+        "teardown-all": cmd_teardown_all,
+        "list": cmd_list,
+        "status": cmd_status,
+    }
+
+    cmd_fn = dispatch.get(args.command)
+    if cmd_fn:
+        cmd_fn(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/deploy_scenarios.py
+++ b/tools/deploy_scenarios.py
@@ -209,15 +209,15 @@ def aurora_cluster_id(env, region):
 
 
 def orchestrator_lambda_name(env):
-    return "fo-{}-orchestrator".format(env)
+    return "{}-orchestrator".format(env)
 
 
 def failback_lambda_name(env):
-    return "fo-{}-failback".format(env)
+    return "{}-failback".format(env)
 
 
 def eventbridge_rule_name(env):
-    return "fo-{}-orchestrator-schedule".format(env)
+    return "{}-orchestrator-schedule".format(env)
 
 
 # ── Template Reading ──────────────────────────────────────────────────────────
@@ -628,10 +628,8 @@ def disable_eventbridge_rule(env, region):
 
 def scale_ecs_to_zero(env, region):
     """Scale ECS service to 0 tasks."""
-    # The ECS service name from CFN is fo-{env}-app-svc
-    svc_name = "fo-{}-app-svc".format(env)
-    # The cluster name from CFN is fo-{env}-cluster
-    cluster = "fo-{}-cluster".format(env)
+    svc_name = "{}-app-svc".format(env)
+    cluster = "fo-demo-cluster"  # Shared cluster from fo-demo-app stack
 
     try:
         client("ecs", region).update_service(
@@ -852,8 +850,8 @@ def deploy_scenario(env, regions=None):
         outputs = app_outputs.get(region, {})
         alb_dns = outputs.get("InternalAlbDns", "placeholder")
         alb_arn_suffix = extract_alb_arn_suffix(outputs)
-        ecs_cluster = outputs.get("EcsClusterName", "fo-{}-cluster".format(env))
-        ecs_service = outputs.get("EcsServiceName", "fo-{}-app-svc".format(env))
+        ecs_cluster = outputs.get("EcsClusterName", "{}-cluster".format(env))
+        ecs_service = outputs.get("EcsServiceName", "{}-app-svc".format(env))
 
         params = {
             "Env": env,
@@ -891,8 +889,8 @@ def deploy_scenario(env, regions=None):
     try:
         for region in regions:
             # The Lambda names come from the CFN template: fo-{Env}-orchestrator
-            orch_name = "fo-{}-orchestrator".format(env)
-            fb_name = "fo-{}-failback".format(env)
+            orch_name = orchestrator_lambda_name(env)
+            fb_name = failback_lambda_name(env)
 
             upload_lambda_code(orch_name, orchestrator_zip, region)
             upload_lambda_code(fb_name, failback_zip, region)
@@ -924,7 +922,7 @@ def deploy_scenario(env, regions=None):
     extra_env["CW_NAMESPACE"] = "Custom/{}".format(env)
 
     for region in regions:
-        orch_name = "fo-{}-orchestrator".format(env)
+        orch_name = orchestrator_lambda_name(env)
         set_lambda_env_vars(orch_name, extra_env, region)
     print()
 

--- a/tools/deploy_scenarios.py
+++ b/tools/deploy_scenarios.py
@@ -40,13 +40,14 @@ PRIMARY_REGION = "us-west-1"
 SECONDARY_REGION = "us-west-2"
 BOTH_REGIONS = [PRIMARY_REGION, SECONDARY_REGION]
 NETWORK_STACK = "fo-demo-network"
+SHARED_APP_STACK = "fo-demo-app"
 NOTIFICATION_EMAIL = "ranohep@gmail.com"
 
 # Paths relative to this script
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 PROJECT_ROOT = os.path.dirname(SCRIPT_DIR)
 CFN_DIR = os.path.join(PROJECT_ROOT, "cfn")
-APP_TEMPLATE = os.path.join(CFN_DIR, "app.yaml")
+APP_TEMPLATE = os.path.join(CFN_DIR, "scenario-app.yaml")
 FAILOVER_TEMPLATE = os.path.join(CFN_DIR, "failover.yaml")
 
 # Lambda source files
@@ -797,6 +798,7 @@ def deploy_scenario(env, regions=None):
         params = {
             "Env": env,
             "NetworkStack": NETWORK_STACK,
+            "SharedAppStack": SHARED_APP_STACK,
             "ContainerImage": container_image,
             "AuroraEndpoint": "placeholder",
             "AuroraPort": "5432",
@@ -804,6 +806,7 @@ def deploy_scenario(env, regions=None):
             "AuroraUser": "appuser",
             "AuroraPassword": "changeme",
             "RegionName": region,
+            "DesiredCount": "0",
         }
         deploy_stack(app_stack_name(env), app_template, params, region)
 


### PR DESCRIPTION
## Summary
- Deploy 9 independent demo environments (3 versions x 3 use cases) across us-west-1 and us-west-2
- New `cfn/scenario-app.yaml` template — per-scenario resources sharing VPC/ECS cluster from existing fo-demo-app
- `tools/deploy_scenarios.py` — CFN deployment script (deploy/teardown/list/status)
- `tools/demo_manager.py` — Runtime management CLI (activate/deactivate/trigger/reset/status)
- On-demand Aurora provisioning to control costs (default: all parked at $0)

## Scenario Matrix
| Env | Version | Use Case | Provider |
|-----|---------|----------|----------|
| fo-v10-s1 | v1.0 | Active/Passive | - |
| fo-v10-s2 | v1.0 | A/P Zero-Container | - |
| fo-v10-s3 | v1.0 | Active/Active | - |
| fo-v11c-s1 | v1.1 | Active/Passive | Claude |
| fo-v11c-s2 | v1.1 | A/P Zero-Container | Claude |
| fo-v11c-s3 | v1.1 | Active/Active | Claude |
| fo-v11g-s1 | v1.1 | Active/Passive | Gemini |
| fo-v11g-s2 | v1.1 | A/P Zero-Container | Gemini |
| fo-v11g-s3 | v1.1 | Active/Active | Gemini |

## Test plan
- [x] All 97 unit tests pass
- [x] All 9 scenarios deployed to AWS (36 CFN stacks across 2 regions)
- [x] Status command shows all 9 PARKED
- [ ] Activate/trigger/reset cycle for at least one scenario per version

Closes #21, closes #22, closes #23, closes #24, closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)