### PR TITLE
Add ElastiCache Global Datastore CFN template for fo-demo-s3 (v1.4 deployment)

### DIFF
--- a/cfn/elasticache.yaml
+++ b/cfn/elasticache.yaml
@@ -1,6 +1,14 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'FO Demo - ElastiCache Redis with Global Datastore (one stack per region)'
 
+# Deployment sequence:
+#   1. Deploy primary stack (us-west-1) with CreatePrimaryResources=true
+#      → creates subnet group + primary RG + Global Datastore (single PRIMARY member)
+#   2. Get full GlobalReplicationGroupId from us-west-1 stack Outputs (AWS prepends a prefix)
+#   3. Deploy secondary stack (us-west-2) with CreatePrimaryResources=false,
+#      GlobalReplicationGroupId=<full-id> → creates subnet group + secondary RG that joins
+#      the Global Datastore automatically
+
 Parameters:
   Env:
     Type: String
@@ -17,18 +25,15 @@ Parameters:
   GlobalReplicationGroupIdSuffix:
     Type: String
     Default: 'fo-demo-s3-redis-global'
-    Description: Suffix for the Global Datastore ID (AWS prepends a random prefix)
-  SecondaryReplicationGroupId:
+    Description: Suffix for Global Datastore ID (AWS prepends a random prefix). Used by primary only.
+  GlobalReplicationGroupId:
     Type: String
-    Default: 'fo-demo-s3-redis-w2'
-    Description: Replication group ID for the secondary region (auto-created by AWS in that region)
-  SecondaryRegion:
-    Type: String
-    Default: 'us-west-2'
-    Description: Secondary region for the Global Datastore
+    Default: ''
+    Description: Full Global Datastore ID (with AWS prefix). Required for secondary region stack.
   NodeType:
     Type: String
-    Default: 'cache.t3.micro'
+    Default: 'cache.m5.large'
+    Description: Node type — Global Datastore requires M5/M6g/R5/R6g families (T-series not supported)
   EngineVersion:
     Type: String
     Default: '7.1'
@@ -40,6 +45,7 @@ Parameters:
 
 Conditions:
   IsPrimary: !Equals [!Ref CreatePrimaryResources, 'true']
+  IsSecondary: !Not [!Equals [!Ref CreatePrimaryResources, 'true']]
 
 Resources:
 
@@ -61,7 +67,7 @@ Resources:
         - Key: Name
           Value: !Sub 'fo-${Env}-redis-sg'
 
-  # Subnet group — created in both regions (required before Global Datastore creates secondary RG)
+  # Subnet group — created in both regions
   RedisSubnetGroup:
     Type: AWS::ElastiCache::SubnetGroup
     Properties:
@@ -77,7 +83,8 @@ Resources:
           Value: !Sub 'fo-${Env}-redis-subnet-group'
 
   # Primary replication group — created only in primary region
-  RedisReplicationGroup:
+  # Note: cache.t3.micro single-node requires AutomaticFailoverEnabled=false
+  RedisReplicationGroupPrimary:
     Type: AWS::ElastiCache::ReplicationGroup
     Condition: IsPrimary
     DependsOn: RedisSubnetGroup
@@ -98,12 +105,12 @@ Resources:
         - Key: Name
           Value: !Sub 'fo-${Env}-redis-${AWS::Region}'
 
-  # Global Datastore — created only in primary region
-  # AWS auto-creates the secondary RG in SecondaryRegion using the subnet group deployed there
+  # Global Datastore — created only in primary region, with single PRIMARY member
+  # The secondary RG (created separately in us-west-2) joins via GlobalReplicationGroupId
   RedisGlobalReplicationGroup:
     Type: AWS::ElastiCache::GlobalReplicationGroup
     Condition: IsPrimary
