### PR TITLE
Fix cfn/failover.yaml: restore fo-${Env} resource naming prefix

### DIFF
--- a/cfn/failover.yaml
+++ b/cfn/failover.yaml
@@ -75,11 +75,11 @@ Resources:
   AlertTopic:
     Type: AWS::SNS::Topic
     Properties:
-      TopicName: !Sub '${Env}-alerts'
+      TopicName: !Sub 'fo-${Env}-alerts'
       DisplayName: !Sub 'FO Demo Alerts (${AWS::Region})'
       Tags:
         - Key: Name
-          Value: !Sub '${Env}-alerts'
+          Value: !Sub 'fo-${Env}-alerts'
 
   AlertSubscription:
     Type: AWS::SNS::Subscription
@@ -92,7 +92,7 @@ Resources:
   LambdaRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub '${Env}-lambda-role-${AWS::Region}'
+      RoleName: !Sub 'fo-${Env}-lambda-role-${AWS::Region}'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -194,13 +194,13 @@ Resources:
                 Resource: '*'
       Tags:
         - Key: Name
-          Value: !Sub '${Env}-lambda-role'
+          Value: !Sub 'fo-${Env}-lambda-role'
 
   # ── Failover Orchestrator Lambda ───────────────────────────────────────────
   OrchestratorLambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub '${Env}-orchestrator'
+      FunctionName: !Sub 'fo-${Env}-orchestrator'
       Runtime: python3.12
       Handler: failover_orchestrator_v3.handler
       Role: !GetAtt LambdaRole.Arn
@@ -247,16 +247,16 @@ Resources:
           CONSECUTIVE_FAILURES_THRESHOLD: !Ref ConsecutiveFailuresThreshold
           HEALTH_EVALUATION_WINDOW_MINUTES: '5'
           MIN_HEALTHY_HOST_COUNT: '1'
-          APP_NAME: !Sub '${Env}'
+          APP_NAME: !Sub 'fo-${Env}'
       Tags:
         - Key: Name
-          Value: !Sub '${Env}-orchestrator'
+          Value: !Sub 'fo-${Env}-orchestrator'
 
   # ── Failback Lambda ────────────────────────────────────────────────────────
   FailbackLambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub '${Env}-failback'
+      FunctionName: !Sub 'fo-${Env}-failback'
       Runtime: python3.12
       Handler: manual_failback_v2.handler
       Role: !GetAtt LambdaRole.Arn
@@ -292,16 +292,16 @@ Resources:
           ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID: !Ref ElastiCacheGlobalReplicationGroupId
           ECS_CLUSTER_NAME: !Ref EcsClusterName
           ECS_SERVICE_NAME: !Ref EcsServiceName
-          APP_NAME: !Sub '${Env}'
+          APP_NAME: !Sub 'fo-${Env}'
       Tags:
         - Key: Name
-          Value: !Sub '${Env}-failback'
+          Value: !Sub 'fo-${Env}-failback'
 
   # ── EventBridge Rule (1-minute schedule) ──────────────────────────────────
   OrchestratorSchedule:
     Type: AWS::Events::Rule
     Properties:
-      Name: !Sub '${Env}-orchestrator-schedule'
+      Name: !Sub 'fo-${Env}-orchestrator-schedule'
       Description: 'Trigger failover orchestrator every minute'
       ScheduleExpression: 'rate(1 minute)'
       State: ENABLED
@@ -322,7 +322,7 @@ Resources:
   RegionActiveAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Sub '${Env}-region-inactive-${AWS::Region}'
+      AlarmName: !Sub 'fo-${Env}-region-inactive-${AWS::Region}'
       AlarmDescription: !Sub 'Region ${AWS::Region} RegionActiveStatus is 0 or missing'
       Namespace: 'Custom/FoDemo'
       MetricName: 'RegionActiveStatus'
@@ -353,7 +353,7 @@ Resources:
         InsufficientDataHealthStatus: Unhealthy
       HealthCheckTags:
         - Key: Name
-          Value: !Sub '${Env}-hc-${AWS::Region}'
+          Value: !Sub 'fo-${Env}-hc-${AWS::Region}'
         - Key: Region
           Value: !Ref AWS::Region
 


### PR DESCRIPTION
## Summary
- Restores `fo-${Env}` prefix on all resource names in `cfn/failover.yaml` (Lambda functions, IAM role, SNS topic, EventBridge rule, CloudWatch alarm, APP_NAME env var)
- Without this fix, updating the `fo-demo-failover` stacks would rename `fo-demo-orchestrator` → `demo-orchestrator`, breaking EventBridge schedules and the portal

## Root cause
The `fo-` prefix was dropped from the template at some point (likely when the template was refactored). The fo-demo stacks were deployed from the old template and expect `fo-${Env}` naming.

## Test plan
- [x] `python3 -m pytest tests/ -v` — 219 passed, 30 skipped
- [ ] Update fo-demo-failover in us-west-1 and us-west-2 — confirm resource names unchanged, new IAM/AllowedValues applied

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)