### PR TITLE
docs: rename project from SentinelFO to Vigil

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Report a bug in SentinelFO
+about: Report a bug in Vigil
 labels: bug
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: Propose a new feature or enhancement for SentinelFO
+about: Propose a new feature or enhancement for Vigil
 labels: enhancement
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**SentinelFO** (Sentinel Failover Orchestrator) — AI-enhanced multi-region failover platform for AWS infrastructure. Lambda-based system that manages automated failover and manual failback between us-west-1 (primary) and us-west-2 (secondary), with progressive AI intelligence for root cause analysis, failback readiness, and Aurora promotion decisions.
+**Vigil** — AI-enhanced multi-region failover platform for AWS infrastructure. Lambda-based system that manages automated failover and manual failback between us-west-1 (primary) and us-west-2 (secondary), with progressive AI intelligence for root cause analysis, failback readiness, and Aurora promotion decisions.
 
 **Core problem solved:** Route 53 failover records are stateless and can flip traffic back and forth rapidly. This system adds a decision layer with consecutive-failure thresholds, cooldowns, and an explicit latch that keeps the old region marked unhealthy until an operator manually runs failback.
 
@@ -24,7 +24,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Demo Environment (v2.0 Platform)
 
-Single shared infrastructure controlled by the SentinelFO portal. Aurora and ECS run permanently. Lambda versioning with aliases enables switching between v1.0/v1.1/v1.2 behavior via env vars.
+Single shared infrastructure controlled by the Vigil portal. Aurora and ECS run permanently. Lambda versioning with aliases enables switching between v1.0/v1.1/v1.2 behavior via env vars.
 
 - **Portal:** `python3 portal/app.py` → http://localhost:5001 (login: eramirez)
 - **Lambda aliases:** `v1-0`, `v1-1`, `v1-2`, `active` — all point to the same code (v1.2.1). Version behavior controlled by env vars.
@@ -76,7 +76,7 @@ Before merging any PR:
 # Run the full test suite (REQUIRED before every commit)
 python3 -m pytest tests/ -v
 
-# Run the SentinelFO control portal (http://localhost:5001)
+# Run the Vigil control portal (http://localhost:5001)
 python3 portal/app.py
 
 # Publish Lambda version and update alias (demo environment)
@@ -130,7 +130,7 @@ Runtime dependencies: `boto3`, `botocore` (provided by Lambda runtime). Portal a
 | `ai/stability_collector.py` | Time-series stability data: Aurora replication lag, ECS task trends, ALB error rates. |
 | `ai/failback_readiness.py` | LLM-powered GO/NO-GO/CAUTION assessment before failback. |
 | `ai/aurora_advisor.py` | Progressive Aurora promotion advisor: advisory → guided → autonomous modes. |
-| `portal/app.py` | SentinelFO control portal (Flask). Test configuration, activation, demo visualization. |
+| `portal/app.py` | Vigil control portal (Flask). Test configuration, activation, demo visualization. |
 | `portal/aws_ops.py` | Portal AWS operations: Lambda alias switching, ECS scaling, Aurora management, state reset. |
 | `portal/config.py` | Portal configuration: version definitions, feature matrix, AWS resource names. |
 | `portal/lock.py` | DynamoDB-based test locking (prevents concurrent tests). |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SentinelFO — AI-Enhanced Failover Orchestration
+# Vigil — AI-Enhanced Failover Orchestration
 
 Automated multi-region failover for AWS infrastructure with progressive AI intelligence. Lambda-based system that evaluates health, manages DNS failover via Route 53, coordinates Aurora database promotion, and uses LLM analysis to provide root cause analysis, failback readiness assessment, and Aurora promotion recommendations.
 

--- a/docs/event-log-format.md
+++ b/docs/event-log-format.md
@@ -1,4 +1,4 @@
-# SentinelFO Event Log Format
+# Vigil Event Log Format
 
 All structured events are emitted to CloudWatch Logs as JSON lines. The ingestion filter for P1 alerting is:
 