-    DependsOn: RedisReplicationGroup
+    DependsOn: RedisReplicationGroupPrimary
     Properties:
       GlobalReplicationGroupIdSuffix: !Ref GlobalReplicationGroupIdSuffix
       GlobalReplicationGroupDescription: !Sub 'fo-${Env} Redis Global Datastore'
@@ -111,14 +118,29 @@ Resources:
         - ReplicationGroupId: !Ref LocalReplicationGroupId
           ReplicationGroupRegion: !Ref AWS::Region
           Role: PRIMARY
-        - ReplicationGroupId: !Ref SecondaryReplicationGroupId
-          ReplicationGroupRegion: !Ref SecondaryRegion
-          Role: SECONDARY
       AutomaticFailoverEnabled: false
+
+  # Secondary replication group — created only in secondary region
+  # Joins the existing Global Datastore by referencing its full ID
+  # Node type, engine version, encryption settings are inherited from the global group
+  RedisReplicationGroupSecondary:
+    Type: AWS::ElastiCache::ReplicationGroup
+    Condition: IsSecondary
+    DependsOn: RedisSubnetGroup
+    Properties:
+      ReplicationGroupId: !Ref LocalReplicationGroupId
+      ReplicationGroupDescription: !Sub 'fo-${Env} Redis secondary (${AWS::Region})'
+      GlobalReplicationGroupId: !Ref GlobalReplicationGroupId
+      CacheSubnetGroupName: !Ref RedisSubnetGroup
+      SecurityGroupIds:
+        - !Ref RedisSG
+      Tags:
+        - Key: Name
+          Value: !Sub 'fo-${Env}-redis-${AWS::Region}'
 
 Outputs:
   GlobalReplicationGroupId:
-    Value: !If [IsPrimary, !Ref RedisGlobalReplicationGroup, 'n/a']
+    Value: !If [IsPrimary, !Ref RedisGlobalReplicationGroup, !Ref GlobalReplicationGroupId]
     Export:
       Name: !Sub '${AWS::StackName}-GlobalReplicationGroupId'
   LocalReplicationGroupId:

--- a/cfn/elasticache.yaml
+++ b/cfn/elasticache.yaml
@@ -1,0 +1,135 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'FO Demo - ElastiCache Redis with Global Datastore (one stack per region)'
+
+Parameters:
+  Env:
+    Type: String
+    Default: demo-s3
+  AppStack:
+    Type: String
+    Description: Name of the app CloudFormation stack
+  NetworkStack:
+    Type: String
+    Description: Name of the network CloudFormation stack
+  LocalReplicationGroupId:
+    Type: String
+    Description: Unique identifier for this region's Redis replication group (e.g. fo-demo-s3-redis-w1)
+  GlobalReplicationGroupIdSuffix:
+    Type: String
+    Default: 'fo-demo-s3-redis-global'
+    Description: Suffix for the Global Datastore ID (AWS prepends a random prefix)
+  SecondaryReplicationGroupId:
+    Type: String
+    Default: 'fo-demo-s3-redis-w2'
+    Description: Replication group ID for the secondary region (auto-created by AWS in that region)
+  SecondaryRegion:
+    Type: String
+    Default: 'us-west-2'
+    Description: Secondary region for the Global Datastore
+  NodeType:
+    Type: String
+    Default: 'cache.t3.micro'
+  EngineVersion:
+    Type: String
+    Default: '7.1'
+  CreatePrimaryResources:
+    Type: String
+    Default: 'false'
+    AllowedValues: ['true', 'false']
+    Description: Set true only for primary (us-west-1) stack
+
+Conditions:
+  IsPrimary: !Equals [!Ref CreatePrimaryResources, 'true']
+
+Resources:
+
+  # Security group for Redis — open port 6379 from the orchestrator Lambda
+  RedisSG:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub 'fo-${Env} ElastiCache Redis cluster'
+      VpcId: !ImportValue
+        Fn::Sub: '${NetworkStack}-VpcId'
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 6379
+          ToPort: 6379
+          SourceSecurityGroupId: !ImportValue
+            Fn::Sub: '${AppStack}-LambdaSGId'
+          Description: 'From failover/failback Lambda'
+      Tags:
+        - Key: Name
+          Value: !Sub 'fo-${Env}-redis-sg'
+
+  # Subnet group — created in both regions (required before Global Datastore creates secondary RG)
+  RedisSubnetGroup:
+    Type: AWS::ElastiCache::SubnetGroup
+    Properties:
+      CacheSubnetGroupName: !Sub 'fo-${Env}-redis-subnet-group'
+      Description: !Sub 'fo-${Env} Redis subnet group'
+      SubnetIds:
+        - !ImportValue
+          Fn::Sub: '${NetworkStack}-PrivateSubnet1Id'
+        - !ImportValue
+          Fn::Sub: '${NetworkStack}-PrivateSubnet2Id'
+      Tags:
+        - Key: Name
+          Value: !Sub 'fo-${Env}-redis-subnet-group'
+
+  # Primary replication group — created only in primary region
+  RedisReplicationGroup:
+    Type: AWS::ElastiCache::ReplicationGroup
+    Condition: IsPrimary
+    DependsOn: RedisSubnetGroup
+    Properties:
+      ReplicationGroupId: !Ref LocalReplicationGroupId
+      ReplicationGroupDescription: !Sub 'fo-${Env} Redis primary (${AWS::Region})'
+      NumCacheClusters: 1
+      CacheNodeType: !Ref NodeType
+      Engine: redis
+      EngineVersion: !Ref EngineVersion
+      CacheSubnetGroupName: !Ref RedisSubnetGroup
+      SecurityGroupIds:
+        - !Ref RedisSG
+      AtRestEncryptionEnabled: true
+      TransitEncryptionEnabled: false
+      AutomaticFailoverEnabled: false
+      Tags:
+        - Key: Name
+          Value: !Sub 'fo-${Env}-redis-${AWS::Region}'
+
+  # Global Datastore — created only in primary region
+  # AWS auto-creates the secondary RG in SecondaryRegion using the subnet group deployed there
+  RedisGlobalReplicationGroup:
+    Type: AWS::ElastiCache::GlobalReplicationGroup
+    Condition: IsPrimary
+    DependsOn: RedisReplicationGroup
+    Properties:
+      GlobalReplicationGroupIdSuffix: !Ref GlobalReplicationGroupIdSuffix
+      GlobalReplicationGroupDescription: !Sub 'fo-${Env} Redis Global Datastore'
+      Members:
+        - ReplicationGroupId: !Ref LocalReplicationGroupId
+          ReplicationGroupRegion: !Ref AWS::Region
+          Role: PRIMARY
+        - ReplicationGroupId: !Ref SecondaryReplicationGroupId
+          ReplicationGroupRegion: !Ref SecondaryRegion
+          Role: SECONDARY
+      AutomaticFailoverEnabled: false
+
+Outputs:
+  GlobalReplicationGroupId:
+    Value: !If [IsPrimary, !Ref RedisGlobalReplicationGroup, 'n/a']
+    Export:
+      Name: !Sub '${AWS::StackName}-GlobalReplicationGroupId'
+  LocalReplicationGroupId:
+    Value: !Ref LocalReplicationGroupId
+    Export:
+      Name: !Sub '${AWS::StackName}-LocalReplicationGroupId'
+  RedisSGId:
+    Value: !Ref RedisSG
+    Export:
+      Name: !Sub '${AWS::StackName}-RedisSGId'
+  RedisSubnetGroupName:
+    Value: !Ref RedisSubnetGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-RedisSubnetGroupName'

--- a/cfn/failover.yaml
+++ b/cfn/failover.yaml
@@ -178,6 +178,20 @@ Resources:
                 Action:
                   - apigateway:GET
                 Resource: '*'
