### PR TITLE
Enhance ECS and ALB collectors for better AI analysis

### DIFF
--- a/ai/collector.py
+++ b/ai/collector.py
@@ -57,7 +57,7 @@ def collect_incident_context(
 
 
 def _collect_ecs_events(region: str, cluster: str, service: str) -> dict:
-    """Collect recent ECS service events (deployments, task failures)."""
+    """Collect recent ECS service events (deployments, task failures, stopped reasons)."""
     try:
         ecs = boto3.client("ecs", region_name=region)
         resp = ecs.describe_services(cluster=cluster, services=[service])
@@ -65,7 +65,7 @@ def _collect_ecs_events(region: str, cluster: str, service: str) -> dict:
             return {"error": f"Service {service} not found in cluster {cluster}"}
 
         svc = resp["services"][0]
-        return {
+        result = {
             "status": svc.get("status"),
             "running_count": svc.get("runningCount"),
             "desired_count": svc.get("desiredCount"),
@@ -84,6 +84,31 @@ def _collect_ecs_events(region: str, cluster: str, service: str) -> dict:
                 for d in svc.get("deployments", [])
             ],
         }
+
+        # Collect recently stopped tasks with their stop reasons
+        try:
+            stopped = ecs.list_tasks(
+                cluster=cluster, serviceName=service,
+                desiredStatus="STOPPED", maxResults=10,
+            )
+            task_arns = stopped.get("taskArns", [])
+            if task_arns:
+                desc = ecs.describe_tasks(cluster=cluster, tasks=task_arns)
+                result["stopped_tasks"] = [
+                    {
+                        "stopped_at": t.get("stoppedAt", "").isoformat() if hasattr(t.get("stoppedAt", ""), "isoformat") else str(t.get("stoppedAt", "")),
+                        "stopped_reason": t.get("stoppedReason", ""),
+                        "stop_code": t.get("stopCode", ""),
+                        "last_status": t.get("lastStatus", ""),
+                    }
+                    for t in desc.get("tasks", [])
+                ]
+            else:
+                result["stopped_tasks"] = []
+        except (ClientError, Exception) as e:
+            result["stopped_tasks_error"] = str(e)
+
+        return result
     except (ClientError, Exception) as e:
         logger.warning(f"Failed to collect ECS events: {e}")
         return {"error": str(e)}

--- a/ai/stability_collector.py
+++ b/ai/stability_collector.py
@@ -324,7 +324,7 @@ def _collect_ecs_task_stability(
 def _collect_alb_error_trend(
     region: str, alb_arn_suffix: str, window_minutes: int
 ) -> dict:
-    """Collect ALB 5xx error rate trend from CloudWatch."""
+    """Collect ALB error rate and target health trends from CloudWatch."""
     try:
         errors_5xx = _collect_cloudwatch_metric_series(
             region=region,
@@ -346,9 +346,31 @@ def _collect_alb_error_trend(
             window_minutes=window_minutes,
         )
 
+        healthy_hosts = _collect_cloudwatch_metric_series(
+            region=region,
+            namespace="AWS/ApplicationELB",
+            metric_name="HealthyHostCount",
+            dimensions=[{"Name": "LoadBalancer", "Value": alb_arn_suffix}],
+            stat="Average",
+            period=60,
+            window_minutes=window_minutes,
+        )
+
+        unhealthy_hosts = _collect_cloudwatch_metric_series(
+            region=region,
+            namespace="AWS/ApplicationELB",
+            metric_name="UnHealthyHostCount",
+            dimensions=[{"Name": "LoadBalancer", "Value": alb_arn_suffix}],
+            stat="Average",
+            period=60,
+            window_minutes=window_minutes,
+        )
+
         return {
             "5xx_count": errors_5xx,
             "request_count": request_count,
+            "healthy_host_count": healthy_hosts,
+            "unhealthy_host_count": unhealthy_hosts,
         }
     except (ClientError, Exception) as e:
         logger.warning(f"Failed to collect ALB error trend: {e}")


### PR DESCRIPTION
## Summary
- ECS collector now captures stopped task reasons (stoppedReason, stopCode)
- Stability collector now includes HealthyHostCount/UnHealthyHostCount trends
- ALB_FULL_ARN set on all 20 scenario Lambdas

Gives the LLM visibility into target deregistration events and host health trends.

## Test plan
- [x] 180 tests passing
- [x] Lambda code re-uploaded for all 20 scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)