### PR TITLE
v1.6 PR1: foundation — ENVIRONMENT env var + detect_data_tier_config()

### DIFF
--- a/failover_orchestrator_v3.py
+++ b/failover_orchestrator_v3.py
@@ -73,6 +73,12 @@ CURRENT_REGION = os.environ.get("AWS_REGION", "us-east-1")
 # is alerting when this solution is deployed across multiple applications.
 APP_NAME = os.environ.get("APP_NAME", "")
 
+# Deployment environment (e.g., "prod", "staging", "demo"). When set together
+# with APP_NAME, notification subjects are prefixed [ENVIRONMENT-APP_NAME] so
+# operators can immediately tell which environment is alerting. Empty falls
+# back to [APP_NAME] only (backwards-compat with v1.0–v1.5 deployments).
+ENVIRONMENT = os.environ.get("ENVIRONMENT", "")
+
 STATE_TABLE = os.environ.get("STATE_TABLE", "failover-state")
 SNS_TOPIC_ARN = os.environ["SNS_TOPIC_ARN"]
 CW_NAMESPACE = os.environ.get("CW_NAMESPACE", "Custom/RegionFailover")
@@ -1135,9 +1141,17 @@ def check_active_region_staleness(active_region: str, state: dict) -> dict:
 # ===========================================================================
 
 def _format_subject(subject: str) -> str:
-    """Prepend APP_NAME to notification subject if configured. Truncates to 100 chars (SNS limit)."""
-    if APP_NAME:
-        return f"[{APP_NAME}] {subject}"[:100]
+    """Prepend [ENVIRONMENT-APP_NAME] to notification subject. SNS limit is 100 chars.
+
+    Composition rules (so operators can immediately tell which environment is alerting):
+      ENVIRONMENT="prod" + APP_NAME="critical-app"  -> [prod-critical-app] {subject}
+      ENVIRONMENT=""     + APP_NAME="critical-app"  -> [critical-app] {subject}
+      ENVIRONMENT="prod" + APP_NAME=""              -> [prod] {subject}
+      both empty                                    -> {subject} (unchanged)
+    """
+    parts = [p for p in (ENVIRONMENT, APP_NAME) if p]
+    if parts:
+        return f"[{'-'.join(parts)}] {subject}"[:100]
     return subject[:100]
 
 
@@ -1447,6 +1461,7 @@ def _reload_dynamic_config():
     global MIN_HEALTHY_HOST_COUNT, API_GW_5XX_THRESHOLD_PERCENT
     global ACTIVE_REGION_STALE_THRESHOLD_MINUTES
     global CW_NAMESPACE
+    global ENVIRONMENT
 
     # All dynamic config — re-read from os.environ every invocation
     ROUTING_MODE = os.environ.get("ROUTING_MODE", "failover").lower()
@@ -1465,6 +1480,7 @@ def _reload_dynamic_config():
     API_GW_5XX_THRESHOLD_PERCENT = float(os.environ.get("API_GW_5XX_THRESHOLD_PERCENT", "50.0"))
     ACTIVE_REGION_STALE_THRESHOLD_MINUTES = int(os.environ.get("ACTIVE_REGION_STALE_THRESHOLD_MINUTES", "3"))
     CW_NAMESPACE = os.environ.get("CW_NAMESPACE", "Custom/RegionFailover")
+    ENVIRONMENT = os.environ.get("ENVIRONMENT", "")
 
     # Reinitialize state backend (DynamoDB or S3)
     _state_backend = create_backend(region=CURRENT_REGION, client_config=_client_config)
@@ -1481,6 +1497,32 @@ def _reload_dynamic_config():
             prefix=os.environ.get("STATE_PREFIX", "failover-state/"),
             client_config=_client_config,
         )