+              # S3 — state backend (when STATE_BACKEND=s3)
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:HeadObject
+                  - s3:DeleteObject
+                  - s3:ListBucket
+                Resource: '*'
+              # SNS — topic validation (preflight check)
+              - Effect: Allow
+                Action:
+                  - sns:GetTopicAttributes
+                Resource: '*'
       Tags:
         - Key: Name
           Value: !Sub '${Env}-lambda-role'

--- a/cfn/failover.yaml
+++ b/cfn/failover.yaml
@@ -60,7 +60,7 @@ Parameters:
   FailoverMode:
     Type: String
     Default: 'auto'
-    AllowedValues: ['auto', 'manual']
+    AllowedValues: ['auto', 'manual', 'parked']
   CooldownMinutes:
     Type: String
     Default: '5'

--- a/docs/deployment_and_configuration_guide.md
+++ b/docs/deployment_and_configuration_guide.md
@@ -217,7 +217,8 @@ Once you've verified the new system is publishing metrics and the Route 53 failo
 | `ECS_CLUSTER_NAME` | (optional) | ECS cluster name |
 | `ECS_SERVICE_NAME` | (optional) | ECS service name |
 | `API_GW_NAME` | (optional) | Private API Gateway ID |
-| `AURORA_CLUSTER_ID` | (required) | Aurora cluster ID in this region (same identifier in both regions) |
+| `AURORA_CLUSTER_ID` | (required) | Aurora cluster ID in this region |
+| `TARGET_AURORA_CLUSTER_ID` | (required) | Aurora cluster ID in the peer region |
 | `AURORA_GLOBAL_CLUSTER_ID` | (required) | Aurora Global Database cluster ID |
 | `AURORA_AUTO_PROMOTE` | `false` | Set to `true` to automatically call `SwitchoverGlobalCluster` (for app failures) or `FailoverGlobalCluster` (for region failures) during failover. If the API call fails, falls back to manual notification. |
 | `FAILOVER_MODE` | `auto` | `auto` = full automated failover. `manual` = detect and notify only, operator must run `execute_failover` command. |
@@ -252,9 +253,101 @@ The failback Lambda shares most config with the orchestrator. These are all requ
 
 **Stale threshold for passive region:** 3 minutes accounts for the 1-minute EventBridge interval plus potential CloudWatch metric publication delay plus one buffer cycle. Setting this lower risks false positive region-down detection.
 
