### PR TITLE
Fix dynamic config reload — re-read env vars every invocation

### DIFF
--- a/failover_orchestrator_v3.py
+++ b/failover_orchestrator_v3.py
@@ -1323,6 +1323,42 @@ def _handle_active_active(state: dict) -> dict:
 # Main Handler
 # ===========================================================================
 
+def _reload_dynamic_config():
+    """Re-read config values that the portal may change between invocations.
+
+    Called at the start of every handler() invocation. This allows the portal
+    to change env vars (STATE_BACKEND, ROUTING_MODE, etc.) and have them
+    take effect on the next 1-minute EventBridge cycle without requiring
+    a Lambda cold start.
+
+    Static values (regions, SNS topic, cluster names, health check URLs)
+    are read once at module import time and don't change.
+    """
+    global ROUTING_MODE, PASSIVE_PUBLISH_ZERO, FAILOVER_MODE
+    global _state_backend, _remote_state_backend, _REMOTE_STATE_BUCKET
+    global AURORA_AUTO_PROMOTE
+
+    ROUTING_MODE = os.environ.get("ROUTING_MODE", "failover").lower()
+    PASSIVE_PUBLISH_ZERO = os.environ.get("PASSIVE_PUBLISH_ZERO", "false").lower() == "true"
+    FAILOVER_MODE = os.environ.get("FAILOVER_MODE", "auto").lower()
+    AURORA_AUTO_PROMOTE = os.environ.get("AURORA_AUTO_PROMOTE", "false").lower() == "true"
+
+    # Reinitialize state backend (DynamoDB or S3)
+    _state_backend = create_backend(region=CURRENT_REGION, client_config=_client_config)
+
+    # Reinitialize remote state backend for S3 CRR
+    _REMOTE_STATE_BUCKET = os.environ.get("REMOTE_STATE_BUCKET", "")
+    _remote_state_backend = None
+    if _REMOTE_STATE_BUCKET and os.environ.get("STATE_BACKEND", "dynamodb").lower() == "s3":
+        from state_backend import S3StateBackend
+        _remote_region = SECONDARY_REGION if CURRENT_REGION == PRIMARY_REGION else PRIMARY_REGION
+        _remote_state_backend = S3StateBackend(
+            bucket=_REMOTE_STATE_BUCKET, region=_remote_region,
+            prefix=os.environ.get("STATE_PREFIX", "failover-state/"),
+            client_config=_client_config,
+        )
+
+
 def handler(event, context):
     """
     Main Lambda handler — runs every 1 minute via EventBridge in BOTH regions.
@@ -1335,6 +1371,9 @@ def handler(event, context):
       {"execute_failover": true}  — trigger failover when FAILOVER_MODE=manual
       {"reset_state": true}       — reset state to PRIMARY_ACTIVE
     """
+    # Re-read dynamic config (portal may have changed env vars)
+    _reload_dynamic_config()
+
     logger.info(
         f"Failover Orchestrator running in {CURRENT_REGION}, "
         f"mode={FAILOVER_MODE}, routing={ROUTING_MODE}"

--- a/manual_failback_v2.py
+++ b/manual_failback_v2.py
@@ -420,6 +420,21 @@ STEP 3: Then run this Lambda IN THE TARGET REGION with aurora_confirmed=true:
 """
 
 
+def _reload_dynamic_config():
+    """Re-read config that the portal may change between invocations."""
+    global _state_backend, _remote_state_backend, _REMOTE_STATE_BUCKET
+    _state_backend = create_backend(region=CURRENT_REGION, client_config=_client_config)
+    _REMOTE_STATE_BUCKET = os.environ.get("REMOTE_STATE_BUCKET", "")
+    _remote_state_backend = None
+    if _REMOTE_STATE_BUCKET and os.environ.get("STATE_BACKEND", "dynamodb").lower() == "s3":
+        _remote_region = SECONDARY_REGION if CURRENT_REGION == PRIMARY_REGION else PRIMARY_REGION
+        _remote_state_backend = S3StateBackend(
+            bucket=_REMOTE_STATE_BUCKET, region=_remote_region,
+            prefix=os.environ.get("STATE_PREFIX", "failover-state/"),
+            client_config=_client_config,
+        )
+
+
 def handler(event, context):
     """
     Manual failback handler.
@@ -432,6 +447,8 @@ def handler(event, context):
         "aurora_confirmed": true    <-- REQUIRED: operator confirms Aurora is switched
     }
     """
+    _reload_dynamic_config()
+
     target_region = event.get("target_region", PRIMARY_REGION)
     skip_health_check = event.get("skip_health_check", False)
     operator = event.get("operator", "unknown")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -671,14 +671,14 @@ class TestHandlerRouting:
     @patch.object(orch, "_handle_active_active", return_value={"statusCode": 200, "body": "aa"})
     @patch.object(orch, "get_failover_state", return_value=_make_state())
     def test_active_active_mode_routes_correctly(self, mock_state, mock_aa):
-        with patch.object(orch, "ROUTING_MODE", "active-active"):
+        with patch.dict(os.environ, {"ROUTING_MODE": "active-active"}):
             result = orch.handler({}, None)
         mock_aa.assert_called_once()
 
     @patch.object(orch, "_execute_manual_failover", return_value={"statusCode": 200, "body": "ok"})
     @patch.object(orch, "get_failover_state", return_value=_make_state())
     def test_execute_failover_event(self, mock_state, mock_exec):
-        with patch.object(orch, "ROUTING_MODE", "failover"):
+        with patch.dict(os.environ, {"ROUTING_MODE": "failover"}):
             result = orch.handler({"execute_failover": True}, None)
         mock_exec.assert_called_once()
 


### PR DESCRIPTION
## Summary
Root cause fix for all portal configuration issues. The orchestrator and failback Lambdas read config (STATE_BACKEND, ROUTING_MODE, AURORA_AUTO_PROMOTE, etc.) at module import time. Warm Lambda containers ignored env var changes from the portal.

Added `_reload_dynamic_config()` called at the start of every `handler()` invocation in both Lambdas. Re-reads all dynamic config and reinitializes the state backend.

## E2E Verified
- DynamoDB backend: Detection 120s, DB promotion 168s, Total 288s
- S3 backend: failover + auto-promote completed
- Auto-promote: works on both backends
- Version switching (v1.0/v1.1/v1.2): works via env vars

## Test plan
- [x] 180 unit tests passing
- [x] DynamoDB E2E: start → trigger → failover → auto-promote → SECONDARY_ACTIVE
- [x] S3 E2E: start → trigger → failover → auto-promote → SECONDARY_ACTIVE