### PR TITLE
v1.6 PR2: notifications.compose_message() + WARNING throttle reform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ python3 tools/publish_version.py --alias active --copy-from v1-2
 # Returns: {"ready": true/false, "checks": {"state_backend": ..., "cloudwatch_metric": ..., "sns_topic": ...}}
 
 # Package and deploy orchestrator Lambda (production)
-zip failover_orchestrator_v3.zip failover_orchestrator_v3.py state_backend.py ai/__init__.py ai/config.py ai/llm_client.py ai/collector.py ai/rca_analyzer.py ai/stability_collector.py ai/aurora_advisor.py
+zip failover_orchestrator_v3.zip failover_orchestrator_v3.py state_backend.py notifications.py ai/__init__.py ai/config.py ai/llm_client.py ai/collector.py ai/rca_analyzer.py ai/stability_collector.py ai/aurora_advisor.py
 aws lambda update-function-code \
   --function-name failover-orchestrator-prod \
   --zip-file fileb://failover_orchestrator_v3.zip \
@@ -96,7 +96,7 @@ aws lambda update-function-code \
 # Repeat for us-west-2
 
 # Package and deploy failback Lambda (production)
-zip manual_failback_v2.zip manual_failback_v2.py state_backend.py ai/__init__.py ai/config.py ai/llm_client.py ai/stability_collector.py ai/failback_readiness.py
+zip manual_failback_v2.zip manual_failback_v2.py state_backend.py notifications.py ai/__init__.py ai/config.py ai/llm_client.py ai/stability_collector.py ai/failback_readiness.py
 aws lambda update-function-code \
   --function-name failover-manual-failback-prod \
   --zip-file fileb://manual_failback_v2.zip \
@@ -252,6 +252,9 @@ All configuration is via Lambda environment variables. Key variables:
 | `PASSIVE_PUBLISH_ZERO` | false | Passive region always publishes metric=0 (for zero-container secondary use case) |
 | `ROUTING_MODE` | failover | `failover` (active/passive with latch) or `active-active` (both regions serve, auto-recovery) |
 | `SNS_TOPIC_ARN` | (required) | Operator notifications |
+| `APP_NAME` | (empty) | Application name shown in notification subject prefix |
+| `ENVIRONMENT` | (empty) | Deployment environment (e.g., `prod`, `staging`, `demo`). Composed with `APP_NAME` into the `[ENVIRONMENT-APP_NAME]` notification subject prefix. Empty falls back to `[APP_NAME]` only. |
+| `WARNING_NOTIFICATION_COOLDOWN_MINUTES` | 5 | Throttle between repeated WARNING-level notifications. First failure of an incident bypasses throttling. |
 | `HEALTH_CHECK_URL` | (empty) | Private ALB URL for HTTP health check |
 | `FAILOVER_MODE` | auto | `auto`, `manual` (notify-only), or `parked` (inactive during staged deployment) |
 | `COOLDOWN_MINUTES` | 30 | Minimum time between failovers |
@@ -398,9 +401,9 @@ python3 tools/setup_s3_state_backend.py
 #    STATE_BUCKET=failover-state-<region>-<account-id>
 #    STATE_PREFIX=failover-state/
 