+---
+
+## 3. ElastiCache Global Datastore
+
+This section covers deploying ElastiCache Redis with Global Datastore for cross-region replication. Skip this section if your application does not use ElastiCache.
+
+### When to Deploy
+
+ElastiCache is an optional 6th health signal. If `ELASTICACHE_REPLICATION_GROUP_ID` is set on the orchestrator Lambda, the replication group's availability status is evaluated every minute. When `ELASTICACHE_AUTO_PROMOTE=true`, the orchestrator automatically promotes the secondary replication group during failover.
+
+### Node Type Requirement
+
+ElastiCache Global Datastore **does not support T-series node types** (cache.t3.micro, cache.t4g.micro, etc.). Use M5, M6g, R5, or R6g families (e.g., `cache.m5.large`). Attempting to create a Global Datastore with a T-series node will fail with a validation error.
+
+### Deployment Sequence
+
+**Order matters.** The primary stack creates the Global Datastore. The secondary stack's replication group joins it — but the secondary's subnet group must already exist when AWS provisions the secondary's nodes.
+
+**Step 1: Deploy the primary region stack (creates subnet group + primary RG + Global Datastore):**
+
+```bash
+aws cloudformation deploy \
+  --stack-name <app>-elasticache \
+  --template-file cfn/elasticache.yaml \
+  --region us-west-1 \
+  --parameter-overrides \
+    Env=<env> \
+    NetworkStack=<network-stack-name> \
+    AppStack=<app-stack-name> \
+    LocalReplicationGroupId=<app>-redis-w1 \
+    GlobalReplicationGroupIdSuffix=<app>-redis-global \
+    NodeType=cache.m5.large \
+    EngineVersion=7.1 \
+    CreatePrimaryResources=true
+```
+
+This takes 10-20 minutes. AWS creates the primary replication group and a Global Datastore object.
+
+**Step 2: Capture the auto-prefixed Global RG ID from the CFN output:**
+
+```bash
+GLOBAL_RG_ID=$(aws cloudformation describe-stacks \
+  --stack-name <app>-elasticache --region us-west-1 \
+  --query "Stacks[0].Outputs[?OutputKey=='GlobalReplicationGroupId'].OutputValue" \
+  --output text)
+echo $GLOBAL_RG_ID
+# Example: ldgnf-<app>-redis-global  (AWS prepends a random 5-char prefix)
+```
+
+AWS always prepends a random prefix to the suffix you specify. Always capture from the CFN output — do not construct the ID manually.
+
+**Step 3: Deploy the secondary region stack (creates subnet group + secondary RG that joins the Global Datastore):**
+
+```bash
+aws cloudformation deploy \
+  --stack-name <app>-elasticache \
+  --template-file cfn/elasticache.yaml \
+  --region us-west-2 \
+  --parameter-overrides \
+    Env=<env> \
+    NetworkStack=<network-stack-name> \
+    AppStack=<app-stack-name> \
+    LocalReplicationGroupId=<app>-redis-w2 \
+    GlobalReplicationGroupId=$GLOBAL_RG_ID \
+    CreatePrimaryResources=false
+```
+
+**Step 4: Verify both members are available:**
+
+```bash
+aws elasticache describe-global-replication-groups \
+  --global-replication-group-id $GLOBAL_RG_ID \
+  --show-member-info --region us-west-1
+# Expect: us-west-1 = PRIMARY (available), us-west-2 = SECONDARY (available)
+```
+
+### Wiring ElastiCache to the Failover Stack
+
+The `cfn/failover.yaml` template has three ElastiCache parameters. Set them when deploying or updating the failover stack:
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `ElastiCacheReplicationGroupId` | `<app>-redis-w1` (us-west-1) / `<app>-redis-w2` (us-west-2) | Local replication group ID — differs per region |
+| `ElastiCacheGlobalReplicationGroupId` | `$GLOBAL_RG_ID` | Same in both regions |
+| `ElastiCacheAutoPromote` | `true` / `false` | Auto-promote on failover (requires `elasticache:FailoverGlobalReplicationGroup` IAM) |
+
+These parameters set the corresponding Lambda environment variables (`ELASTICACHE_REPLICATION_GROUP_ID`, `ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID`, `ELASTICACHE_AUTO_PROMOTE`) automatically.
+
+### Security Group
+
+The `cfn/elasticache.yaml` template creates a security group that allows inbound TCP 6379 from the Lambda security group (`${AppStack}-LambdaSGId`). The Lambda's VPC security group does not need a new outbound rule — TCP 443 to 0.0.0.0/0 (for AWS APIs) is already required, and port 6379 is allowed by the Redis SG's inbound rule.
+
 --- 
 
-## 3. Networking and VPC Requirements
+## 4. Networking and VPC Requirements
 
 ### Why the Lambda Must Be VPC-Attached
 

--- a/docs/failover_orchestrator_operational_guide.md
+++ b/docs/failover_orchestrator_operational_guide.md
@@ -124,13 +124,19 @@ Once failover executes, the Lambda sets `latch_engaged = true` in the DynamoDB G
 
 The latch can only be released by an operator explicitly invoking the Manual Failback Lambda. This ensures that failback is always a deliberate, validated action — never an automatic reaction to a recovering region.
 
