### PR TITLE
Fix #54: Treat Aurora maintenance statuses as healthy

### DIFF
--- a/failover_orchestrator_v3.py
+++ b/failover_orchestrator_v3.py
@@ -643,7 +643,13 @@ def check_aurora_cluster_status() -> dict:
                     "reason": "Cluster not found"}
 
         status = clusters[0].get("Status", "unknown")
-        healthy = status in {"available", "backing-up"}
+        # Include transient maintenance statuses where the cluster is still
+        # serving reads/writes (e.g., password reset, parameter changes).
+        healthy = status in {
+            "available", "backing-up", "modifying",
+            "resetting-master-credentials", "upgrading",
+            "maintenance", "renaming",
+        }
         return {
             "signal": "aurora_status",
             "healthy": healthy,

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -314,6 +314,56 @@ class TestCheckAuroraClusterStatus:
             result = orch.check_aurora_cluster_status()
             assert result["healthy"] is True
 
+    def test_healthy_when_modifying(self):
+        mock_rds = MagicMock()
+        mock_rds.describe_db_clusters.return_value = {
+            "DBClusters": [{"Status": "modifying"}]
+        }
+        with patch.object(orch, "AURORA_CLUSTER_ID", "my-cluster"), \
+             patch.object(orch, "rds", mock_rds):
+            result = orch.check_aurora_cluster_status()
+            assert result["healthy"] is True
+
+    def test_healthy_when_resetting_master_credentials(self):
+        mock_rds = MagicMock()
+        mock_rds.describe_db_clusters.return_value = {
+            "DBClusters": [{"Status": "resetting-master-credentials"}]
+        }
+        with patch.object(orch, "AURORA_CLUSTER_ID", "my-cluster"), \
+             patch.object(orch, "rds", mock_rds):
+            result = orch.check_aurora_cluster_status()
+            assert result["healthy"] is True
+
+    def test_healthy_when_upgrading(self):
+        mock_rds = MagicMock()
+        mock_rds.describe_db_clusters.return_value = {
+            "DBClusters": [{"Status": "upgrading"}]
+        }
+        with patch.object(orch, "AURORA_CLUSTER_ID", "my-cluster"), \
+             patch.object(orch, "rds", mock_rds):
+            result = orch.check_aurora_cluster_status()
+            assert result["healthy"] is True
+
+    def test_healthy_when_maintenance(self):
+        mock_rds = MagicMock()
+        mock_rds.describe_db_clusters.return_value = {
+            "DBClusters": [{"Status": "maintenance"}]
+        }
+        with patch.object(orch, "AURORA_CLUSTER_ID", "my-cluster"), \
+             patch.object(orch, "rds", mock_rds):
+            result = orch.check_aurora_cluster_status()
+            assert result["healthy"] is True
+
+    def test_healthy_when_renaming(self):
+        mock_rds = MagicMock()
+        mock_rds.describe_db_clusters.return_value = {
+            "DBClusters": [{"Status": "renaming"}]
+        }
+        with patch.object(orch, "AURORA_CLUSTER_ID", "my-cluster"), \
+             patch.object(orch, "rds", mock_rds):
+            result = orch.check_aurora_cluster_status()
+            assert result["healthy"] is True
+
     def test_unhealthy_when_failing_over(self):
         mock_rds = MagicMock()
         mock_rds.describe_db_clusters.return_value = {


### PR DESCRIPTION
## Summary

- Expands the Aurora health check's "healthy" status set to include transient maintenance statuses (`modifying`, `resetting-master-credentials`, `upgrading`, `maintenance`, `renaming`)
- Prevents false degradation warnings during routine Aurora operations (e.g., master password reset)
- Adds 5 new test cases covering each maintenance status

Closes #54

## Test plan

- [x] All 185 existing tests pass
- [x] New tests verify each maintenance status is treated as healthy
- [x] `failing-over` and other truly unhealthy statuses still correctly report unhealthy
- [ ] Deploy and verify no alert during next scheduled password rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)