+
+
+def detect_data_tier_config() -> dict:
+    """Inspect env to determine which data tiers are configured and how.
+
+    Returns a dict with four boolean flags driving configuration-aware
+    behavior (notification suppression, failback gates, retry policies):
+
+      aurora_present : Aurora cluster ID is set (tier exists)
+      aurora_auto    : Aurora present AND AURORA_AUTO_PROMOTE=true
+      redis_present  : ElastiCache global RG ID is set (tier exists)
+      redis_auto     : Redis present AND ELASTICACHE_AUTO_PROMOTE=true
+
+    The nine combinations of (aurora ∈ {absent, manual, auto}) ×
+    (redis ∈ {absent, manual, auto}) cover all supported deployments
+    from app-only stacks (C1) to fully automated dual-tier (C9).
+
+    Read at invocation time — do not cache; the portal can flip these
+    env vars between cycles. Call after _reload_dynamic_config().
+    """
+    return {
+        "aurora_present": bool(AURORA_CLUSTER_ID),
+        "aurora_auto":    bool(AURORA_CLUSTER_ID) and AURORA_AUTO_PROMOTE,
+        "redis_present":  bool(ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID),
+        "redis_auto":     bool(ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID) and ELASTICACHE_AUTO_PROMOTE,
+    }
 
 
 def _run_preflight_checks() -> dict:

--- a/manual_failback_v2.py
+++ b/manual_failback_v2.py
@@ -61,13 +61,20 @@ CW_METRIC_NAME = os.environ.get("CW_METRIC_NAME", "RegionActiveStatus")
 AURORA_GLOBAL_CLUSTER_ID = os.environ.get("AURORA_GLOBAL_CLUSTER_ID", "")
 AURORA_CLUSTER_ID = os.environ.get("AURORA_CLUSTER_ID", "")
 TARGET_AURORA_CLUSTER_ID = os.environ.get("TARGET_AURORA_CLUSTER_ID", "")
+AURORA_AUTO_PROMOTE = os.environ.get("AURORA_AUTO_PROMOTE", "false").lower() == "true"
 ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID = os.environ.get("ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", "")
+ELASTICACHE_REPLICATION_GROUP_ID = os.environ.get("ELASTICACHE_REPLICATION_GROUP_ID", "")
+ELASTICACHE_AUTO_PROMOTE = os.environ.get("ELASTICACHE_AUTO_PROMOTE", "false").lower() == "true"
 
 # Derive AWS account ID from the SNS topic ARN
 _AWS_ACCOUNT_ID = SNS_TOPIC_ARN.split(":")[4] if ":" in SNS_TOPIC_ARN else ""
 
 # Application name - included in all SNS notifications
 APP_NAME = os.environ.get("APP_NAME", "")
+
+# Deployment environment (e.g., "prod", "staging", "demo"). Composed with
+# APP_NAME into the [ENVIRONMENT-APP_NAME] subject prefix when both are set.
+ENVIRONMENT = os.environ.get("ENVIRONMENT", "")
 
 HEALTH_CHECK_URL = os.environ.get("HEALTH_CHECK_URL", "")
 HEALTH_ENDPOINT = os.environ.get("HEALTH_ENDPOINT", "/actuator/health")
@@ -181,10 +188,36 @@ def publish_region_health_metric(region: str, is_healthy: bool) -> None:
 
 
 def _format_subject(subject: str) -> str:
-    """Prepend APP_NAME to notification subject if configured."""
-    if APP_NAME:
-        return f"[{APP_NAME}] {subject}"[:100]
+    """Prepend [ENVIRONMENT-APP_NAME] to notification subject. SNS limit is 100 chars.
+
+    Composition rules (matches orchestrator's _format_subject):
+      ENVIRONMENT="prod" + APP_NAME="critical-app"  -> [prod-critical-app] {subject}
+      ENVIRONMENT=""     + APP_NAME="critical-app"  -> [critical-app] {subject}
+      ENVIRONMENT="prod" + APP_NAME=""              -> [prod] {subject}
+      both empty                                    -> {subject}
+    """
+    parts = [p for p in (ENVIRONMENT, APP_NAME) if p]
+    if parts:
+        return f"[{'-'.join(parts)}] {subject}"[:100]
     return subject[:100]