+### Layer 4: Dual-Region Circuit Breaker (v1.0.1+)
+
+Before triggering an automated failover, the orchestrator checks the *target* region's health in the state backend. If the target region is ALSO unhealthy or its heartbeat is stale, the orchestrator aborts the failover and enters a "Dual-Region Outage" state.
+
+In this state, the Lambda stays in the current region and sends a CRITICAL alert. This prevents the "infinite loop" where regions fail back and forth during a global outage (e.g., a bad deployment or widespread dependency failure). Failover only resumes once the target region is confirmed healthy.
+
 ---
 
 ## Health Signal Evaluation
 
 ### Signal Priority
 
-The orchestrator evaluates five health signals. They are not all weighted equally.
+The orchestrator evaluates up to six health signals. They are not all weighted equally.
 
 **HTTP Health Check (`/actuator/health`) — PRIMARY SIGNAL.** This is the most important signal because it tests what actually matters: can a client reach the application and get a response? If this check fails, the region is marked unhealthy regardless of what the infrastructure metrics say. A failing HTTP check means the app is down from the consumer's perspective, period.
 
@@ -143,6 +149,8 @@ The HTTP check calls the configured endpoint on the private ALB. For Spring Boot
 **API Gateway 5xx Error Rate — MEDIUM PRIORITY.** Checks the `AWS/ApiGateway/5XXError` metric relative to total request count. If the 5xx rate exceeds the threshold (default: 50%), it indicates the API Gateway layer is unable to serve most requests. If there is no traffic in the evaluation window, this signal is assumed healthy (no traffic means no errors, and the HTTP check is a better indicator).
 
 **Aurora Cluster Status — HIGH PRIORITY.** Queries `DescribeDBClusters` to verify the local Aurora cluster has status `available`. Any other status (e.g., `failing-over`, `maintenance`, `stopped`) is unhealthy.
+
+**ElastiCache Replication Group Status — HIGH PRIORITY (optional).** Queries `DescribeReplicationGroups` to verify the local ElastiCache replication group has status `available`. This signal is only evaluated when `ELASTICACHE_REPLICATION_GROUP_ID` is set; when the env var is empty, the signal is skipped entirely and does not count toward the quorum. Any status other than `available` (e.g., `modifying`, `snapshotting`, `deleting`) causes the signal to fail.
 
 ### Decision Logic
 
@@ -308,6 +316,7 @@ The Global Table stores a single record with partition key `REGION_STATE`:
 | consecutive_failures | Number | How many consecutive unhealthy evaluations have occurred (resets to 0 on recovery or failover) |
 | last_active_metric_ts | String | ISO 8601 timestamp of the last time the active region Lambda published its metric (used by passive Lambda for staleness detection) |
 | aurora_promotion_pending | Boolean | If true, DNS has been moved but Aurora has not been promoted yet. The Lambda sends periodic reminders and automatically clears this flag when it detects the local Aurora cluster has become the writer via `DescribeDBClusters` (checking `ReplicationSourceIdentifier`). |
+| redis_promotion_pending | Boolean | If true, ElastiCache Global Datastore failover (promoting the secondary replication group to primary) is in progress. Only set to `True` when `ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID` is configured and `ELASTICACHE_AUTO_PROMOTE=true`. State transitions to `SECONDARY_ACTIVE` only when both `aurora_promotion_pending` and `redis_promotion_pending` are `False`. |
 | last_warning_notification_ts | String | ISO 8601 timestamp of the last WARNING-level notification sent. Used for notification throttling to prevent inbox flooding during flapping scenarios. |
 
 ---