-# 3. Include state_backend.py in the Lambda deployment zip:
-zip failover_orchestrator_v3.zip failover_orchestrator_v3.py state_backend.py
-zip manual_failback_v2.zip manual_failback_v2.py state_backend.py ai/__init__.py ai/config.py ai/llm_client.py ai/stability_collector.py ai/failback_readiness.py
+# 3. Include state_backend.py and notifications.py in the Lambda deployment zip:
+zip failover_orchestrator_v3.zip failover_orchestrator_v3.py state_backend.py notifications.py
+zip manual_failback_v2.zip manual_failback_v2.py state_backend.py notifications.py ai/__init__.py ai/config.py ai/llm_client.py ai/stability_collector.py ai/failback_readiness.py
 ```
 
 ### Trade-offs vs DynamoDB

--- a/failover_orchestrator_v3.py
+++ b/failover_orchestrator_v3.py
@@ -224,7 +224,7 @@ AURORA_PROMOTION_REMINDER_INTERVAL_MINUTES = int(
 # are NEVER throttled.
 # ---------------------------------------------------------------------------
 WARNING_NOTIFICATION_COOLDOWN_MINUTES = int(
-    os.environ.get("WARNING_NOTIFICATION_COOLDOWN_MINUTES", "10")
+    os.environ.get("WARNING_NOTIFICATION_COOLDOWN_MINUTES", "5")
 )
 
 logger = logging.getLogger()
@@ -1165,7 +1165,12 @@ def send_notification(subject: str, message: str) -> None:
         logger.error(f"Notification failed: {type(e).__name__}: {e}")
 
 
-def send_warning_notification(subject: str, message: str, state: dict) -> None:
+def send_warning_notification(
+    subject: str,
+    message: str,
+    state: dict,
+    bypass_throttle: bool = False,
+) -> None:
     """
     Send a WARNING-level SNS notification with throttling.
 
@@ -1174,7 +1179,14 @@ def send_warning_notification(subject: str, message: str, state: dict) -> None:
     out immediately, then subsequent alerts are suppressed for N minutes.
 
     The first alert always sends (so the team knows something is wrong).
-    Subsequent alerts send only every WARNING_NOTIFICATION_COOLDOWN_MINUTES.
+    Subsequent alerts send only every WARNING_NOTIFICATION_COOLDOWN_MINUTES
+    (default 5min in v1.6, was 10min in v1.5).
+
+    Set ``bypass_throttle=True`` for notifications that must always reach the
+    operator regardless of recent traffic — e.g., the very first failure of an
+    incident, retry-attempt-N alerts during stuck data-tier promotion, or the
+    final escalation when retries exhaust. These signal-class events lose
+    information if collapsed under a cooldown window.
 
     CRITICAL one-time events (failover, region failure, failover failed) should
     use send_notification() directly - they are NEVER throttled.
@@ -1182,22 +1194,23 @@ def send_warning_notification(subject: str, message: str, state: dict) -> None:
     now = datetime.now(timezone.utc)
     last_warning_ts_str = state.get("last_warning_notification_ts", "1970-01-01T00:00:00Z")
 
-    try:
-        last_warning_ts = datetime.fromisoformat(last_warning_ts_str.replace("Z", "+00:00"))
-        seconds_since_last = (now - last_warning_ts).total_seconds()
-        cooldown_seconds = WARNING_NOTIFICATION_COOLDOWN_MINUTES * 60
+    if not bypass_throttle:
+        try:
+            last_warning_ts = datetime.fromisoformat(last_warning_ts_str.replace("Z", "+00:00"))
+            seconds_since_last = (now - last_warning_ts).total_seconds()
+            cooldown_seconds = WARNING_NOTIFICATION_COOLDOWN_MINUTES * 60
 
-        if seconds_since_last < cooldown_seconds:
-            remaining = (cooldown_seconds - seconds_since_last) / 60
-            logger.info(
-                f"Warning notification throttled. Last sent {seconds_since_last:.0f}s ago, "
-                f"cooldown {cooldown_seconds}s. Next in ~{remaining:.0f}m. "
-                f"Subject: {subject}"
-            )
-            return
-    except (ValueError, TypeError):
-        # Can't parse timestamp - send the notification to be safe
-        pass
+            if seconds_since_last < cooldown_seconds:
+                remaining = (cooldown_seconds - seconds_since_last) / 60
+                logger.info(
+                    f"Warning notification throttled. Last sent {seconds_since_last:.0f}s ago, "
+                    f"cooldown {cooldown_seconds}s. Next in ~{remaining:.0f}m. "
+                    f"Subject: {subject}"
+                )
+                return
+        except (ValueError, TypeError):
+            # Can't parse timestamp - send the notification to be safe
+            pass
 
     # Send the notification and update the timestamp
     try:

--- a/notifications.py
+++ b/notifications.py
@@ -1,0 +1,135 @@
+"""Shared notification template for Vigil Lambdas (v1.6).
+
+Provides ``compose_message()`` — a single contract used by the failover
+orchestrator and the manual failback Lambda for every operator-facing
+notification. The goal: an operator who has never seen this system can
+read any one email and immediately understand:
+
+  * **WHAT** is happening (one-line summary)
+  * **WHY** it is happening (root signal evidence in plain English)
+  * **WHAT TO DO NEXT** (explicit operator action — including
+    "no action required, the system will retry")
+
+Optional sections:
+
+  * **journey** — 3-line breadcrumb showing where in the failover lifecycle
+    this notification falls. Lets operators triage quickly even if they
+    missed earlier emails.
+  * **context** — a small key/value table of timestamps, regions, counters.
+
+The composed (subject, body) tuple does NOT include the
+``[ENVIRONMENT-APP_NAME]`` prefix; each Lambda's ``_format_subject()`` adds
+that. Keeping prefix logic Lambda-side avoids duplicating env-var reads in
+this module and keeps the helper purely formatting-focused.
+
+Used by ``failover_orchestrator_v3.py`` and ``manual_failback_v2.py``.
+Both Lambda zips must include this file (see CLAUDE.md deploy commands).
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+
+SEVERITY_INFO = "INFO"
+SEVERITY_WARNING = "WARNING"
+SEVERITY_CRITICAL = "CRITICAL"
+
+_VALID_SEVERITIES = frozenset({SEVERITY_INFO, SEVERITY_WARNING, SEVERITY_CRITICAL})
+
+
+def compose_message(
+    *,
+    severity: str,
+    what: str,
+    why: str,
+    next_step: str,
+    context: Optional[dict] = None,
+    journey: Optional[list] = None,
+    source: str = "",
+    region: str = "",
+    version: str = "v1.6",
+    now: Optional[datetime] = None,
+) -> tuple:
+    """Build a structured (subject, body) pair for an SNS notification.
+
+    All four content fields (severity, what, why, next_step) are required.
+    Empty strings are rejected so call sites cannot silently ship a
+    notification with a missing operator instruction — that is exactly the
+    "buggy journey" the v1.5 drill flagged.
+
+    Args:
+        severity: One of ``INFO``, ``WARNING``, ``CRITICAL``. Becomes the
+            leading token of the subject (after the bracketed env-app prefix).
+        what: One-line summary, e.g.
+            "Region us-west-1 reported its FIRST health failure (1 of 3)".
+        why: One to three plain-English sentences explaining the root signal.
+            Avoid raw JSON dumps — paste health-signal blobs into ``context``
+            instead so the body stays readable in an email client.
+        next_step: Explicit operator action. When no human action is needed
+            yet, say so: "No action — the system will retry. You will be
+            notified again if the failure persists."
+        context: Optional ``{label: value}`` dict rendered as a small aligned
+            table under a CONTEXT heading. Use for timestamps, regions,
+            counters — anything tabular.
+        journey: Optional list of breadcrumb strings (typically 3) showing
+            position in the incident lifecycle, e.g.
+            ``["[1] First failure", "[ ] Sustained", "[ ] Failover"]``.
+        source: Lambda function name shown in the footer (e.g.,
+            ``"failover-orchestrator"``). Empty string omits it.
+        region: Publishing region shown in the footer (e.g., ``"us-west-1"``).
+            Empty string omits it.
+        version: Vigil version string shown in the footer.
+        now: Override timestamp for tests; production should leave unset.
+
+    Returns:
+        ``(subject, body)``. The subject is the bare ``"<SEVERITY>: <what>"``
+        form; each Lambda's ``_format_subject()`` prepends the
+        ``[ENVIRONMENT-APP_NAME]`` prefix and applies the 100-char SNS truncation.
+
+    Raises:
+        ValueError: If ``severity`` is not one of the allowed values, or if
+            any of ``what``, ``why``, ``next_step`` is empty.
+    """
+    if severity not in _VALID_SEVERITIES:
+        raise ValueError(
+            f"severity must be one of {sorted(_VALID_SEVERITIES)}, got {severity!r}"
+        )
+    if not what:
+        raise ValueError("compose_message: 'what' is required and cannot be empty")
+    if not why:
+        raise ValueError("compose_message: 'why' is required and cannot be empty")
+    if not next_step:
+        raise ValueError("compose_message: 'next_step' is required and cannot be empty")
+
+    subject = f"{severity}: {what}"
+
+    sections = ["WHAT IS HAPPENING", why]
+
+    if journey:
+        sections.append("")
+        sections.append("WHERE WE ARE IN THE INCIDENT")
+        sections.extend(str(line) for line in journey)
+
+    if context:
+        sections.append("")
+        sections.append("CONTEXT")
+        max_label = max(len(str(k)) for k in context)
+        for label, value in context.items():
+            sections.append(f"  {str(label).ljust(max_label)} : {value}")
+
+    sections.append("")
+    sections.append("WHAT TO DO NEXT")
+    sections.append(next_step)
+
+    sections.append("")
+    sections.append("—")
+
+    ts = (now or datetime.now(timezone.utc)).isoformat(timespec="seconds")
+    footer = [f"Vigil {version}", ts]
+    if source:
+        footer.append(source)
+    if region:
+        footer.append(f"region={region}")
+    sections.append(" · ".join(footer))
+
+    return subject, "\n".join(sections)

--- a/tests/test_notification_template.py
+++ b/tests/test_notification_template.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Tests for v1.6 PR2: notifications.compose_message() + throttle reform.
+
+Pins the contract that PR3 will use to rewrite all 29 SNS call sites:
+
+  - Required fields (severity, what, why, next_step) are validated.
+  - Severity must be one of INFO/WARNING/CRITICAL.
+  - Body always contains WHAT IS HAPPENING / WHAT TO DO NEXT sections.
+  - Optional sections (CONTEXT table, journey breadcrumb) render only when given.
+  - Footer carries version / timestamp / source / region in a stable format.
+  - Throttle reform: default cooldown is 5min (was 10min in v1.5).
+  - Throttle bypass via bypass_throttle=True for first-failure / retry / escalation
+    notifications that must never be silenced by recent traffic.
+
+Run: python3 -m pytest tests/test_notification_template.py -v
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+_MIN_ENV = {
+    "SNS_TOPIC_ARN": "arn:aws:sns:us-east-1:123456789012:failover-alerts",
+    "AWS_REGION": "us-east-1",
+    "PRIMARY_REGION": "us-east-1",
+    "SECONDARY_REGION": "us-east-2",
+    "STATE_BACKEND": "dynamodb",
+    "STATE_TABLE": "failover-state",
+}
+
+for k, v in _MIN_ENV.items():
+    os.environ.setdefault(k, v)
+
+# Mock boto3 + state backend before importing the orchestrator (matches the
+# pattern in test_orchestrator.py / test_config_detection.py).
+_mock_boto3_patcher = patch("boto3.client")
+_mock_boto3_patcher.start().return_value = MagicMock()
+_mock_create_backend_patcher = patch("state_backend.create_backend")
+_mock_create_backend_patcher.start().return_value = MagicMock()
+
+import notifications  # noqa: E402
+import failover_orchestrator_v3 as orch  # noqa: E402
+
+_mock_boto3_patcher.stop()
+_mock_create_backend_patcher.stop()
+
+
+# ---------------------------------------------------------------------------
+# compose_message: required-field validation
+# ---------------------------------------------------------------------------
+
+def test_compose_rejects_invalid_severity():
+    with pytest.raises(ValueError, match="severity"):
+        notifications.compose_message(
+            severity="WHATEVER", what="x", why="y", next_step="z",
+        )
+
+
+@pytest.mark.parametrize("missing", ["what", "why", "next_step"])
+def test_compose_rejects_missing_required_field(missing):
+    """Empty required field is a programmer error — fail loudly, not silently."""
+    args = {
+        "severity": notifications.SEVERITY_WARNING,
+        "what": "ok",
+        "why": "ok",
+        "next_step": "ok",
+    }
+    args[missing] = ""
+    with pytest.raises(ValueError, match=missing):
+        notifications.compose_message(**args)
+
+
+@pytest.mark.parametrize("severity", [
+    notifications.SEVERITY_INFO,
+    notifications.SEVERITY_WARNING,
+    notifications.SEVERITY_CRITICAL,
+])
+def test_compose_accepts_all_three_severities(severity):
+    subject, _ = notifications.compose_message(
+        severity=severity, what="x", why="y", next_step="z",
+    )
+    assert subject.startswith(severity + ": ")
+
+
+# ---------------------------------------------------------------------------
+# compose_message: subject is bare "<SEVERITY>: <what>" (no env-app prefix)
+# ---------------------------------------------------------------------------
+
+def test_subject_does_not_include_env_app_prefix():
+    """Caller's _format_subject() handles the [ENVIRONMENT-APP_NAME] prefix."""
+    subject, _ = notifications.compose_message(
+        severity="WARNING",
+        what="Region us-west-1 reported its FIRST health failure (1 of 3)",
+        why="HTTP /healthcheck returned 503 from one of three configured signals.",
+        next_step="No action — system will retry.",
+    )
+    assert subject == "WARNING: Region us-west-1 reported its FIRST health failure (1 of 3)"
+    # No bracketed prefix here — that gets added by the Lambda's _format_subject.
+    assert not subject.startswith("[")
+
+
+# ---------------------------------------------------------------------------
+# compose_message: body sections in order
+# ---------------------------------------------------------------------------
+
+def _fixed_now():
+    return datetime(2026, 4, 25, 20, 30, 0, tzinfo=timezone.utc)
+
+
+def test_body_minimum_content_includes_what_why_next():
+    _, body = notifications.compose_message(
+        severity="WARNING",
+        what="Region us-west-1 unhealthy",
+        why="HTTP 503 from /healthcheck.",
+        next_step="No action.",
+        now=_fixed_now(),
+    )
+    # All three required headings present, in order.
+    what_idx = body.index("WHAT IS HAPPENING")
+    next_idx = body.index("WHAT TO DO NEXT")
+    assert what_idx < next_idx
+    assert "HTTP 503 from /healthcheck." in body
+    assert "No action." in body
+
+
+def test_body_renders_journey_when_provided():
+    _, body = notifications.compose_message(
+        severity="WARNING", what="x", why="y", next_step="z",
+        journey=[
+            "[1] First failure",
+            "[ ] Sustained",
+            "[ ] Failover",
+        ],
+        now=_fixed_now(),
+    )
+    assert "WHERE WE ARE IN THE INCIDENT" in body
+    assert "[1] First failure" in body
+    assert "[ ] Failover" in body
+
+
+def test_body_omits_journey_section_when_not_provided():
+    _, body = notifications.compose_message(
+        severity="WARNING", what="x", why="y", next_step="z",
+        now=_fixed_now(),
+    )
+    assert "WHERE WE ARE IN THE INCIDENT" not in body
+
+
+def test_body_renders_context_as_aligned_table():
+    _, body = notifications.compose_message(
+        severity="WARNING", what="x", why="y", next_step="z",
+        context={
+            "Active region": "us-west-1",
+            "Consecutive failures": "1 of 3",
+            "Last heartbeat": "2026-04-25T20:29:30Z",
+        },
+        now=_fixed_now(),
+    )
+    assert "CONTEXT" in body
+    # Labels left-padded to a common width — spot-check alignment.
+    assert "Active region" in body
+    assert "Consecutive failures" in body
+    # Each line uses " : " separator.
+    assert " : us-west-1" in body
+    assert " : 1 of 3" in body
+
+
+def test_body_omits_context_section_when_not_provided():
+    _, body = notifications.compose_message(
+        severity="WARNING", what="x", why="y", next_step="z",
+        now=_fixed_now(),
+    )
+    assert "CONTEXT" not in body
+
+
+# ---------------------------------------------------------------------------
+# compose_message: footer
+# ---------------------------------------------------------------------------
+
+def test_footer_contains_version_and_timestamp():
+    _, body = notifications.compose_message(
+        severity="WARNING", what="x", why="y", next_step="z",
+        version="v1.6", now=_fixed_now(),
+    )
+    assert "Vigil v1.6" in body
+    assert "2026-04-25T20:30:00+00:00" in body
+
+
+def test_footer_includes_source_and_region_when_provided():
+    _, body = notifications.compose_message(
+        severity="WARNING", what="x", why="y", next_step="z",
+        source="failover-orchestrator", region="us-west-1",
+        now=_fixed_now(),
+    )
+    assert "failover-orchestrator" in body
+    assert "region=us-west-1" in body
+
+
+def test_footer_omits_source_and_region_when_empty():
+    _, body = notifications.compose_message(
+        severity="WARNING", what="x", why="y", next_step="z",
+        source="", region="",
+        now=_fixed_now(),
+    )
+    # Footer should still have version + timestamp, but neither source nor region tokens.
+    assert "Vigil" in body
+    assert "region=" not in body
+
+
+# ---------------------------------------------------------------------------
+# Throttle reform on send_warning_notification
+# ---------------------------------------------------------------------------
+
+class TestWarningThrottleReform:
+    """v1.6 lowers the WARNING throttle to 5min and adds bypass_throttle=True."""
+
+    def test_default_cooldown_is_five_minutes(self):
+        """Default dropped from 10min → 5min in v1.6."""
+        assert orch.WARNING_NOTIFICATION_COOLDOWN_MINUTES == 5
+
+    @patch.object(orch, "sns")
+    @patch.object(orch, "update_failover_state")
+    def test_throttled_when_recent_warning_and_no_bypass(self, mock_update, mock_sns):
+        """Existing behavior: a recent warning suppresses the next one."""
+        recent = (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat()
+        state = {"last_warning_notification_ts": recent}
+
+        orch.send_warning_notification("WARNING: x", "body", state)
+
+        mock_sns.publish.assert_not_called()
+        mock_update.assert_not_called()
+
+    @patch.object(orch, "sns")
+    @patch.object(orch, "update_failover_state")
+    def test_bypass_throttle_sends_even_when_recent(self, mock_update, mock_sns):
+        """First-failure / retry-N / escalation notifications bypass the cooldown."""
+        recent = (datetime.now(timezone.utc) - timedelta(seconds=30)).isoformat()
+        state = {"last_warning_notification_ts": recent}
+
+        orch.send_warning_notification(
+            "WARNING: First failure", "body", state, bypass_throttle=True,
+        )
+
+        # SNS was called despite recent warning timestamp.
+        mock_sns.publish.assert_called_once()
+        # State update still happens (so subsequent throttled calls see fresh ts).
+        mock_update.assert_called_once()
+
+    @patch.object(orch, "sns")
+    @patch.object(orch, "update_failover_state")
+    def test_no_throttle_when_no_prior_warning(self, mock_update, mock_sns):
+        """The very first WARNING ever (epoch ts) always sends."""
+        state = {"last_warning_notification_ts": "1970-01-01T00:00:00Z"}
+
+        orch.send_warning_notification("WARNING: x", "body", state)
+
+        mock_sns.publish.assert_called_once()
+        mock_update.assert_called_once()
+
+    @patch.object(orch, "sns")
+    @patch.object(orch, "update_failover_state")
+    def test_no_throttle_after_cooldown_window(self, mock_update, mock_sns):
+        """After WARNING_NOTIFICATION_COOLDOWN_MINUTES elapse, next warning sends."""
+        long_ago = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+        state = {"last_warning_notification_ts": long_ago}
+
+        orch.send_warning_notification("WARNING: x", "body", state)
+
+        mock_sns.publish.assert_called_once()
+        mock_update.assert_called_once()


### PR DESCRIPTION
## Summary

PR2 of v1.6 — adds the structured-notification helper that PR3 will use to rewrite all 29 SNS call sites. Backwards-compatible: no existing call site changes behavior in this PR.

- New \`notifications.py\` with \`compose_message()\` helper. Body sections in order: WHAT IS HAPPENING / WHERE WE ARE IN THE INCIDENT (optional) / CONTEXT (optional) / WHAT TO DO NEXT.
- Required-field validation: \`what\`, \`why\`, \`next_step\` cannot be empty.
- Subject is bare \`<SEVERITY>: <what>\` — caller's \`_format_subject()\` adds the \`[ENVIRONMENT-APP_NAME]\` prefix from PR1.
- WARNING throttle default lowered 10→5 min. New \`bypass_throttle\` param so PR3 can mark first-failure / retry / escalation as must-deliver.
- CLAUDE.md updated for the new env vars and zip commands.

## Test plan

- [x] \`pytest tests/test_notification_template.py -v\` — 21 new cases pass
- [x] \`pytest tests/ -v\` — 328 passed (307 + 21 new), 0 regressions

## Stack

- Base: \`feature/v1.6-config-detection\` (#72)
- Builds on PR1 (#72) which added the ENVIRONMENT env var the new subject composer uses.
- Merge PR1 first, then this auto-rebases onto main.

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)