--- a/portal/app.py
+++ b/portal/app.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""SentinelFO Control Portal — stack-aware."""
+"""Vigil Control Portal — stack-aware."""
 
 import json
 import logging

--- a/portal/aws_ops.py
+++ b/portal/aws_ops.py
@@ -1,4 +1,4 @@
-"""AWS operations for the SentinelFO portal — stack-aware.
+"""AWS operations for the Vigil portal — stack-aware.
 
 Every function takes a stack_id ('ddb' or 's3') to select which
 set of AWS resources to operate on. No runtime env var switching.

--- a/portal/config.py
+++ b/portal/config.py
@@ -1,4 +1,4 @@
-"""SentinelFO Portal configuration — version definitions, feature matrix, AWS resource names."""
+"""Vigil Portal configuration — version definitions, feature matrix, AWS resource names."""
 
 # ── Regions ──────────────────────────────────────────────────────────────────
 

--- a/portal/static/app.js
+++ b/portal/static/app.js
@@ -1,4 +1,4 @@
-/* SentinelFO Portal — Shared JavaScript */
+/* Vigil Portal — Shared JavaScript */
 
 // ── API Layer ───────────────────────────────────────────────────────────────
 

--- a/portal/templates/demo.html
+++ b/portal/templates/demo.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>SentinelFO — Demo</title>
+  <title>Vigil — Demo</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>

--- a/portal/templates/index.html
+++ b/portal/templates/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>SentinelFO — Admin</title>
+  <title>Vigil — Admin</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>

--- a/portal/templates/landing.html
+++ b/portal/templates/landing.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>SentinelFO</title>
+  <title>Vigil</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>

--- a/portal/templates/login.html
+++ b/portal/templates/login.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>SentinelFO — Sign In</title>
+  <title>Vigil — Sign In</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body class="login-page">
   <div class="login-box">
-    <h1>SentinelFO</h1>
+    <h1>Vigil</h1>
     <div class="subtitle">AI-Enhanced Failover Orchestration</div>
     {% if error %}<div class="login-error">{{ error }}</div>{% endif %}
     <form method="post">

--- a/tests/test_sns_notifications_failover.py
+++ b/tests/test_sns_notifications_failover.py
@@ -57,7 +57,7 @@ _ENV = {
     "ROUTING_MODE": "failover",
     "FAILOVER_MODE": "auto",
     # App identity
-    "APP_NAME": "SentinelFO",
+    "APP_NAME": "Vigil",
     # Timing
     "COOLDOWN_MINUTES": "30",
     "CONSECUTIVE_FAILURES_THRESHOLD": "3",
@@ -103,7 +103,7 @@ _mock_create_backend_patcher.stop()
 
 
 # ===========================================================================
-# Autouse fixture: ensure APP_NAME is "SentinelFO" for every test in this file.
+# Autouse fixture: ensure APP_NAME is "Vigil" for every test in this file.
 # Other test files set APP_NAME="" via os.environ.setdefault, which silently
 # wins when they run first. Patch the module attribute directly so our tests
 # are isolated from load-order effects.
@@ -111,8 +111,8 @@ _mock_create_backend_patcher.stop()
 
 @pytest.fixture(autouse=True)
 def patch_app_name():
-    with patch.object(orch, "APP_NAME", "SentinelFO"), \
-         patch.object(failback, "APP_NAME", "SentinelFO"):
+    with patch.object(orch, "APP_NAME", "Vigil"), \
+         patch.object(failback, "APP_NAME", "Vigil"):
         yield
 
 
@@ -248,7 +248,7 @@ class TestSNSDegradationWarnings:
         assert "degraded" in subject
         assert "2/3" in subject
         assert "us-east-1" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[Vigil]")
         assert len(subject) <= 100
 
     @patch.object(orch, "update_failover_state")
@@ -405,7 +405,7 @@ class TestSNSRegionRecovery:
         assert "RECOVERED" in subject
         assert "us-east-1" in subject
         assert "rejoining" in subject.lower() or "healthy" in subject.lower()
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[Vigil]")
         assert len(subject) <= 100
 
     @patch.object(orch, "update_failover_state")
@@ -543,7 +543,7 @@ class TestSNSFailoverExecution:
         assert "FAILOVER" in subject
         assert "us-east-2" in subject
         assert "PROMOTE DATA TIER NOW" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[Vigil]")
         assert len(subject) <= 100
 
         assert "failover-global-replication-group" in message
@@ -642,7 +642,7 @@ class TestSNSFailoverExecution:
         subject = failover_calls[-1][1]["Subject"]
         assert "FAILOVER" in subject
         assert "PROMOTE DATA TIER NOW" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[Vigil]")
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "publish_region_health_metric")
@@ -739,7 +739,7 @@ class TestSNSAuroraPromotionReminders:
         subject = _get_sns_subject(mock_sns)
         assert "Aurora promotion confirmed" in subject
         assert "us-east-2" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[Vigil]")
         assert len(subject) <= 100
         # Flag must be cleared
         mock_upd.assert_called_with({"aurora_promotion_pending": False})
@@ -770,7 +770,7 @@ class TestSNSAuroraPromotionReminders:
         assert "Aurora" in subject
         assert "pending" in subject
         assert "5m" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[Vigil]")
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "publish_region_health_metric")
@@ -844,7 +844,7 @@ class TestSNSElasticachePromotionReminders:
         subject = _get_sns_subject(mock_sns)
         assert "ElastiCache promotion confirmed" in subject
         assert "us-east-2" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[Vigil]")
         assert len(subject) <= 100
         mock_upd.assert_called_with({"redis_promotion_pending": False})
 
@@ -977,7 +977,7 @@ class TestSNSPassiveRegionNotifications:
         assert "Passive" in subject
         assert "us-east-2" in subject
         assert "unhealthy" in subject.lower()
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[Vigil]")
         assert len(subject) <= 100
 
     @patch.object(orch, "update_failover_state")
@@ -1033,7 +1033,7 @@ class TestSNSPassiveRegionNotifications:
         assert "CRITICAL" in subject
         assert "Dual-Region" in subject
         assert "Outage" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[Vigil]")
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "publish_region_health_metric")
@@ -1098,12 +1098,12 @@ class TestSNSSubjectAndThrottling:
 
     @patch.object(orch, "sns")
     def test_subject_prefixed_with_app_name(self, mock_sns):
-        """Subject is prefixed with [SentinelFO] when APP_NAME is configured."""
-        with patch.object(orch, "APP_NAME", "SentinelFO"):
+        """Subject is prefixed with [Vigil] when APP_NAME is configured."""
+        with patch.object(orch, "APP_NAME", "Vigil"):
             orch.send_notification("FAILOVER: test subject", "body")
 
         subject = _get_sns_subject(mock_sns)
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[Vigil]")
         assert "FAILOVER" in subject
 
     @patch.object(orch, "sns")
@@ -1120,7 +1120,7 @@ class TestSNSSubjectAndThrottling:
     def test_subject_truncated_to_100_chars(self, mock_sns):
         """Subject is truncated to 100 characters maximum."""
         long_subject = "X" * 200
-        with patch.object(orch, "APP_NAME", "SentinelFO"):
+        with patch.object(orch, "APP_NAME", "Vigil"):
             orch.send_notification(long_subject, "body")
 
         subject = _get_sns_subject(mock_sns)
@@ -1341,7 +1341,7 @@ class TestSNSFailback:
         assert "FAILBACK BLOCKED" in subject
         assert "us-east-1" in subject
         assert "not ready" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[Vigil]")
         assert len(subject) <= 100
 
     @patch.object(failback, "create_backend")
@@ -1363,7 +1363,7 @@ class TestSNSFailback:
         subject = _get_sns_subject(mock_sns)
         assert "FAILBACK COMPLETE" in subject
         assert "us-east-1" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[Vigil]")
         assert len(subject) <= 100
 
         message = _get_sns_message(mock_sns)
@@ -1401,7 +1401,7 @@ class TestSNSFailback:
         assert len(failed_calls) == 1
         subject = failed_calls[0][1]["Subject"]
         assert "us-east-1" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[Vigil]")
 
     @patch.object(failback, "create_backend")
     @patch.object(failback, "publish_region_health_metric")
@@ -1425,4 +1425,4 @@ class TestSNSFailback:
         subject = _get_sns_subject(mock_sns)
         assert "FAILBACK COMPLETE" in subject
         assert "us-east-1" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[Vigil]")


### PR DESCRIPTION
## Summary

Mechanical rename SentinelFO → Vigil across 14 files. Closes the naming inconsistency where some files used \"SentinelFO\" while CLAUDE.md's \"Prerequisites & Dependency Settings\" section already used \"Vigil\".

## Files

Docs, portal docstrings, HTML titles, and test fixture strings. See commit message for the full list.

## Test plan

- [x] \`python3 -m pytest tests/ -v\` — 276 passed (matches main baseline), 0 regressions
- [ ] Visual: portal pages render with \"Vigil\" in the topbar/login

## Note

This branch is **independent** of the rest of the v1.6 stack — it branches from \`main\` and can merge in any order relative to PR1–PR9. PR2's \`notifications.py\` already uses \"Vigil\" in its footer; the rest of v1.6 is naming-neutral.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)