+
+
+def detect_data_tier_config() -> dict:
+    """Inspect env to determine which data tiers are present and how they promote.
+
+    Returns the same shape as the orchestrator's helper. The failback Lambda
+    uses this to decide which gates to enforce on the operator's payload
+    (aurora_confirmed, redis_confirmed, etc.) and to suppress notifications
+    for absent tiers.
+
+    See failover_orchestrator_v3.py:detect_data_tier_config for full docs.
+    """
+    return {
+        "aurora_present": bool(AURORA_CLUSTER_ID),
+        "aurora_auto":    bool(AURORA_CLUSTER_ID) and AURORA_AUTO_PROMOTE,
+        "redis_present":  bool(ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID),
+        "redis_auto":     bool(ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID) and ELASTICACHE_AUTO_PROMOTE,
+    }
 
 
 def send_notification(subject: str, message: str) -> None:

--- a/tests/test_config_detection.py
+++ b/tests/test_config_detection.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Tests for v1.6 PR1: ENVIRONMENT env var + detect_data_tier_config() helper.
+
+Covers:
+  - _format_subject() composition rules across all ENVIRONMENT × APP_NAME states.
+  - detect_data_tier_config() for all 9 baseline configurations (C1–C9):
+      Aurora ∈ {absent, manual, auto} × Redis ∈ {absent, manual, auto}
+  - Parity between orchestrator and manual_failback_v2 helpers (must match).
+
+PR1 introduces no behavior change; these tests pin the new helpers' contracts
+so subsequent PRs (notification template, failback gates, retry caps) can
+build on them.
+
+Note on style: matches tests/test_orchestrator.py — env vars are set once
+before module import via os.environ; per-test variation is done via
+patch.object() to avoid sys.modules pollution that breaks downstream tests.
+
+Run: python3 -m pytest tests/test_config_detection.py -v
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# Minimum env required for both modules to import without crashing.
+_MIN_ENV = {
+    "SNS_TOPIC_ARN": "arn:aws:sns:us-east-1:123456789012:failover-alerts",
+    "AWS_REGION": "us-east-1",
+    "PRIMARY_REGION": "us-east-1",
+    "SECONDARY_REGION": "us-east-2",
+    "STATE_BACKEND": "dynamodb",
+    "STATE_TABLE": "failover-state",
+}
+
+for k, v in _MIN_ENV.items():
+    os.environ.setdefault(k, v)
+
+# Mock boto3 and the state backend at module level so the orchestrator's
+# top-level client creation does not make real AWS calls. Same pattern as
+# tests/test_orchestrator.py so the two test files share a consistent
+# mocked module instance via the import cache.
+_mock_boto3_patcher = patch("boto3.client")
+_mock_boto3_client = _mock_boto3_patcher.start()
+_mock_boto3_client.return_value = MagicMock()
+
+_mock_create_backend_patcher = patch("state_backend.create_backend")
+_mock_create_backend = _mock_create_backend_patcher.start()
+_mock_create_backend.return_value = MagicMock()
+
+import failover_orchestrator_v3 as orch  # noqa: E402
+import manual_failback_v2 as failback    # noqa: E402
+
+_mock_boto3_patcher.stop()
+_mock_create_backend_patcher.stop()
+
+
+# ---------------------------------------------------------------------------
+# _format_subject — composition rules
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("environment,app_name,subject,expected", [
+    # Both set → [ENVIRONMENT-APP_NAME] prefix (the new shape).
+    ("prod", "critical-app", "FAILOVER", "[prod-critical-app] FAILOVER"),
+    ("staging", "billing", "WARNING", "[staging-billing] WARNING"),
+    ("demo", "fo-v10x-s1", "Test", "[demo-fo-v10x-s1] Test"),
+
+    # APP_NAME only → [APP_NAME] (backwards-compat with v1.0–v1.5).
+    ("", "critical-app", "FAILOVER", "[critical-app] FAILOVER"),
+
+    # ENVIRONMENT only → [ENVIRONMENT].
+    ("prod", "", "FAILOVER", "[prod] FAILOVER"),
+
+    # Neither set → bare subject (no prefix at all).
+    ("", "", "FAILOVER", "FAILOVER"),
+])
+def test_format_subject_orchestrator(environment, app_name, subject, expected):
+    """Orchestrator's _format_subject composes prefix per environment/app_name."""
+    with patch.object(orch, "ENVIRONMENT", environment), \
+         patch.object(orch, "APP_NAME", app_name):
+        assert orch._format_subject(subject) == expected
+
+
+@pytest.mark.parametrize("environment,app_name,subject,expected", [
+    ("prod", "critical-app", "FAILBACK COMPLETE", "[prod-critical-app] FAILBACK COMPLETE"),
+    ("", "critical-app", "FAILBACK COMPLETE", "[critical-app] FAILBACK COMPLETE"),
+    ("prod", "", "FAILBACK COMPLETE", "[prod] FAILBACK COMPLETE"),
+    ("", "", "FAILBACK COMPLETE", "FAILBACK COMPLETE"),
+])
+def test_format_subject_failback(environment, app_name, subject, expected):
+    """Failback Lambda's _format_subject must match orchestrator behavior."""
+    with patch.object(failback, "ENVIRONMENT", environment), \
+         patch.object(failback, "APP_NAME", app_name):
+        assert failback._format_subject(subject) == expected
+
+
+def test_format_subject_truncates_to_100_chars():
+    """SNS subject limit is 100 chars; long inputs are truncated."""
+    with patch.object(orch, "ENVIRONMENT", "prod"), \
+         patch.object(orch, "APP_NAME", "critical-app"):
+        long_subject = "X" * 200
+        result = orch._format_subject(long_subject)
+        assert len(result) == 100
+        assert result.startswith("[prod-critical-app] ")
+
+
+# ---------------------------------------------------------------------------
+# detect_data_tier_config — all 9 baseline configurations (C1–C9)
+# ---------------------------------------------------------------------------
+
+# Each row: (id, aurora_cluster_id, aurora_auto, redis_global_rg, redis_auto, expected)
+_CONFIG_MATRIX = [
+    ("C1", "",       False, "",          False,
+     {"aurora_present": False, "aurora_auto": False, "redis_present": False, "redis_auto": False}),
+    ("C2", "ac-w1",  False, "",          False,
+     {"aurora_present": True,  "aurora_auto": False, "redis_present": False, "redis_auto": False}),
+    ("C3", "ac-w1",  True,  "",          False,
+     {"aurora_present": True,  "aurora_auto": True,  "redis_present": False, "redis_auto": False}),
+    ("C4", "",       False, "rg-global", False,
+     {"aurora_present": False, "aurora_auto": False, "redis_present": True,  "redis_auto": False}),
+    ("C5", "ac-w1",  False, "rg-global", False,
+     {"aurora_present": True,  "aurora_auto": False, "redis_present": True,  "redis_auto": False}),
+    ("C6", "ac-w1",  True,  "rg-global", False,
+     {"aurora_present": True,  "aurora_auto": True,  "redis_present": True,  "redis_auto": False}),
+    ("C7", "",       False, "rg-global", True,
+     {"aurora_present": False, "aurora_auto": False, "redis_present": True,  "redis_auto": True}),
+    ("C8", "ac-w1",  False, "rg-global", True,
+     {"aurora_present": True,  "aurora_auto": False, "redis_present": True,  "redis_auto": True}),
+    ("C9", "ac-w1",  True,  "rg-global", True,
+     {"aurora_present": True,  "aurora_auto": True,  "redis_present": True,  "redis_auto": True}),
+]
+
+
+@pytest.mark.parametrize("cid,aurora_id,aurora_auto,redis_id,redis_auto,expected",
+                         _CONFIG_MATRIX, ids=[c[0] for c in _CONFIG_MATRIX])
+def test_detect_data_tier_config_orchestrator(cid, aurora_id, aurora_auto, redis_id, redis_auto, expected):
+    """Orchestrator's detect_data_tier_config returns correct flags for C1–C9."""
+    with patch.object(orch, "AURORA_CLUSTER_ID", aurora_id), \
+         patch.object(orch, "AURORA_AUTO_PROMOTE", aurora_auto), \
+         patch.object(orch, "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", redis_id), \
+         patch.object(orch, "ELASTICACHE_AUTO_PROMOTE", redis_auto):
+        assert orch.detect_data_tier_config() == expected
+
+
+@pytest.mark.parametrize("cid,aurora_id,aurora_auto,redis_id,redis_auto,expected",
+                         _CONFIG_MATRIX, ids=[c[0] for c in _CONFIG_MATRIX])
+def test_detect_data_tier_config_failback(cid, aurora_id, aurora_auto, redis_id, redis_auto, expected):
+    """Failback Lambda's helper must match the orchestrator exactly."""
+    with patch.object(failback, "AURORA_CLUSTER_ID", aurora_id), \
+         patch.object(failback, "AURORA_AUTO_PROMOTE", aurora_auto), \
+         patch.object(failback, "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", redis_id), \
+         patch.object(failback, "ELASTICACHE_AUTO_PROMOTE", redis_auto):
+        assert failback.detect_data_tier_config() == expected
+
+
+def test_aurora_auto_requires_aurora_present():
+    """AURORA_AUTO_PROMOTE=true with empty AURORA_CLUSTER_ID → aurora_auto=False (defensive)."""
+    with patch.object(orch, "AURORA_CLUSTER_ID", ""), \
+         patch.object(orch, "AURORA_AUTO_PROMOTE", True):
+        cfg = orch.detect_data_tier_config()
+        assert cfg["aurora_present"] is False
+        assert cfg["aurora_auto"] is False  # cannot auto-promote a tier that isn't there
+
+
+def test_redis_auto_requires_redis_present():
+    """ELASTICACHE_AUTO_PROMOTE=true with empty global RG ID → redis_auto=False."""
+    with patch.object(orch, "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", ""), \
+         patch.object(orch, "ELASTICACHE_AUTO_PROMOTE", True):
+        cfg = orch.detect_data_tier_config()
+        assert cfg["redis_present"] is False
+        assert cfg["redis_auto"] is False


