### PR TITLE
v1.0.1 patch: Fix #47 cross-region CloudWatch timeout log noise

### DIFF
--- a/failover_orchestrator_v3.py
+++ b/failover_orchestrator_v3.py
@@ -953,13 +953,19 @@ def check_active_region_staleness(active_region: str, state: dict) -> dict:
         # Cannot reach active region's CloudWatch - region is likely down
         cw_stale = True
         cw_reason = f"Cannot reach CloudWatch in {active_region}: {str(e)}"
-        logger.error(cw_reason)
+        if heartbeat_stale:
+            logger.error(cw_reason)
+        else:
+            logger.debug(cw_reason)
     except Exception as e:
         # Catch connection timeouts, DNS failures, and any other network errors.
         # These are not ClientError - they're lower-level socket/connection issues.
         cw_stale = True
         cw_reason = f"Cross-region CW call failed ({type(e).__name__}): {str(e)}"
-        logger.error(cw_reason)
+        if heartbeat_stale:
+            logger.error(cw_reason)
+        else:
+            logger.debug(cw_reason)
 
     # -----------------------------------------------------------------------
     # Decision: stale if BOTH methods agree the active region is down.


### PR DESCRIPTION
## Summary

Patch release for prod users on the v1.0 git tag.

- Backport of the same fix in PR #51 (targeting `main`)
- Downgrade `logger.error` → `logger.debug` in both `except` blocks of `_check_active_region_staleness()` when `heartbeat_stale` is `False`
- `logger.error` is preserved when both Method 1 and Method 2 agree the region is stale (real incident signal)

## Context

Prod users who deployed from the `v1.0` tag see a `ConnectTimeoutError` ERROR every 60 seconds in VPCs with CloudWatch interface endpoints. This is cosmetic — the AND logic already prevents false failovers — but the log noise is confusing.

## Test plan

- [x] `python3 -m pytest tests/ -v` — 13 passed (v1.0 test suite)
- [ ] Deploy to secondary region Lambda and verify no ERROR logs when primary is healthy

## After merge

Tag this commit as `v1.0.1` so prod users can deploy the patched version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)