### PR TITLE
fix: treat CW network timeouts as inconclusive in staleness check (v1.5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | v1.4 | `v1.4` | + Staged deployment: `FAILOVER_MODE=parked` activation gate, pre-flight resource validation |
 | v1.4.2 | `v1.4.2` | + CFN resource naming fix: restore `fo-${Env}` prefix in `cfn/failover.yaml` |
 | v1.4.3 | `v1.4.3` | + Comprehensive SNS notification validation: 50 tests across all config variants (S3/DDB, ElastiCache on/off, API GW on/off, active/passive + active/active) |
+| v1.5 | `v1.5` | + Three-state CW staleness logic: network-layer CW failures now inconclusive (cw_stale=None) instead of confirming; heartbeat alone requires 2× deep staleness to fire failover when CW unreachable. Fixes false-failover on borderline heartbeat + transient CW timeout. |
 
 ### Demo Environment (v2.0 Platform)
 
@@ -296,6 +297,7 @@ All configuration is via Lambda environment variables. Key variables:
 - **ElastiCache Global Datastore tracking** (v1.3): `redis_promotion_pending` state field tracks ElastiCache promotion independently from Aurora. When `ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID` is empty, the field is never set to `True` and existing behavior is unchanged. State transitions to `SECONDARY_ACTIVE` only when both `aurora_promotion_pending` and `redis_promotion_pending` are `False`. Apps poll the S3 state file to determine when all data tier promotions are complete.
 - **v1.0 is production-stable**: v1.0 code at the `v1.0` git tag must not be modified. If a bug is found, create v1.0.1 with a minimal fix. The demo portal uses v1.2.1 code for all versions — the v1.0 behavior is identical when AI features are disabled via env vars.
 - **Staged deployment with parked mode** (v1.4): `FAILOVER_MODE=parked` causes the handler to exit immediately before `_reload_dynamic_config()`, avoiding state backend init errors when infrastructure doesn't exist yet. Engineers deploy components in any order with the Lambda parked, then change the env var to `auto` to activate. Pre-flight validation available via `{"preflight": true}` Lambda test event.
+- **Three-state CW staleness logic** (v1.5): `check_active_region_staleness()` returns `cw_stale` as tri-state — `True` (confirming), `False` (fresh), or `None` (inconclusive). Network-layer failures (`EndpointConnectionError`, `HTTPClientError` — connect/read timeouts, DNS, socket errors) set `cw_stale=None` instead of `True`, because an unreachable CW endpoint tells us nothing about the active region's health. When inconclusive, failover only fires if the heartbeat is deeply stale (> 2× `ACTIVE_REGION_STALE_THRESHOLD_MINUTES`). `ClientError` and empty-datapoints paths remain confirming. Closes the false-failover mode where a borderline heartbeat + transient CW timeout collapsed into a region-down verdict.
 
 ## Prerequisites & Dependency Settings
 

--- a/failover_orchestrator_v3.py
+++ b/failover_orchestrator_v3.py
@@ -51,7 +51,11 @@ from urllib.error import URLError, HTTPError
 
 import boto3
 from botocore.config import Config as BotoConfig
-from botocore.exceptions import ClientError
+from botocore.exceptions import (
+    ClientError,
+    EndpointConnectionError,
+    HTTPClientError,
+)
 
 from state_backend import create_backend, ConditionalCheckFailedError
 
@@ -958,15 +962,24 @@ def check_active_region_staleness(active_region: str, state: dict) -> dict:
       the local replica (DynamoDB Global Table or S3 CRR) is independent.
       No cross-region API call needed.
 
-    Method 2 - Cross-region CloudWatch API (SECONDARY, fallback):
+    Method 2 - Cross-region CloudWatch API (SECONDARY, corroborating):
       Query the active region's CloudWatch for its RegionActiveStatus metric.
-      This requires a cross-region API call, which may itself fail if the active
-      region is down. A failed call is treated as stale (region unreachable).
+      This requires a cross-region API call, which may itself fail. Failures
+      are classified into two categories:
+        - Confirming failure (ClientError, empty datapoints): CW responded
+          but said the region is not publishing. Counts as "stale".
+        - Inconclusive failure (network timeout, endpoint unreachable): we
+          could not reach CW at all, so we have no information about the
+          active region. Counts as "inconclusive" (cw_stale=None), NOT as
+          confirming staleness.
 
-    The region is considered stale if BOTH methods detect staleness.
-    AND logic prevents false positives in VPCs where cross-region calls
-    are blocked by network configuration. Method 1 (state heartbeat) is the
-    primary signal; Method 2 (CloudWatch) confirms it.
+    Decision (three-state cw_stale):
+      - cw_stale=True  → both methods agree region is stale → failover
+      - cw_stale=False → CW says region is fresh → not stale (AND blocks)
+      - cw_stale=None  → CW inconclusive → fall back to heartbeat alone, but
+        require DEEP staleness (2× threshold) before firing without CW
+        corroboration. Prevents a transient network blip from upgrading a
+        borderline heartbeat into a false failover.
     """
     now = datetime.now(timezone.utc)
 
@@ -976,11 +989,12 @@ def check_active_region_staleness(active_region: str, state: dict) -> dict:
     heartbeat_stale = False
     heartbeat_reason = ""
     last_active_ts_str = state.get("last_active_metric_ts", "1970-01-01T00:00:00Z")
+    stale_threshold_seconds = ACTIVE_REGION_STALE_THRESHOLD_MINUTES * 60
+    age_seconds = 0.0
 
     try:
         last_active_ts = datetime.fromisoformat(last_active_ts_str.replace("Z", "+00:00"))
         age_seconds = (now - last_active_ts).total_seconds()
-        stale_threshold_seconds = ACTIVE_REGION_STALE_THRESHOLD_MINUTES * 60
 
         if age_seconds > stale_threshold_seconds:
             heartbeat_stale = True
@@ -994,17 +1008,18 @@ def check_active_region_staleness(active_region: str, state: dict) -> dict:
                 f"Heartbeat last_active_metric_ts is fresh ({age_seconds:.0f}s old)"
             )
     except (ValueError, TypeError) as e:
+        # Unparseable timestamp is treated as maximally stale.
         heartbeat_stale = True
+        age_seconds = float("inf")
         heartbeat_reason = f"Cannot parse last_active_metric_ts: {last_active_ts_str} ({e})"
         logger.error(heartbeat_reason)
 
     # -----------------------------------------------------------------------
-    # Method 2: Cross-region CloudWatch API call (may fail if region is down)
-    # Uses a short timeout (5s connect, 10s read) so the Lambda doesn't hang
-    # for minutes if the cross-region endpoint is unreachable. A timeout is
-    # treated as stale, which is correct - we can't reach the other region.
+    # Method 2: Cross-region CloudWatch API call.
+    # cw_stale tri-state: True = stale confirmed, False = fresh, None = inconclusive.
+    # Uses short timeouts (5s connect, 10s read) so the Lambda doesn't hang.
     # -----------------------------------------------------------------------
-    cw_stale = False
+    cw_stale = False  # optimistic default; set to True on confirm, None on inconclusive
     cw_reason = ""
 
     try:
@@ -1031,6 +1046,7 @@ def check_active_region_staleness(active_region: str, state: dict) -> dict:
             cw_age = (now - latest["Timestamp"]).total_seconds()
             cw_reason = f"CloudWatch metric is fresh ({cw_age:.0f}s old)"
         else:
+            # CW responded but has no recent datapoints — confirming staleness.
             cw_stale = True
             cw_reason = (
                 f"No CloudWatch metric data from {active_region} in the last "
@@ -1038,16 +1054,28 @@ def check_active_region_staleness(active_region: str, state: dict) -> dict:
             )
 
     except ClientError as e:
-        # Cannot reach active region's CloudWatch - region is likely down
+        # CW API responded but rejected us (throttled, auth, 4xx/5xx). The API
+        # is reachable — this is a CONFIRMING signal that something is wrong.
         cw_stale = True
         cw_reason = f"Cannot reach CloudWatch in {active_region}: {str(e)}"
         if heartbeat_stale:
             logger.error(cw_reason)
         else:
             logger.debug(cw_reason)
+    except (EndpointConnectionError, HTTPClientError) as e:
+        # Network-layer failure (connect timeout, read timeout, DNS, socket).
+        # We could not reach CW at all — we have NO information about the active
+        # region. INCONCLUSIVE, not confirming. Prevents a transient network
+        # blip from collapsing into a false failover (see 2026-04-24 incident).
+        cw_stale = None
+        cw_reason = f"Cross-region CW call inconclusive ({type(e).__name__}): {str(e)}"
+        if heartbeat_stale:
+            logger.warning(cw_reason)
+        else:
+            logger.debug(cw_reason)
     except Exception as e:
-        # Catch connection timeouts, DNS failures, and any other network errors.
-        # These are not ClientError - they're lower-level socket/connection issues.
+        # Unknown failure class. Err on the side of confirming staleness
+        # (preserves pre-v1.5 behavior for any exception we didn't anticipate).
         cw_stale = True
         cw_reason = f"Cross-region CW call failed ({type(e).__name__}): {str(e)}"
         if heartbeat_stale:
@@ -1056,31 +1084,34 @@ def check_active_region_staleness(active_region: str, state: dict) -> dict:
             logger.debug(cw_reason)
 
     # -----------------------------------------------------------------------
-    # Decision: stale if BOTH methods agree the active region is down.
+    # Decision (three-state):
     #
-    # AND logic prevents false positives in VPCs where cross-region
-    # CloudWatch calls are blocked by network configuration (interface
-    # endpoints, firewalls, etc). In those environments, Method 2 always
-    # returns stale - without AND, every check would trigger failover.
+    #   cw_stale=True  → confirming signal. AND with heartbeat_stale.
+    #   cw_stale=False → CW says region is fresh. AND with heartbeat_stale
+    #                    (i.e. heartbeat alone cannot fire failover).
+    #   cw_stale=None  → inconclusive. Fall back to heartbeat alone, but
+    #                    require DEEP staleness (2× threshold) before firing
+    #                    without CW corroboration. This protects against a
+    #                    borderline heartbeat + simultaneous network blip.
     #
-    # Method 1 (state heartbeat) is the primary, most reliable signal.
-    # Method 2 (cross-region CloudWatch) is a confirming signal.
-    #
-    # When the active region truly goes down:
-    #   - Method 1: DDB timestamp ages past threshold → stale
-    #   - Method 2: cross-region call fails or returns no data → stale
-    #   - AND: True AND True → stale detected ✓
-    #
-    # When the active region is healthy but cross-region call is blocked:
-    #   - Method 1: heartbeat timestamp is fresh → not stale
-    #   - Method 2: cross-region call times out → stale
-    #   - AND: False AND True → NOT stale ✓ (false positive prevented)
+    # Rationale: the original AND logic assumed Method 2 always produced a
+    # yes/no answer, so any exception was treated as "yes, stale". That
+    # collapsed network-unreachability into confirmation, which is wrong —
+    # if we can't reach CW, we don't know anything. The inconclusive path
+    # preserves failover capability (via deep-staleness fallback) while
+    # removing the false-positive mode.
     # -----------------------------------------------------------------------
-    is_stale = heartbeat_stale and cw_stale
+    cw_inconclusive = cw_stale is None
+    if cw_inconclusive:
+        deep_stale_seconds = stale_threshold_seconds * 2
+        is_stale = heartbeat_stale and age_seconds > deep_stale_seconds
+    else:
+        is_stale = heartbeat_stale and cw_stale
 
     combined_reason = f"Heartbeat: {heartbeat_reason} | CW: {cw_reason}"
     logger.info(
-        f"Staleness result: stale={is_stale} (heartbeat={heartbeat_stale}, cw={cw_stale})"
+        f"Staleness result: stale={is_stale} (heartbeat={heartbeat_stale}, "
+        f"cw={cw_stale}, inconclusive={cw_inconclusive})"
     )
 
     if is_stale:
@@ -1092,6 +1123,7 @@ def check_active_region_staleness(active_region: str, state: dict) -> dict:
         "stale": is_stale,
         "heartbeat_stale": heartbeat_stale,
         "cw_stale": cw_stale,
+        "cw_inconclusive": cw_inconclusive,
         "reason": combined_reason,
         "heartbeat_reason": heartbeat_reason,
         "cw_reason": cw_reason,

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -897,6 +897,177 @@ class TestPassiveStalenessFailover:
 
 
 # ===========================================================================
+# 13b. Staleness check three-state logic (v1.5)
+#
+# Directly exercises check_active_region_staleness() rather than mocking it
+# wholesale. Verifies that:
+#   - A CW network timeout is INCONCLUSIVE (cw_stale=None), not confirming.
+#   - A borderline-stale heartbeat + CW timeout does NOT trigger failover
+#     (the 2026-04-24 prod incident regression).
+#   - A deeply-stale heartbeat (>2× threshold) fires failover even when CW is
+#     unreachable (preserves failover capability under simultaneous outages).
+#   - ClientError and empty-datapoints paths still CONFIRM staleness (unchanged).
+# ===========================================================================
+
+class TestStalenessCheckLogic:
+    """Direct tests of check_active_region_staleness() tri-state cw_stale logic."""
+
+    THRESHOLD_MIN = 3  # matches default ACTIVE_REGION_STALE_THRESHOLD_MINUTES
+
+    def _state_with_heartbeat_age(self, age_seconds: float) -> dict:
+        """Build a state dict whose last_active_metric_ts is `age_seconds` in the past."""
+        ts = datetime.now(timezone.utc) - timedelta(seconds=age_seconds)
+        return _make_state(last_active_metric_ts=ts.isoformat())
+
+    def _cw_client_with_fresh_datapoints(self):
+        mock_cw = MagicMock()
+        mock_cw.get_metric_statistics.return_value = {
+            "Datapoints": [{"Timestamp": datetime.now(timezone.utc), "Minimum": 1.0}]
+        }
+        return mock_cw
+
+    def _cw_client_raising(self, exc):
+        mock_cw = MagicMock()
+        mock_cw.get_metric_statistics.side_effect = exc
+        return mock_cw
+
+    def _cw_client_with_empty_datapoints(self):
+        mock_cw = MagicMock()
+        mock_cw.get_metric_statistics.return_value = {"Datapoints": []}
+        return mock_cw
+
+    # ---- Case 1: fresh heartbeat + CW fresh → not stale (baseline) -------
+
+    def test_fresh_heartbeat_and_cw_fresh_is_not_stale(self):
+        state = self._state_with_heartbeat_age(30)  # well under 180s threshold
+        with patch.object(orch, "ACTIVE_REGION_STALE_THRESHOLD_MINUTES", self.THRESHOLD_MIN), \
+             patch.object(orch.boto3, "client", return_value=self._cw_client_with_fresh_datapoints()):
+            result = orch.check_active_region_staleness("us-east-1", state)
+
+        assert result["stale"] is False
+        assert result["heartbeat_stale"] is False
+        assert result["cw_stale"] is False
+        assert result["cw_inconclusive"] is False
+
+    # ---- Case 2: fresh heartbeat + CW timeout → not stale, inconclusive --
+
+    def test_fresh_heartbeat_and_cw_timeout_is_not_stale(self):
+        """VPC-blocked CW + healthy heartbeat: inconclusive, but not stale."""
+        from botocore.exceptions import EndpointConnectionError as EndpointErr
+        state = self._state_with_heartbeat_age(30)
+        with patch.object(orch, "ACTIVE_REGION_STALE_THRESHOLD_MINUTES", self.THRESHOLD_MIN), \
+             patch.object(
+                orch.boto3, "client",
+                return_value=self._cw_client_raising(
+                    EndpointErr(endpoint_url="https://monitoring-us-east-1.amazonaws.com/")
+                ),
+             ):
+            result = orch.check_active_region_staleness("us-east-1", state)
+
+        assert result["stale"] is False
+        assert result["heartbeat_stale"] is False
+        assert result["cw_stale"] is None
+        assert result["cw_inconclusive"] is True
+
+    # ---- Case 3: borderline heartbeat + CW timeout → not stale -----------
+    # REGRESSION TEST for the 2026-04-24 prod incident.
+
+    def test_borderline_heartbeat_and_cw_timeout_is_not_stale(self):
+        """
+        Heartbeat just barely over threshold (205s old, 180s threshold) +
+        simultaneous CW network timeout. Under pre-v1.5 code this collapsed
+        into a false failover. Under v1.5 this must NOT fire.
+        """
+        from botocore.exceptions import HTTPClientError
+        state = self._state_with_heartbeat_age(205)  # 25s over 180s threshold
+        with patch.object(orch, "ACTIVE_REGION_STALE_THRESHOLD_MINUTES", self.THRESHOLD_MIN), \
+             patch.object(
+                orch.boto3, "client",
+                return_value=self._cw_client_raising(
+                    HTTPClientError(error="Connect timeout on endpoint URL")
+                ),
+             ):
+            result = orch.check_active_region_staleness("us-east-1", state)
+
+        assert result["heartbeat_stale"] is True, "heartbeat should be flagged stale"
+        assert result["cw_stale"] is None, "CW timeout must be inconclusive, not confirming"
+        assert result["cw_inconclusive"] is True
+        assert result["stale"] is False, (
+            "borderline heartbeat + CW timeout must NOT trigger failover "
+            "(regression for 2026-04-24 incident)"
+        )
+
+    # ---- Case 4: deeply stale heartbeat + CW timeout → stale -------------
+
+    def test_deeply_stale_heartbeat_and_cw_timeout_is_stale(self):
+        """
+        Heartbeat >2× threshold (e.g. 400s > 360s = 2×180s) + CW timeout.
+        Preserves failover capability when CW is unreachable but the
+        heartbeat is emphatically stale.
+        """
+        from botocore.exceptions import HTTPClientError
+        state = self._state_with_heartbeat_age(400)  # 2× threshold is 360s
+        with patch.object(orch, "ACTIVE_REGION_STALE_THRESHOLD_MINUTES", self.THRESHOLD_MIN), \
+             patch.object(
+                orch.boto3, "client",
+                return_value=self._cw_client_raising(
+                    HTTPClientError(error="Connect timeout on endpoint URL")
+                ),
+             ):
+            result = orch.check_active_region_staleness("us-east-1", state)
+
+        assert result["heartbeat_stale"] is True
+        assert result["cw_stale"] is None
+        assert result["cw_inconclusive"] is True
+        assert result["stale"] is True, (
+            "deep heartbeat staleness should fire failover even when CW is inconclusive"
+        )
+
+    # ---- Case 5: stale heartbeat + CW ClientError → stale (unchanged) ----
+
+    def test_stale_heartbeat_and_cw_client_error_is_stale(self):
+        """ClientError (CW API responded with error) is CONFIRMING, unchanged from v1.0."""
+        from botocore.exceptions import ClientError
+        err = ClientError({"Error": {"Code": "Throttling", "Message": "Rate exceeded"}}, "GetMetricStatistics")
+        state = self._state_with_heartbeat_age(300)
+        with patch.object(orch, "ACTIVE_REGION_STALE_THRESHOLD_MINUTES", self.THRESHOLD_MIN), \
+             patch.object(orch.boto3, "client", return_value=self._cw_client_raising(err)):
+            result = orch.check_active_region_staleness("us-east-1", state)
+
+        assert result["heartbeat_stale"] is True
+        assert result["cw_stale"] is True
+        assert result["cw_inconclusive"] is False
+        assert result["stale"] is True
+
+    # ---- Case 6: stale heartbeat + CW empty datapoints → stale (unchanged)
+
+    def test_stale_heartbeat_and_cw_empty_datapoints_is_stale(self):
+        state = self._state_with_heartbeat_age(300)
+        with patch.object(orch, "ACTIVE_REGION_STALE_THRESHOLD_MINUTES", self.THRESHOLD_MIN), \
+             patch.object(orch.boto3, "client", return_value=self._cw_client_with_empty_datapoints()):
+            result = orch.check_active_region_staleness("us-east-1", state)
+
+        assert result["heartbeat_stale"] is True
+        assert result["cw_stale"] is True
+        assert result["cw_inconclusive"] is False
+        assert result["stale"] is True
+
+    # ---- Case 7: fresh heartbeat + CW ClientError → not stale (AND holds)
+
+    def test_fresh_heartbeat_and_cw_client_error_is_not_stale(self):
+        from botocore.exceptions import ClientError
+        err = ClientError({"Error": {"Code": "AccessDenied", "Message": "nope"}}, "GetMetricStatistics")
+        state = self._state_with_heartbeat_age(30)
+        with patch.object(orch, "ACTIVE_REGION_STALE_THRESHOLD_MINUTES", self.THRESHOLD_MIN), \
+             patch.object(orch.boto3, "client", return_value=self._cw_client_raising(err)):
+            result = orch.check_active_region_staleness("us-east-1", state)
+
+        assert result["heartbeat_stale"] is False
+        assert result["cw_stale"] is True
+        assert result["stale"] is False
+
+
+# ===========================================================================
 # 14. APP_NAME in notification subjects
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

- Fixes the false-failover mode triggered on 2026-04-24 in production: a borderline-stale heartbeat + a simultaneous transient CW network timeout collapsed into a region-down verdict.
- Introduces three-state `cw_stale` (True/False/None) in `check_active_region_staleness()` so network-layer failures are treated as **inconclusive** rather than as confirmation of staleness.
- When CW is inconclusive, failover only fires if the heartbeat is deeply stale (> 2× `ACTIVE_REGION_STALE_THRESHOLD_MINUTES`). Preserves failover capability under simultaneous outages; removes the false-positive.
- Adds `TestStalenessCheckLogic` class (7 direct tests) including an explicit regression test for the 2026-04-24 scenario.
- Documented in CLAUDE.md: new v1.5 row in Version History + new entry in Key Design Decisions.

Closes #68

## Change Detail

`failover_orchestrator_v3.py` — `check_active_region_staleness()`:

| Exception / result | Before | After |
|---|---|---|
| Empty datapoints | `cw_stale=True` | `cw_stale=True` — unchanged |
| `ClientError` | `cw_stale=True` | `cw_stale=True` — unchanged |
| `EndpointConnectionError`, `HTTPClientError` (connect/read timeouts, DNS, socket) | `cw_stale=True` ❌ | `cw_stale=None` (inconclusive) ✅ |
| Unknown `Exception` | `cw_stale=True` | `cw_stale=True` — preserved as safety net |

Decision logic (simplified):

```python
if cw_stale is None:
    deep_stale_seconds = stale_threshold_seconds * 2
    is_stale = heartbeat_stale and age_seconds > deep_stale_seconds
else:
    is_stale = heartbeat_stale and cw_stale
```

Return dict gains a `cw_inconclusive: bool` field so downstream SNS / log formatting can distinguish the three outcomes.

## Test Plan

- [x] `python3 -m pytest tests/test_orchestrator.py -v -k "Staleness"` — 8 passed (7 new + 1 existing)
- [x] `python3 -m pytest tests/ -v` — 276 passed, 30 skipped (integration tests requiring AWS creds — expected)
- [x] New regression test `test_borderline_heartbeat_and_cw_timeout_is_not_stale` replays the 2026-04-24 conditions and asserts NO failover
- [x] Existing `TestPassiveStalenessFailover` passes unchanged (no behavior regression for the "truly stale" path)
- [ ] Post-merge & post-tag: demo-environment smoke test on the `v1-5` alias — run a scenario from the 20-scenario matrix, inspect CloudWatch Logs for the new `inconclusive=` field in staleness-check log lines
- [ ] Prod deploy v1.0 → v1.5 with `FAILOVER_MODE=manual` first; one-week soak watching for SNS notifications that would previously have triggered failover but now log `cw_inconclusive=True` and hold; flip to `auto` after soak

## Deployment Notes

- Fix lands on `main` only, tagged `v1.5`. No v1.0.x backport — prod will upgrade v1.0 → v1.5 in a single jump.
- Prod keeps AI features env-var-disabled: `AI_RCA_ENABLED=false`, `AI_FAILBACK_READINESS_ENABLED=false`, `AI_AURORA_ADVISOR_MODE=disabled`.
- Keep the operational mitigation in place during cutover: `FAILOVER_MODE=manual`, `ACTIVE_REGION_STALE_THRESHOLD_MINUTES=20`. After soak, flip `FAILOVER_MODE=auto`; leave `ACTIVE_REGION_STALE_THRESHOLD_MINUTES=20` as a permanent backstop.
- `portal/config.py` v1-5 alias registration intentionally NOT included here — user has in-progress portal work in that file. The one-line addition (`VERSION_TO_ALIAS["v1.5"] = "v1-5"`) should be included in the next portal commit.

## Out of Scope

- S3 → DynamoDB state backend migration (tracked separately).
- CloudWatch alarm on S3 RTC `ReplicationLatency` for early warning before the staleness threshold trips — follow-up enhancement.