### PR DESCRIPTION
## Summary

PR1 of the v1.6 release — pure foundation, no behavior change for existing deployments.

- Adds `ENVIRONMENT` env var, threaded through both Lambdas' `_format_subject()` to produce the new `[ENVIRONMENT-APP_NAME]` notification subject prefix when both are set. Falls back to `[APP_NAME]` only when ENVIRONMENT is empty.
- Adds shared `detect_data_tier_config()` helper returning `{aurora_present, aurora_auto, redis_present, redis_auto}`. This is the single source of truth that PR2–PR7 build their per-configuration behavior on.
- Failback Lambda now reads `AURORA_AUTO_PROMOTE`, `ELASTICACHE_AUTO_PROMOTE`, `ELASTICACHE_REPLICATION_GROUP_ID` (it was missing all three — they're needed by PR5's gate).

## Test plan

- [x] `python3 -m pytest tests/test_config_detection.py -v` — 31 new cases pass
- [x] `python3 -m pytest tests/ -v` — 307 passed (276 baseline + 31 new), 0 regressions

## v1.6 release context

This is the first of 10 stacked PRs implementing the v1.6 plan from the 2026-04-25 v1.5 stability drill. See \`docs/drills/2026-04-25-v15-validation.md\` (committed in PR9) for the full drill report.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)