@@ -555,7 +564,7 @@ Once you've verified the new system is publishing metrics and the Route 53 failo
 | `AURORA_AUTO_PROMOTE` | `false` | Set to `true` to automatically call `SwitchoverGlobalCluster` or `FailoverGlobalCluster` during failover. When `false`, operator receives CLI commands via SNS. See [Automated Aurora Promotion](#automated-aurora-promotion). |
 | `AURORA_PROMOTION_STRATEGY` | `SWITCHOVER_THEN_FAILOVER` | Sets the auto-promotion method. Use `FAILOVER_ONLY` if your IAM policy denies `rds:SwitchoverGlobalCluster`. |
 | `AURORA_MAX_REPLICATION_LAG_SECONDS` | `5` | If `AURORA_AUTO_PROMOTE` is true, this is the maximum replication lag in seconds allowed before an automated promotion is attempted. Prevents promotion if the secondary is too far behind. |
-| `FAILOVER_MODE` | `auto` | `auto` = full automated failover. `manual` = detect and notify only, operator must run `execute_failover` command. Start with `manual` during initial deployment validation. |
+| `FAILOVER_MODE` | `auto` | `auto` = full automated failover. `manual` = detect and notify only, operator must run `execute_failover` command. `parked` = Lambda exits immediately without evaluating health or reading state — use during staged deployments to keep the orchestrator dormant while deploying new code. Switch to `auto` once deployment is verified. |
 | `COOLDOWN_MINUTES` | `30` | Minimum minutes between automated failovers |
 | `CONSECUTIVE_FAILURES_THRESHOLD` | `3` | Consecutive unhealthy evaluations before failover |
 | `HEALTH_EVALUATION_WINDOW_MINUTES` | `5` | CloudWatch metric evaluation window |
@@ -655,7 +664,20 @@ Note: The failback Lambda works bidirectionally — it moves traffic TO whatever
 
 ### Performing a Manual Failback
 
-Failback is a two-step process: promote Aurora first, then move DNS.
+Failback is a three-step process when ElastiCache is configured: check ElastiCache readiness, promote Aurora, then move DNS.
+
+**Step 0 (if ElastiCache is configured): Verify ElastiCache Global Datastore before failback.**
+
+Confirm the current PRIMARY member is the secondary region and us-east-1 is SECONDARY — this is the state after failover:
+
+```bash
+aws elasticache describe-global-replication-groups \
+  --global-replication-group-id <GLOBAL_RG_ID> \
+  --show-member-info --region us-east-1
+# Expect: us-east-2 member = PRIMARY, us-east-1 member = SECONDARY, both available
+```
+
+The failback Lambda automatically calls `failover_global_replication_group` to promote us-east-1's replication group back to PRIMARY during failback. This is handled by the Lambda if `ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID` is set — no manual ElastiCache API call is needed.
 
 **Step 1: Switchover Aurora back to us-east-1:**
 
@@ -729,6 +751,24 @@ aws dynamodb update-item \
 ```
 
 **Warning:** This does NOT switchover Aurora. Only use this if Aurora has already been manually switched and you just need to reset the orchestrator's state.
+
+### Running a Preflight Check (v1.4+)
+
+Invoke the orchestrator with `{"preflight": true}` to validate connectivity to all configured services — state backend, CloudWatch, SNS, ElastiCache — without triggering any health evaluation or failover logic. Returns `ready: true/false` with per-check results.
+
+Run this after any infrastructure change (new Lambda code, CFN stack update, ElastiCache deployment) before switching `FAILOVER_MODE` from `parked` to `auto`:
+
+```bash
+aws lambda invoke \
+  --function-name <orchestrator-function-name> \
+  --payload '{"preflight": true}' \
+  --cli-binary-format raw-in-base64-out \
+  --region us-east-1 \
+  /dev/stdout
+# Expect: {"ready": true, "checks": {"state_backend": "PASS", "cloudwatch": "PASS", "sns": "PASS", "elasticache": "CONFIGURED"}}
+```
+
+If any check returns `FAIL`, resolve the issue before enabling auto mode.
 
 ### Verifying Health Signal Evaluation
 
@@ -1027,9 +1067,12 @@ sns:Publish
 ### Conditional Permissions
 
 ```
-kms:GenerateDataKey, kms:Decrypt          — Only if SNS topic is KMS-encrypted
-rds:FailoverGlobalCluster                 — Only if AURORA_AUTO_PROMOTE=true
-rds:SwitchoverGlobalCluster               — Only if AURORA_AUTO_PROMOTE=true and AURORA_PROMOTION_STRATEGY is SWITCHOVER_THEN_FAILOVER
+kms:GenerateDataKey, kms:Decrypt                      — Only if SNS topic is KMS-encrypted
+rds:FailoverGlobalCluster                             — Only if AURORA_AUTO_PROMOTE=true
+rds:SwitchoverGlobalCluster                           — Only if AURORA_AUTO_PROMOTE=true and AURORA_PROMOTION_STRATEGY is SWITCHOVER_THEN_FAILOVER
+elasticache:DescribeReplicationGroups                 — Only if ELASTICACHE_REPLICATION_GROUP_ID is set (health signal 6)
+elasticache:DescribeGlobalReplicationGroups           — Only if ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID is set (primary detection)
+elasticache:FailoverGlobalReplicationGroup            — Only if ELASTICACHE_AUTO_PROMOTE=true (auto-promote on failover)
 ```
 
 Note: When using guarded auto-promotion, the Lambda role will also need `cloudwatch:GetMetricStatistics` and `rds:DescribeDBClusters` permissions that can access resources in the secondary region to perform the pre-flight safety checks.


### PR DESCRIPTION
## Summary
- **cfn/elasticache.yaml** (new): ElastiCache Global Datastore CFN template — primary stack creates replication group + Global Datastore (single PRIMARY member); secondary stack joins via `GlobalReplicationGroupId` property
- **cfn/failover.yaml** (fixed): adds `parked` to `FailoverMode` AllowedValues; adds S3 state backend IAM (s3:GetObject/PutObject/HeadObject/DeleteObject/ListBucket) and `sns:GetTopicAttributes` for preflight check validation
- **docs/deployment_and_configuration_guide.md**: new Section 3 — ElastiCache Global Datastore (node type restriction, deployment sequence, CFN parameters, security group wiring)
- **docs/failover_orchestrator_operational_guide.md**: ElastiCache as 6th health signal, `redis_promotion_pending` state field, ElastiCache IAM permissions, failback runbook updated with ElastiCache prerequisite check, `parked` mode description, preflight check runbook step

## Issues Discovered and Fixed (fo-demo-s3 deployment exercise)
- **IAM drift**: manual `fo-elasticache-policy` + `fo-s3-backend-policy` inline policies superseded by CFN-managed policy in `fo-orchestrator-policy` (S3 and ElastiCache IAM now in template)
- **SNS cross-region**: CFN wires `SNS_TOPIC_ARN` to the stack's own `AlertTopic` per region — us-west-2 now gets its correct ARN
- **AuroraClusterId wrong in us-west-2**: CFN now sets `fo-demo-s3-aurora-w2` correctly via `AuroraClusterId` parameter
- **`TargetAuroraClusterId` was already in template**: confirmed present, wired via `TARGET_AURORA_CLUSTER_ID` env var
- **`parked` missing from FailoverMode**: added to AllowedValues
- **Node type for Global Datastore**: T-series rejected by AWS — default changed to `cache.m5.large` (M5/M6g/R5/R6g required)

## Deployment notes (fo-demo-s3 environment)
- Both `fo-demo-s3-failover` stacks updated in us-west-1 and us-west-2
- `demo-s3-orchestrator` and `demo-s3-failback` running v1.4 code in both regions
- Preflight check returns `ready: true` with all checks PASS in us-west-1
- ElastiCache Global Datastore (`virxk-fo-demo-s3-redis-global`) active with us-west-1 as PRIMARY

## Test plan
- [x] `python3 -m pytest tests/ -v` — 219 passed, 30 skipped
- [x] CFN stack updates complete in both regions
- [x] Preflight check returns `ready: true` in us-west-1
- [x] v1.4 code deployed to both orchestrator and failback Lambdas in both regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)