### PR TITLE
Feature: FAILOVER_MODE=parked activation gate (v1.4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | v1.2 | `v1.2` | + Failback readiness (GO/NO-GO), Aurora promotion advisor (advisory/guided/autonomous) |
 | v1.2.1 | `v1.2.1` | + Dynamic config reload (`_reload_dynamic_config`), portal compatibility |
 | v1.3 | `v1.3` | + ElastiCache Global Datastore failover tracking, 6th health signal, combined Aurora+Redis promotion gate |
+| v1.4 | `v1.4` | + Staged deployment: `FAILOVER_MODE=parked` activation gate, pre-flight resource validation |
 
 ### Demo Environment (v2.0 Platform)
 
@@ -47,8 +48,8 @@ All changes to this codebase MUST follow these practices:
 - **Run the full test suite before every commit:** `python3 -m pytest tests/ -v`
 - **All tests must pass** before pushing or creating a PR
 - New features require new tests — no untested code reaches `main`
-- Regression test suite (180 tests) covers:
-  - `tests/test_orchestrator.py` — Core orchestrator logic (52 tests)
+- Regression test suite covers:
+  - `tests/test_orchestrator.py` — Core orchestrator logic (66 tests)
   - `tests/test_rca.py` — AI RCA module (32 tests)
   - `tests/test_state_backend.py` — State backend (13 tests)
 
@@ -63,6 +64,7 @@ Before merging any PR:
 ### Deployment
 - Package Lambda zips with all required modules
 - Deploy to BOTH regions (us-west-1 and us-west-2)
+- For staged deployments: set `FAILOVER_MODE=parked` → deploy infrastructure in any order → run pre-flight check → change to `FAILOVER_MODE=auto` to activate
 - Verify health after deployment (check orchestrator logs)
 
 ## Commands
@@ -77,6 +79,10 @@ python3 portal/app.py
 # Publish Lambda version and update alias (demo environment)
 python3 tools/publish_version.py --alias v1-2
 python3 tools/publish_version.py --alias active --copy-from v1-2
+
+# Pre-flight check: validate resources before activation (invoke from AWS console)
+# Lambda Test tab → {"preflight": true}
+# Returns: {"ready": true/false, "checks": {"state_backend": ..., "cloudwatch_metric": ..., "sns_topic": ...}}
 
 # Package and deploy orchestrator Lambda (production)
 zip failover_orchestrator_v3.zip failover_orchestrator_v3.py state_backend.py ai/__init__.py ai/config.py ai/llm_client.py ai/collector.py ai/rca_analyzer.py ai/stability_collector.py ai/aurora_advisor.py
@@ -242,7 +248,7 @@ All configuration is via Lambda environment variables. Key variables:
 | `ROUTING_MODE` | failover | `failover` (active/passive with latch) or `active-active` (both regions serve, auto-recovery) |
 | `SNS_TOPIC_ARN` | (required) | Operator notifications |
 | `HEALTH_CHECK_URL` | (empty) | Private ALB URL for HTTP health check |
-| `FAILOVER_MODE` | auto | `auto` or `manual` (notify-only, no DNS change) |
+| `FAILOVER_MODE` | auto | `auto`, `manual` (notify-only), or `parked` (inactive during staged deployment) |
 | `COOLDOWN_MINUTES` | 30 | Minimum time between failovers |
 | `CONSECUTIVE_FAILURES_THRESHOLD` | 3 | Sustained failures to trigger failover |
 | `AURORA_AUTO_PROMOTE` | false | Auto-promote Aurora or wait for operator |
@@ -285,6 +291,7 @@ All configuration is via Lambda environment variables. Key variables:
 - **Lambda versioning for demos**: One codebase deployed to all aliases (v1-0, v1-1, v1-2, active). Version behavior is controlled by env vars set by the portal. Production deployments use actual git tags (v1.0, v1.1, v1.2) with env vars set at deploy time.
 - **ElastiCache Global Datastore tracking** (v1.3): `redis_promotion_pending` state field tracks ElastiCache promotion independently from Aurora. When `ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID` is empty, the field is never set to `True` and existing behavior is unchanged. State transitions to `SECONDARY_ACTIVE` only when both `aurora_promotion_pending` and `redis_promotion_pending` are `False`. Apps poll the S3 state file to determine when all data tier promotions are complete.
 - **v1.0 is production-stable**: v1.0 code at the `v1.0` git tag must not be modified. If a bug is found, create v1.0.1 with a minimal fix. The demo portal uses v1.2.1 code for all versions — the v1.0 behavior is identical when AI features are disabled via env vars.
+- **Staged deployment with parked mode** (v1.4): `FAILOVER_MODE=parked` causes the handler to exit immediately before `_reload_dynamic_config()`, avoiding state backend init errors when infrastructure doesn't exist yet. Engineers deploy components in any order with the Lambda parked, then change the env var to `auto` to activate. Pre-flight validation available via `{"preflight": true}` Lambda test event.
 
 ## Prerequisites & Dependency Settings
 

--- a/failover_orchestrator_v3.py
+++ b/failover_orchestrator_v3.py
@@ -156,14 +156,17 @@ ACTIVE_REGION_STALE_THRESHOLD_MINUTES = int(
 # Failover Mode
 # "auto"   = full automated failover (default for production steady state)
 # "manual" = detect and notify only, wait for operator to trigger failover
+# "parked" = system inactive during staged deployment — handler exits
+#            immediately without accessing state backend, evaluating health,
+#            or publishing metrics. Activate by changing env var to "auto".
 #
 # In manual mode, the Lambda does everything the same (health evaluation,
 # consecutive failure counting, cooldown checking) but when it reaches the
 # point of triggering failover, it sends a CRITICAL notification instead
 # and includes the exact CLI command to execute the failover.
 #
-# Start with "manual" for initial deployment validation, switch to "auto"
-# once the team has confidence in the system.
+# Start with "parked" during initial deployment, switch to "manual" for
+# validation, then "auto" once the team has confidence in the system.
 # ---------------------------------------------------------------------------
 FAILOVER_MODE = os.environ.get("FAILOVER_MODE", "auto").lower()
 
@@ -1398,6 +1401,10 @@ def _reload_dynamic_config():
 
     Static values (regions, SNS topic, cluster names, health check URLs)
     are read once at module import time and don't change.
+
+    Note: FAILOVER_MODE "parked" is handled BEFORE this function runs
+    (in handler()) to avoid state backend init errors during staged deployment.
+    Valid FAILOVER_MODE values: "auto", "manual", "parked".
     """
     global ROUTING_MODE, PASSIVE_PUBLISH_ZERO, FAILOVER_MODE
     global _state_backend, _remote_state_backend, _REMOTE_STATE_BUCKET
@@ -1444,18 +1451,93 @@ def _reload_dynamic_config():
         )
 
 
+def _run_preflight_checks() -> dict:
+    """Validate required resources are accessible before activation.
+
+    Invoke from the AWS console Test tab with: {"preflight": true}
+    Returns a diagnostic report showing what's ready and what's missing.
+    No activation side effects — purely diagnostic (publishes one test metric).
+    """
+    checks = {}
+
+    # 1. State backend reachable
+    try:
+        _reload_dynamic_config()
+        _state_backend.get_state()
+        checks["state_backend"] = {"status": "PASS"}
+    except Exception as e:
+        checks["state_backend"] = {"status": "FAIL", "error": str(e)}
+
+    # 2. CloudWatch metric writable
+    try:
+        publish_region_health_metric(CURRENT_REGION, True)
+        checks["cloudwatch_metric"] = {"status": "PASS"}
+    except Exception as e:
+        checks["cloudwatch_metric"] = {"status": "FAIL", "error": str(e)}
+
+    # 3. SNS topic exists
+    try:
+        sns.get_topic_attributes(TopicArn=SNS_TOPIC_ARN)
+        checks["sns_topic"] = {"status": "PASS"}
+    except Exception as e:
+        checks["sns_topic"] = {"status": "FAIL", "error": str(e)}
+
+    # 4. Optional health signals — report configured vs skipped
+    for name, var, val in [
+        ("aurora", "AURORA_CLUSTER_ID", AURORA_CLUSTER_ID),
+        ("ecs", "ECS_CLUSTER_NAME", ECS_CLUSTER_NAME),
+        ("health_endpoint", "HEALTH_CHECK_URL", HEALTH_CHECK_URL),
+        ("elasticache", "ELASTICACHE_REPLICATION_GROUP_ID",
+         os.environ.get("ELASTICACHE_REPLICATION_GROUP_ID", "")),
+    ]:
+        checks[name] = (
+            {"status": "CONFIGURED"} if val
+            else {"status": "SKIPPED", "note": f"{var} not set"}
+        )
+
+    required = ["state_backend", "cloudwatch_metric", "sns_topic"]
+    all_pass = all(checks[k]["status"] == "PASS" for k in required)
+
+    return {
+        "statusCode": 200 if all_pass else 400,
+        "ready": all_pass,
+        "checks": checks,
+        "region": CURRENT_REGION,
+    }
+
+
 def handler(event, context):
     """
     Main Lambda handler — runs every 1 minute via EventBridge in BOTH regions.
+
+    Behavior depends on FAILOVER_MODE:
+      "parked"  → system inactive, exits immediately (staged deployment)
+      "auto"    → full automated failover
+      "manual"  → detect and notify only
 
     Behavior depends on ROUTING_MODE:
       "failover"      → active/passive roles, latch, manual failback
       "active-active"  → each region evaluates own health, auto-recovery
 
-    Manual invocations (failover mode only):
+    Manual invocations:
+      {"preflight": true}         — validate resources before activation
       {"execute_failover": true}  — trigger failover when FAILOVER_MODE=manual
       {"reset_state": true}       — reset state to PRIMARY_ACTIVE
     """
+    # ── Parked mode gate ──────────────────────────────────────────────
+    # FAILOVER_MODE=parked: system inactive during staged deployment.
+    # Checked BEFORE _reload_dynamic_config() to avoid state backend
+    # init errors when infrastructure doesn't exist yet.
+    if os.environ.get("FAILOVER_MODE", "auto").lower() == "parked":
+        logger.info("PARKED mode - system inactive, skipping all evaluation")
+        return {"statusCode": 200, "body": "Parked - activation pending"}
+
+    # ── Pre-flight check ──────────────────────────────────────────────
+    # Invoke with {"preflight": true} from the AWS console to validate
+    # resources before changing FAILOVER_MODE to "auto".
+    if event.get("preflight", False):
+        return _run_preflight_checks()
+
     # Re-read dynamic config (portal may have changed env vars)
     _reload_dynamic_config()
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -917,3 +917,120 @@ class TestFormatSubject:
             long_subject = "X" * 200
             result = orch._format_subject(long_subject)
             assert len(result) <= 100
+
+
+# ===========================================================================
+# 15. Parked mode — staged deployment gate
+# ===========================================================================
+
+class TestParkedMode:
+    """Tests for FAILOVER_MODE=parked early-exit behavior."""
+
+    def test_parked_mode_returns_immediately(self):
+        """Handler returns 200 with 'Parked' body, no further processing."""
+        with patch.dict(os.environ, {"FAILOVER_MODE": "parked"}):
+            result = orch.handler({}, None)
+        assert result["statusCode"] == 200
+        assert "Parked" in result["body"]
+
+    @patch.object(orch, "get_failover_state")
+    def test_parked_mode_no_state_access(self, mock_get_state):
+        """State backend is never accessed in parked mode."""
+        with patch.dict(os.environ, {"FAILOVER_MODE": "parked"}):
+            orch.handler({}, None)
+        mock_get_state.assert_not_called()
+
+    @patch.object(orch, "publish_region_health_metric")
+    def test_parked_mode_no_metric_published(self, mock_publish):
+        """No CloudWatch metrics are published in parked mode."""
+        with patch.dict(os.environ, {"FAILOVER_MODE": "parked"}):
+            orch.handler({}, None)
+        mock_publish.assert_not_called()
+
+    @patch.object(orch, "_reload_dynamic_config")
+    def test_parked_mode_no_reload_dynamic_config(self, mock_reload):
+        """_reload_dynamic_config() is not called — avoids state backend init."""
+        with patch.dict(os.environ, {"FAILOVER_MODE": "parked"}):
+            orch.handler({}, None)
+        mock_reload.assert_not_called()
+
+    def test_parked_mode_works_without_state_bucket(self):
+        """Parked mode succeeds even when STATE_BUCKET is missing (S3 mode).
+
+        This is the key scenario: Lambda deployed but S3 bucket not created yet.
+        Without parked mode, _reload_dynamic_config() → create_backend() would
+        raise ValueError for missing STATE_BUCKET.
+        """
+        env = {"FAILOVER_MODE": "parked", "STATE_BACKEND": "s3"}
+        with patch.dict(os.environ, env):
+            # Remove STATE_BUCKET if present
+            os.environ.pop("STATE_BUCKET", None)
+            result = orch.handler({}, None)
+        assert result["statusCode"] == 200
+        assert "Parked" in result["body"]
+
+
+# ===========================================================================
+# 16. Pre-flight checks — resource validation before activation
+# ===========================================================================
+
+class TestPreflightChecks:
+    """Tests for the {"preflight": true} resource validation handler."""
+
+    @patch.object(orch, "sns")
+    @patch.object(orch, "publish_region_health_metric")
+    @patch.object(orch, "_state_backend")
+    def test_preflight_all_pass(self, mock_backend, mock_publish, mock_sns):
+        """All required resources accessible → ready=True."""
+        mock_backend.get_state.return_value = _make_state()
+        mock_sns.get_topic_attributes.return_value = {}
+        with patch.dict(os.environ, {"FAILOVER_MODE": "auto"}):
+            result = orch.handler({"preflight": True}, None)
+        assert result["ready"] is True
+        assert result["statusCode"] == 200
+        assert result["checks"]["state_backend"]["status"] == "PASS"
+        assert result["checks"]["cloudwatch_metric"]["status"] == "PASS"
+        assert result["checks"]["sns_topic"]["status"] == "PASS"
+
+    @patch.object(orch, "sns")
+    @patch.object(orch, "publish_region_health_metric")
+    def test_preflight_state_backend_fail(self, mock_publish, mock_sns):
+        """State backend unreachable → ready=False with error detail."""
+        mock_sns.get_topic_attributes.return_value = {}
+        with patch.object(orch, "_reload_dynamic_config",
+                          side_effect=Exception("table not found")), \
+             patch.dict(os.environ, {"FAILOVER_MODE": "auto"}):
+            result = orch.handler({"preflight": True}, None)
+        assert result["ready"] is False
+        assert result["checks"]["state_backend"]["status"] == "FAIL"
+        assert "table not found" in result["checks"]["state_backend"]["error"]
+
+    @patch.object(orch, "sns")
+    @patch.object(orch, "publish_region_health_metric",
+                  side_effect=Exception("AccessDenied"))
+    @patch.object(orch, "_state_backend")
+    def test_preflight_cloudwatch_fail(self, mock_backend, mock_publish, mock_sns):
+        """CloudWatch permission denied → ready=False."""
+        mock_backend.get_state.return_value = _make_state()
+        mock_sns.get_topic_attributes.return_value = {}
+        with patch.dict(os.environ, {"FAILOVER_MODE": "auto"}):
+            result = orch.handler({"preflight": True}, None)
+        assert result["ready"] is False
+        assert result["checks"]["cloudwatch_metric"]["status"] == "FAIL"
+
+    @patch.object(orch, "sns")
+    @patch.object(orch, "publish_region_health_metric")
+    @patch.object(orch, "_state_backend")
+    def test_preflight_optional_signals_reported(self, mock_backend, mock_publish, mock_sns):
+        """Non-configured optional signals show SKIPPED, don't block readiness."""
+        mock_backend.get_state.return_value = _make_state()
+        mock_sns.get_topic_attributes.return_value = {}
+        with patch.dict(os.environ, {"FAILOVER_MODE": "auto",
+                                     "AURORA_CLUSTER_ID": "",
+                                     "ECS_CLUSTER_NAME": "",
+                                     "HEALTH_CHECK_URL": ""}):
+            result = orch.handler({"preflight": True}, None)
+        assert result["ready"] is True
+        assert result["checks"]["aurora"]["status"] == "SKIPPED"
+        assert result["checks"]["ecs"]["status"] == "SKIPPED"
+        assert result["checks"]["health_endpoint"]["status"] == "SKIPPED"


### PR DESCRIPTION
## Summary

- Add `FAILOVER_MODE=parked` — handler exits immediately before `_reload_dynamic_config()`, preventing crashes when infrastructure (DynamoDB table, S3 bucket, IAM) doesn't exist yet during staged deployments
- Add pre-flight resource validation via `{"preflight": true}` Lambda test event — checks state backend, CloudWatch, and SNS accessibility before activation
- 9 new tests (`TestParkedMode` + `TestPreflightChecks`)

## Engineer Workflow

```
1. Deploy Lambda with FAILOVER_MODE=parked       → fires every 60s but does nothing
2. Build infrastructure in any order              → no crashes, no false failovers
3. (Optional) Invoke {"preflight": true}          → validate resources
4. Change FAILOVER_MODE to "auto"                 → system starts clean (~10 min)
```

## Test plan

- [ ] `python3 -m pytest tests/ -v` — all 219 tests pass (9 new)
- [ ] Verify parked mode: set `FAILOVER_MODE=parked`, invoke handler → returns "Parked", no state/metric calls
- [ ] Verify preflight: invoke with `{"preflight": true}` → returns check results
- [ ] Verify backward compat: existing `FAILOVER_MODE=auto` behavior unchanged

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)