### PR TITLE
v1.6 PR3: rewrite all 29 SNS call sites with WHAT/WHY/JOURNEY/NEXT template

### DIFF
--- a/failover_orchestrator_v3.py
+++ b/failover_orchestrator_v3.py
@@ -1354,15 +1354,33 @@ def _handle_active_active(state: dict) -> dict:
                     reason="Health restored, region rejoining traffic pool",
                     severity="INFO",
                 )
-                send_notification(
-                    subject=f"RECOVERED: {CURRENT_REGION} healthy, rejoining traffic pool",
-                    message=(
-                        f"Region {CURRENT_REGION} has recovered and is publishing healthy.\n"
-                        f"Route 53 will resume routing traffic here based on latency.\n\n"
-                        f"Time: {now.isoformat()}\n"
-                        f"Previous failures: {consecutive_failures}\n"
+                subject, body = compose_message(
+                    severity=SEVERITY_INFO,
+                    what=f"Region {CURRENT_REGION} recovered — rejoining traffic pool",
+                    why=(
+                        f"After {consecutive_failures} failed health-check cycle(s), "
+                        f"region {CURRENT_REGION} is reporting healthy again. In "
+                        f"active-active mode this means Route 53 will resume "
+                        f"routing latency-based traffic here automatically."
                     ),
+                    next_step=(
+                        "No action required. Watch for sustained-failure WARNINGs "
+                        "in the next 5–10 minutes to verify the underlying issue "
+                        "is fully resolved."
+                    ),
+                    context={
+                        "Region": CURRENT_REGION,
+                        "Previous failure count": str(consecutive_failures),
+                        "Mode": "active-active",
+                    },
+                    journey=[
+                        f"[✓] Region {CURRENT_REGION} healthy",
+                        "[✓] Rejoined Route 53 traffic pool",
+                    ],
+                    source="failover-orchestrator",
+                    region=CURRENT_REGION,
                 )
+                send_notification(subject, body)
 
         publish_region_health_metric(CURRENT_REGION, True)
         return {"statusCode": 200, "body": "Region healthy"}
@@ -1376,17 +1394,57 @@ def _handle_active_active(state: dict) -> dict:
     if new_count < CONSECUTIVE_FAILURES_THRESHOLD:
         # Below threshold — still publishing healthy, send warning
         publish_region_health_metric(CURRENT_REGION, True)
-        send_warning_notification(
-            subject=f"WARNING: {CURRENT_REGION} degraded ({new_count}/{CONSECUTIVE_FAILURES_THRESHOLD})",
-            message=(
-                f"Region {CURRENT_REGION} health check failing.\n"
-                f"Consecutive failures: {new_count}/{CONSECUTIVE_FAILURES_THRESHOLD}\n"
-                f"Reason: {health.get('decision_reason', 'N/A')}\n\n"
-                f"If failures reach threshold, this region will be removed from the "
-                f"Route 53 traffic pool.\n"
-            ),
-            state=state,
+        is_first = new_count == 1
+        if is_first:
+            what = (
+                f"Region {CURRENT_REGION} (active-active) reported its FIRST "
+                f"health failure (1 of {CONSECUTIVE_FAILURES_THRESHOLD})"
+            )
+            why = (
+                f"{health.get('decision_reason', 'health check failed')}. "
+                f"Active-active mode: traffic is still flowing here based on "
+                f"Route 53 latency routing — this is the first failure of an incident."
+            )
+            next_step = (
+                f"No action required. The orchestrator will keep evaluating "
+                f"every 60s. If {CONSECUTIVE_FAILURES_THRESHOLD} consecutive "
+                f"failures occur and the cooldown has expired, this region will "
+                f"be removed from the traffic pool automatically."
+            )
+        else:
+            what = (
+                f"Region {CURRENT_REGION} (active-active) health failure "
+                f"{new_count} of {CONSECUTIVE_FAILURES_THRESHOLD} — sustained"
+            )
+            why = (
+                f"{health.get('decision_reason', 'health check failed')}. "
+                f"This is failure {new_count} in a row — one more and the "
+                f"region will be removed from the Route 53 traffic pool."
+            )
+            next_step = (
+                f"Investigate {CURRENT_REGION} now. If the next cycle (~60s) "
+                f"also fails, this region will be removed from the traffic pool."
+            )
+        subject, body = compose_message(
+            severity=SEVERITY_WARNING,
+            what=what,
+            why=why,
+            next_step=next_step,
+            context={
+                "Region": CURRENT_REGION,
+                "Mode": "active-active",
+                "Consecutive failures": f"{new_count} of {CONSECUTIVE_FAILURES_THRESHOLD}",
+                "Decision": health.get("decision_reason", "N/A"),
+            },
+            journey=[
+                f"[{'1' if is_first else '✓'}] First failure",
+                f"[{'→' if not is_first else ' '}] Sustained ({new_count}/{CONSECUTIVE_FAILURES_THRESHOLD})",
+                "[ ] Removed from traffic pool",
+            ],
+            source="failover-orchestrator",
+            region=CURRENT_REGION,
         )
+        send_warning_notification(subject, body, state, bypass_throttle=is_first)
         return {"statusCode": 200, "body": "Below threshold, monitoring"}
 
     # Threshold reached — check cooldown
@@ -1395,17 +1453,43 @@ def _handle_active_active(state: dict) -> dict:
         cooldown_window = timedelta(minutes=COOLDOWN_MINUTES)
         if now < last_ts + cooldown_window:
             remaining = (last_ts + cooldown_window - now).total_seconds()
+            remaining_min = remaining / 60
             logger.info(f"Cooldown active: {remaining:.0f}s remaining")
             publish_region_health_metric(CURRENT_REGION, True)
-            send_warning_notification(
-                subject=f"WARNING: {CURRENT_REGION} unhealthy but cooldown active",
-                message=(
-                    f"Health threshold reached but cooldown prevents marking unhealthy.\n"
-                    f"Cooldown remaining: {remaining:.0f}s\n"
-                    f"Reason: {health.get('decision_reason', 'N/A')}\n"
+            subject, body = compose_message(
+                severity=SEVERITY_WARNING,
+                what=(
+                    f"Region {CURRENT_REGION} (active-active) unhealthy but "
+                    f"removal blocked by cooldown ({remaining_min:.0f} min remaining)"
                 ),
-                state=state,
+                why=(
+                    f"{health.get('decision_reason', 'health check failed')}. "
+                    f"The {CONSECUTIVE_FAILURES_THRESHOLD}-failure threshold has "
+                    f"been reached, but a previous removal happened within the "
+                    f"{COOLDOWN_MINUTES}-minute cooldown so the orchestrator will "
+                    f"NOT remove {CURRENT_REGION} from the traffic pool right now."
+                ),
+                next_step=(
+                    f"Investigate {CURRENT_REGION} immediately — Route 53 is still "
+                    f"routing traffic here despite the unhealthy signal. If the "
+                    f"region cannot be restored before the cooldown expires (in "
+                    f"{remaining_min:.0f} min), it will be removed on the next cycle."
+                ),
+                context={
+                    "Region": CURRENT_REGION,
+                    "Mode": "active-active",
+                    "Cooldown remaining": f"{remaining_min:.0f} min",
+                    "Decision": health.get("decision_reason", "N/A"),
+                },
+                journey=[
+                    "[✓] First failure",
+                    f"[✓] Sustained ({CONSECUTIVE_FAILURES_THRESHOLD}/{CONSECUTIVE_FAILURES_THRESHOLD})",
+                    "[⏸] Cooldown — removal deferred",
+                ],
+                source="failover-orchestrator",
+                region=CURRENT_REGION,
             )
+            send_warning_notification(subject, body, state)
             return {"statusCode": 200, "body": "Cooldown active"}
     except (ValueError, TypeError):
         pass  # No valid last timestamp, proceed
@@ -1436,18 +1520,47 @@ def _handle_active_active(state: dict) -> dict:
         },
     )
 
-    send_notification(
-        subject=f"CRITICAL: {CURRENT_REGION} removed from traffic pool",
-        message=(
-            f"Region {CURRENT_REGION} has been marked unhealthy.\n"
-            f"Route 53 will stop routing traffic to this region.\n\n"
-            f"Reason: {health.get('decision_reason', 'N/A')}\n"
-            f"Consecutive failures: {new_count}\n"
-            f"Time: {now.isoformat()}\n\n"
-            f"The region will automatically rejoin the traffic pool when health is restored.\n"
-            f"No manual intervention required.\n"
-        ),
+    signals_brief = ", ".join(
+        f"{s['signal']}={'OK' if s.get('healthy') else 'FAIL'}"
+        for s in health.get("signals", [])
+        if not s.get("skipped")
     )
+    ctx = {
+        "Region": CURRENT_REGION,
+        "Mode": "active-active",
+        "Consecutive failures": str(new_count),
+        "Decision": health.get("decision_reason", "N/A"),
+    }
+    if signals_brief:
+        ctx["Health signals"] = signals_brief
+    subject, body = compose_message(
+        severity=SEVERITY_CRITICAL,
+        what=f"Region {CURRENT_REGION} removed from traffic pool (active-active)",
+        why=(
+            f"{health.get('decision_reason', 'health check failed')}. "
+            f"After {new_count} consecutive failures, the orchestrator marked "
+            f"{CURRENT_REGION} unhealthy. Route 53 will stop routing traffic here. "
+            f"Unlike active/passive failover, no latch is engaged: as soon as "
+            f"{CURRENT_REGION} reports healthy again, it will rejoin the pool "
+            f"automatically (no failback step needed)."
+        ),
+        next_step=(
+            f"Investigate the root cause in {CURRENT_REGION}. The region will "
+            f"auto-recover and rejoin the traffic pool on the next healthy cycle "
+            f"— no manual failback required. If you don't expect quick recovery, "
+            f"verify the *other* region is healthy (otherwise you have no traffic-"
+            f"serving region)."
+        ),
+        context=ctx,
+        journey=[
+            "[✓] Threshold reached",
+            "[✓] Region removed from traffic pool",
+            "[ ] Auto-rejoin when health restored",
+        ],
+        source="failover-orchestrator",
+        region=CURRENT_REGION,
+    )
+    send_notification(subject, body)
 
     return {"statusCode": 200, "body": "Region marked unhealthy, removed from pool"}
 
@@ -1823,41 +1936,91 @@ def _execute_manual_failover() -> dict:
             else:
                 manual_parts.append(build_elasticache_promotion_commands(target_region))
 
+        cfg = detect_data_tier_config()
+        ctx = {
+            "From region": active_region,
+            "To region": target_region,
+            "Trigger": "operator (manual execute_failover invoke)",
+        }
+        journey_lines = ["[✓] Operator invoked manual failover", "[✓] DNS moved"]
+        if cfg["aurora_present"]:
+            ctx["Aurora cluster"] = AURORA_CLUSTER_ID or "(local cluster)"
+            ctx["Aurora action"] = (
+                f"{aurora_result['method']} (auto, in progress)" if aurora_auto_done
+                else "MANUAL — see commands below"
+            )
+            journey_lines.append("[→] Aurora promoting" if aurora_auto_done
+                                  else "[→] Aurora — operator action required")
+        if cfg["redis_present"]:
+            ctx["ElastiCache action"] = (
+                "failover (auto, in progress)" if elasticache_auto_done
+                else "MANUAL — see commands below"
+            )
+            journey_lines.append("[→] Redis promoting" if elasticache_auto_done
+                                  else "[→] Redis — operator action required")
+
         if auto_parts and not manual_parts:
             # Everything auto-promoted
-            send_notification(
-                subject=f"FAILOVER EXECUTED: DNS moved to {target_region} - data tier promotion initiated",
-                message=(
-                    f"Manual failover executed by operator.\n\n"
-                    f"From: {active_region}\n"
-                    f"To: {target_region}\n"
-                    f"Time: {now.isoformat()}\n\n"
-                    f"DNS has been moved. Route 53 is now routing traffic to {target_region}.\n\n"
-                    + "\n".join(auto_parts) + "\n\n"
-                    f"Latch is ENGAGED. {active_region} will remain marked unhealthy."
-                ),
+            next_step = (
+                f"No immediate action — {' and '.join(auto_parts).lower()} The "
+                f"orchestrator will detect each tier's promotion and notify you "
+                f"when complete. The latch is ENGAGED — {active_region} stays "
+                f"marked unhealthy until you run failback manually."
             )
+            subject, body = compose_message(
+                severity=SEVERITY_CRITICAL,
+                what=f"Manual failover executed — DNS moved to {target_region}",
+                why=(
+                    f"Operator invoked the orchestrator with execute_failover=true "
+                    f"to move traffic from {active_region} to {target_region}. "
+                    f"All configured data tiers are auto-promoting in the "
+                    f"background."
+                ),
+                next_step=next_step,
+                context=ctx,
+                journey=journey_lines,
+                source="failover-orchestrator",
+                region=CURRENT_REGION,
+            )
+            send_notification(subject, body)
         else:
             # Some or all require manual action
-            subject_action = "PROMOTE DATA TIER NOW" if manual_parts else "promotion initiated"
-            send_notification(
-                subject=f"FAILOVER EXECUTED: DNS moved to {target_region} - {subject_action}",
-                message=(
-                    f"Manual failover executed by operator.\n\n"
-                    f"From: {active_region}\n"
-                    f"To: {target_region}\n"
-                    f"Time: {now.isoformat()}\n\n"
-                    f"DNS has been moved. Route 53 is now routing traffic to {target_region}.\n\n"
-                    + (("\n".join(auto_parts) + "\n\n") if auto_parts else "")
-                    + "ACTION REQUIRED: Manual promotion needed.\n"
-                    f"Your app in {target_region} CANNOT WRITE until promotion completes.\n\n"
-                    + "\n".join(manual_parts) + "\n\n"
-                    f"Latch is ENGAGED. {active_region} will remain marked unhealthy.\n"
-                    f"You will receive reminders every "
-                    f"{AURORA_PROMOTION_REMINDER_INTERVAL_MINUTES} minutes until "
-                    f"promotion is detected automatically."
-                ),
+            next_step_parts = []
+            if auto_parts:
+                next_step_parts.append(
+                    f"In flight automatically: {', '.join(auto_parts).lower()}."
+                )
+            next_step_parts.append(
+                f"**Operator action required.** App in {target_region} CANNOT "
+                f"WRITE to the data tier until promotion completes. Run the "
+                f"command(s) below."
             )
+            for i, m in enumerate(manual_parts, 1):
+                label = "Promote Aurora" if i == 1 and cfg["aurora_present"] and not aurora_auto_done \
+                        else "Promote ElastiCache"
+                next_step_parts.append(f"\n--- {label} ---\n{m}")
+            next_step_parts.append(
+                f"\nReminders fire every {AURORA_PROMOTION_REMINDER_INTERVAL_MINUTES} "
+                f"min until promotion is detected. Latch is ENGAGED — "
+                f"{active_region} stays unhealthy until you run failback."
+            )
+            subject, body = compose_message(
+                severity=SEVERITY_CRITICAL,
+                what=f"Manual failover executed — promote data tier in {target_region} now",
+                why=(
+                    f"Operator invoked the orchestrator with execute_failover=true. "
+                    f"DNS has moved to {target_region}, but at least one data tier "
+                    f"is configured for manual promotion (or its auto-promote "
+                    f"failed), so the operator must run promotion commands "
+                    f"before {target_region} can serve writes."
+                ),
+                next_step="\n".join(next_step_parts),
+                context=ctx,
+                journey=journey_lines,
+                source="failover-orchestrator",
+                region=CURRENT_REGION,
+            )
+            send_notification(subject, body)
 
         return {
             "statusCode": 200,
@@ -1872,14 +2035,35 @@ def _execute_manual_failover() -> dict:
             "aurora_promotion_pending": False,
             "redis_promotion_pending": False,
         })
-        send_notification(
-            subject=f"MANUAL FAILOVER FAILED: {active_region} -> {target_region}",
-            message=(
-                f"Manual failover FAILED.\n"
-                f"Error: {str(e)}\n"
-                f"Manual intervention required."
+        subject, body = compose_message(
+            severity=SEVERITY_CRITICAL,
+            what=f"Manual failover FAILED — {active_region} → {target_region} did not complete",
+            why=(
+                f"Operator invoked the orchestrator with execute_failover=true but "
+                f"the failover threw {type(e).__name__} during execution. State "
+                f"has been reverted to {expected_state}. Error: {e}"
             ),
+            next_step=(
+                "Inspect the Lambda's CloudWatch logs for the full traceback. "
+                "Common causes: state backend write failure, Aurora switchover-"
+                "global-cluster API error, or CW PutMetricData failure. Once the "
+                "root cause is fixed, re-invoke with execute_failover=true."
+            ),
+            context={
+                "From region": active_region,
+                "To region": target_region,
+                "Error type": type(e).__name__,
+                "Error detail": str(e)[:200],
+                "State after revert": expected_state,
+            },
+            journey=[
+                "[✓] Operator invoked manual failover",
+                "[✗] Execution FAILED — state reverted",
+            ],
+            source="failover-orchestrator",
+            region=CURRENT_REGION,
         )
+        send_notification(subject, body)
         raise
 
 
@@ -2497,24 +2681,44 @@ def _handle_passive_region(state: dict, active_region: str) -> dict:
                 aurora_result = _auto_promote_aurora(target_region, "region_failure")
                 if aurora_result["success"]:
                     aurora_handled = True
-                    send_notification(
-                        subject=f"REGION FAILURE: DNS moved to {target_region} - Aurora {aurora_result['method']} initiated (AI-advised)",
-                        message=(
-                            f"REGION-LEVEL FAILURE DETECTED.\n\n"
-                            f"The active region {active_region} has stopped responding.\n"
-                            f"DNS has been moved to {target_region}.\n\n"
-                            f"Aurora {aurora_result['method']} has been initiated AUTOMATICALLY "
-                            f"(AI advisor confidence: {advisor_rec.get('confidence')}%).\n"
-                            f"Monitor progress with:\n\n"
-                            f"  aws rds describe-db-clusters \\\n"
-                            f"    --db-cluster-identifier {AURORA_CLUSTER_ID} \\\n"
-                            f"    --query 'DBClusters[0].{{Status:Status,ReplicationSource:ReplicationSourceIdentifier}}' \\\n"
-                            f"    --region {target_region}\n\n"
-                            f"Time: {now.isoformat()}\n"
-                            f"Detection: {staleness['reason']}"
-                            f"{advisor_appendix}"
+                    confidence = advisor_rec.get("confidence")
+                    subject, body = compose_message(
+                        severity=SEVERITY_CRITICAL,
+                        what=f"Region failure — {active_region} unreachable, DNS moved to {target_region}",
+                        why=(
+                            f"The active region {active_region} stopped responding "
+                            f"({staleness['reason']}). The orchestrator's AI advisor "
+                            f"recommended an automatic Aurora {aurora_result['method']} "
+                            f"with {confidence}% confidence and executed it without "
+                            f"operator intervention."
                         ),
+                        next_step=(
+                            f"No immediate action. Aurora {aurora_result['method']} is "
+                            f"in flight. Monitor progress with:\n"
+                            f"  aws rds describe-db-clusters --db-cluster-identifier "
+                            f"{AURORA_CLUSTER_ID or '<cluster-id>'} "
+                            f"--query 'DBClusters[0].{{Status:Status,ReplicationSource:ReplicationSourceIdentifier}}' "
+                            f"--region {target_region}\n\n"
+                            f"Latch is ENGAGED. {active_region} stays unhealthy until "
+                            f"failback. Investigate why {active_region} went unresponsive "
+                            f"once recovery is complete."
+                        ),
+                        context={
+                            "Failed region": active_region,
+                            "Target region": target_region,
+                            "Detection": staleness["reason"],
+                            "Aurora action": f"{aurora_result['method']} (auto, AI-advised)",
+                            "AI confidence": f"{confidence}%",
+                        },
+                        journey=[
+                            "[✗] Active region unresponsive",
+                            "[✓] Passive detected via staleness check",
+                            "[→] Failover IN PROGRESS (AI-advised)",
+                        ],
+                        source="failover-orchestrator",
+                        region=CURRENT_REGION,
                     )
+                    send_notification(subject, body + (advisor_appendix or ""))
                 else:
                     logger.warning(
                         f"AI-advised Aurora promotion failed: {aurora_result['error']}. "
@@ -2524,23 +2728,42 @@ def _handle_passive_region(state: dict, active_region: str) -> dict:
                 aurora_result = _auto_promote_aurora(target_region, "region_failure")
                 if aurora_result["success"]:
                     aurora_handled = True
-                    send_notification(
-                        subject=f"REGION FAILURE: DNS moved to {target_region} - Aurora {aurora_result['method']} initiated",
-                        message=(
-                            f"REGION-LEVEL FAILURE DETECTED.\n\n"
-                            f"The active region {active_region} has stopped responding.\n"
-                            f"DNS has been moved to {target_region}.\n\n"
-                            f"Aurora {aurora_result['method']} has been initiated AUTOMATICALLY.\n"
-                            f"Monitor progress with:\n\n"
-                            f"  aws rds describe-db-clusters \\\n"
-                            f"    --db-cluster-identifier {AURORA_CLUSTER_ID} \\\n"
-                            f"    --query 'DBClusters[0].{{Status:Status,ReplicationSource:ReplicationSourceIdentifier}}' \\\n"
-                            f"    --region {target_region}\n\n"
-                            f"Time: {now.isoformat()}\n"
-                            f"Detection: {staleness['reason']}"
-                            f"{advisor_appendix}"
+                    subject, body = compose_message(
+                        severity=SEVERITY_CRITICAL,
+                        what=f"Region failure — {active_region} unreachable, DNS moved to {target_region}",
+                        why=(
+                            f"The active region {active_region} stopped responding "
+                            f"({staleness['reason']}). DNS has been moved to "
+                            f"{target_region} and Aurora {aurora_result['method']} "
+                            f"was triggered automatically per AURORA_AUTO_PROMOTE=true."
                         ),
+                        next_step=(
+                            f"No immediate action. Aurora {aurora_result['method']} is "
+                            f"in flight. Monitor with:\n"
+                            f"  aws rds describe-db-clusters --db-cluster-identifier "
+                            f"{AURORA_CLUSTER_ID or '<cluster-id>'} "
+                            f"--query 'DBClusters[0].{{Status:Status,ReplicationSource:ReplicationSourceIdentifier}}' "
+                            f"--region {target_region}\n\n"
+                            f"Latch is ENGAGED. Investigate why {active_region} went "
+                            f"unresponsive — region-level outages are unusual and "
+                            f"warrant deeper investigation than app-level failures."
+                        ),
+                        context={
+                            "Failed region": active_region,
+                            "Target region": target_region,
+                            "Detection": staleness["reason"],
+                            "Aurora action": f"{aurora_result['method']} (auto, in progress)",
+                        },
+                        journey=[
+                            "[✗] Active region unresponsive",
+                            "[✓] Passive detected via staleness check",
+                            "[→] Failover IN PROGRESS",
+                            "[→] Aurora promoting",
+                        ],
+                        source="failover-orchestrator",
+                        region=CURRENT_REGION,
                     )
+                    send_notification(subject, body + (advisor_appendix or ""))
                 else:
                     logger.warning(
                         f"Auto Aurora promotion failed: {aurora_result['error']}. "
@@ -2555,41 +2778,102 @@ def _handle_passive_region(state: dict, active_region: str) -> dict:
 
             if not aurora_handled:
                 # Manual Aurora promotion (default, or auto-promote failed)
-                aurora_commands = build_aurora_promotion_commands(
-                    target_region, "region_failure"
+                cfg = detect_data_tier_config()
+                aurora_commands = (
+                    build_aurora_promotion_commands(target_region, "region_failure")
+                    if cfg["aurora_present"] else ""
                 )
-                elasticache_commands = build_elasticache_promotion_commands(target_region)
+                elasticache_commands = (
+                    build_elasticache_promotion_commands(target_region)
+                    if cfg["redis_present"] else ""
+                )
+                next_step_parts = [
+                    f"DNS has moved to {target_region} but the data tier needs "
+                    f"manual promotion. App in {target_region} CANNOT WRITE until "
+                    f"you complete the steps below."
+                ]
+                if aurora_commands:
+                    next_step_parts.append("\n--- Step 1: Promote Aurora ---\n" + aurora_commands)
+                if elasticache_commands:
+                    n = 2 if aurora_commands else 1
+                    next_step_parts.append(f"\n--- Step {n}: Promote ElastiCache ---\n" + elasticache_commands)
+                next_step_parts.append(
+                    f"\nReminders fire every {AURORA_PROMOTION_REMINDER_INTERVAL_MINUTES} "
+                    f"min. Latch is ENGAGED. **Investigate why {active_region} went "
+                    f"unresponsive** — region-level outages are unusual."
+                )
 
-                send_notification(
-                    subject=f"REGION FAILURE: DNS moved to {target_region} - PROMOTE DATA TIER NOW",
-                    message=(
-                        f"REGION-LEVEL FAILURE DETECTED.\n\n"
-                        f"The active region {active_region} has stopped responding.\n"
-                        f"DNS has been moved to {target_region}.\n\n"
-                        f"ACTION REQUIRED: Data tier must be promoted MANUALLY.\n"
-                        f"Your app in {target_region} CANNOT WRITE until promotion completes.\n\n"
-                        f"Time: {now.isoformat()}\n"
-                        f"Detection: {staleness['reason']}\n\n"
-                        f"{aurora_commands}\n"
-                        f"{elasticache_commands}\n\n"
-                        f"You will receive reminders every "
-                        f"{AURORA_PROMOTION_REMINDER_INTERVAL_MINUTES} minutes until "
-                        f"promotion is detected automatically."
-                        f"{advisor_appendix}"
+                journey_lines = [
+                    "[✗] Active region unresponsive",
+                    "[✓] Passive detected via staleness check",
+                    "[✓] Failover (DNS moved)",
+                ]
+                if cfg["aurora_present"]:
+                    journey_lines.append("[→] Aurora — operator action required")
+                if cfg["redis_present"]:
+                    journey_lines.append("[→] Redis — operator action required")
+
+                ctx = {
+                    "Failed region": active_region,
+                    "Target region": target_region,
+                    "Detection": staleness["reason"],
+                }
+                if cfg["aurora_present"]:
+                    ctx["Aurora action"] = "MANUAL — see commands below"
+                if cfg["redis_present"]:
+                    ctx["ElastiCache action"] = "MANUAL — see commands below"
+
+                subject, body = compose_message(
+                    severity=SEVERITY_CRITICAL,
+                    what=f"Region failure — {active_region} down, promote data tier in {target_region}",
+                    why=(
+                        f"The active region {active_region} stopped responding "
+                        f"({staleness['reason']}). DNS was moved to {target_region}, "
+                        f"but data-tier auto-promote is disabled (or it failed) so "
+                        f"the operator must run promotion commands now."
                     ),
+                    next_step="\n".join(next_step_parts),
+                    context=ctx,
+                    journey=journey_lines,
+                    source="failover-orchestrator",
+                    region=CURRENT_REGION,
                 )
+                send_notification(subject, body + (advisor_appendix or ""))
 
         except Exception as e:
             logger.error(f"Passive region failover handling FAILED: {e}")
-            send_notification(
-                subject=f"FAILOVER HANDLING FAILED in passive region",
-                message=(
-                    f"Region {active_region} appears down but failover handling "
-                    f"in {CURRENT_REGION} FAILED.\n\n"
-                    f"Error: {str(e)}\n\n"
-                    f"MANUAL INTERVENTION REQUIRED."
+            subject, body = compose_message(
+                severity=SEVERITY_CRITICAL,
+                what=f"Region failover handling FAILED in passive region {CURRENT_REGION}",
+                why=(
+                    f"The passive Lambda in {CURRENT_REGION} detected that "
+                    f"{active_region} was unresponsive and attempted to claim "
+                    f"failover, but the handler threw {type(e).__name__}: {e}"
                 ),
+                next_step=(
+                    f"**MANUAL INTERVENTION REQUIRED.** Inspect the passive "
+                    f"Lambda's CloudWatch logs in {CURRENT_REGION} for the full "
+                    f"traceback. Both regions may now be in inconsistent state — "
+                    f"verify Aurora writer location, ElastiCache primary, and "
+                    f"Route 53 failover record state before taking any action. "
+                    f"Likely causes: state backend write failure, IAM permission "
+                    f"issue, or cross-region API outage."
+                ),
+                context={
+                    "Failed region": active_region,
+                    "Passive region (this Lambda)": CURRENT_REGION,
+                    "Error type": type(e).__name__,
+                    "Error detail": str(e)[:200],
+                },
+                journey=[
+                    "[✗] Active region unresponsive",
+                    "[✓] Passive detected via staleness check",
+                    "[✗] Failover handling FAILED — manual recovery needed",
+                ],
+                source="failover-orchestrator",
+                region=CURRENT_REGION,
             )
+            send_notification(subject, body)
             raise
 
         # Failover claimed and handled successfully. Return immediately.
@@ -3052,27 +3336,57 @@ def _handle_active_region(state: dict, active_region: str,
             aurora_result = _auto_promote_aurora(target_region, "app_failure")
             if aurora_result["success"]:
                 aurora_handled = True
-                send_notification(
-                    subject=f"FAILOVER: DNS moved to {target_region} - Aurora {aurora_result['method']} initiated (AI-advised)",
-                    message=(
-                        f"Automated DNS failover triggered.\n\n"
-                        f"From: {active_region}\n"
-                        f"To: {target_region}\n"
-                        f"Time: {now.isoformat()}\n"
-                        f"Decision: {health.get('decision_reason', 'N/A')}\n\n"
-                        f"DNS has been moved. Route 53 is now routing traffic to {target_region}.\n\n"
-                        f"Aurora {aurora_result['method']} has been initiated AUTOMATICALLY "
-                        f"(AI advisor confidence: {advisor_rec.get('confidence')}%).\n"
-                        f"Monitor progress with:\n\n"
-                        f"  aws rds describe-db-clusters \\\n"
-                        f"    --db-cluster-identifier {AURORA_CLUSTER_ID} \\\n"
-                        f"    --query 'DBClusters[0].{{Status:Status,ReplicationSource:ReplicationSourceIdentifier}}' \\\n"
-                        f"    --region {target_region}\n\n"
-                        f"Latch is ENGAGED. {active_region} will remain marked unhealthy.\n\n"
-                        f"Signals:\n{json.dumps(health['signals'], indent=2, default=str)}"
-                        f"{ai_appendix}"
-                    ),
+                cfg = detect_data_tier_config()
+                confidence = advisor_rec.get("confidence")
+                journey_lines = ["[✓] Threshold reached", "[→] Failover IN PROGRESS"]
+                if cfg["aurora_present"]:
+                    journey_lines.append("[→] Aurora promoting (AI-advised)")
+                if cfg["redis_present"]:
+                    journey_lines.append("[→] Redis promoting" if cfg["redis_auto"]
+                                          else "[ ] Redis (manual — operator)")
+                ctx = {
+                    "From region": active_region,
+                    "To region": target_region,
+                    "Decision": health.get("decision_reason", "N/A"),
+                    "Aurora cluster": AURORA_CLUSTER_ID or "(not configured)",
+                    "Aurora action": f"{aurora_result['method']} (auto, AI-advised)",
+                    "AI confidence": f"{confidence}%",
+                }
+                signals_brief = ", ".join(
+                    f"{s['signal']}={'OK' if s.get('healthy') else 'FAIL'}"
+                    for s in health.get("signals", [])
+                    if not s.get("skipped")
                 )
+                if signals_brief:
+                    ctx["Health signals"] = signals_brief
+                next_step = (
+                    f"No immediate action. Aurora {aurora_result['method']} is "
+                    f"in flight (AI advisor recommended this method with "
+                    f"{confidence}% confidence). Monitor with:\n"
+                    f"  aws rds describe-db-clusters --db-cluster-identifier "
+                    f"{AURORA_CLUSTER_ID or '<cluster-id>'} "
+                    f"--query 'DBClusters[0].{{Status:Status,ReplicationSource:ReplicationSourceIdentifier}}' "
+                    f"--region {target_region}\n\n"
+                    f"Latch is ENGAGED. {active_region} stays unhealthy until "
+                    f"failback."
+                )
+                subject, body = compose_message(
+                    severity=SEVERITY_CRITICAL,
+                    what=f"Failover triggered (AI-advised) — {active_region} → {target_region}",
+                    why=(
+                        f"{health.get('decision_reason', 'health check failed')}. "
+                        f"Threshold reached and cooldown expired. The Aurora AI "
+                        f"advisor (mode=guided/autonomous) recommended a "
+                        f"{aurora_result['method']} with {confidence}% confidence "
+                        f"and the orchestrator executed it automatically."
+                    ),
+                    next_step=next_step + (ai_appendix or ""),
+                    context=ctx,
+                    journey=journey_lines,
+                    source="failover-orchestrator",
+                    region=CURRENT_REGION,
+                )
+                send_notification(subject, body)
             else:
                 logger.warning(
                     f"AI-advised Aurora promotion failed: {aurora_result['error']}. "
@@ -3243,23 +3557,52 @@ def _handle_active_region(state: dict, active_region: str,
 
     except Exception as e:
         logger.error(f"FAILOVER FAILED: {e}")
+        revert_state = (
+            "PRIMARY_ACTIVE" if active_region == PRIMARY_REGION
+            else "SECONDARY_ACTIVE"
+        )
         update_failover_state({
-            "state": (
-                "PRIMARY_ACTIVE"
-                if active_region == PRIMARY_REGION
-                else "SECONDARY_ACTIVE"
-            ),
+            "state": revert_state,
             "consecutive_failures": 0,
             "aurora_promotion_pending": False,
             "redis_promotion_pending": False,
         })
-        send_notification(
-            subject=f"FAILOVER FAILED: {active_region} -> {target_region}",
-            message=(
-                f"DNS failover FAILED.\n"
-                f"Error: {str(e)}\n"
-                f"Manual intervention required.\n\n"
-                f"State has been reset. Orchestrator will re-evaluate next cycle."
+        subject, body = compose_message(
+            severity=SEVERITY_CRITICAL,
+            what=f"Auto-failover FAILED — {active_region} → {target_region} did not complete",
+            why=(
+                f"The orchestrator detected sustained failures in {active_region} "
+                f"and attempted an automatic DNS failover, but the failover "
+                f"handler threw {type(e).__name__} during execution. State has "
+                f"been reverted to {revert_state}. Error: {e}"
             ),
+            next_step=(
+                f"**Manual intervention required.** Inspect the orchestrator "
+                f"Lambda's CloudWatch logs in {CURRENT_REGION} for the full "
+                f"traceback. The orchestrator will re-evaluate health on the "
+                f"next 60s cycle and try again — but if the underlying issue "
+                f"causes the same exception, you'll get another FAILED email. "
+                f"Common causes: state backend write failure (IAM/connectivity), "
+                f"Aurora switchover-global-cluster API error, or CW PutMetricData "
+                f"failure. If {active_region} cannot be restored quickly, "
+                f"consider invoking the failover Lambda directly with "
+                f"`{{\"execute_failover\": true}}` once the underlying error "
+                f"is resolved."
+            ),
+            context={
+                "From region": active_region,
+                "To region": target_region,
+                "Error type": type(e).__name__,
+                "Error detail": str(e)[:200],
+                "State after revert": revert_state,
+            },
+            journey=[
+                "[✓] Threshold reached",
+                "[✗] Failover handler FAILED — state reverted",
+                "[ ] Will retry on next cycle",
+            ],
+            source="failover-orchestrator",
+            region=CURRENT_REGION,
         )
+        send_notification(subject, body)
         raise

--- a/failover_orchestrator_v3.py
+++ b/failover_orchestrator_v3.py
@@ -1533,14 +1533,19 @@ def detect_data_tier_config() -> dict:
     (redis ∈ {absent, manual, auto}) cover all supported deployments
     from app-only stacks (C1) to fully automated dual-tier (C9).
 
-    Read at invocation time — do not cache; the portal can flip these
-    env vars between cycles. Call after _reload_dynamic_config().
+    Reads os.environ directly (not module globals) so portal env-var
+    flips and per-test patch.dict overrides take effect immediately
+    without depending on _reload_dynamic_config() ordering.
     """
+    aurora_id = os.environ.get("AURORA_CLUSTER_ID", "")
+    redis_id = os.environ.get("ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", "")
+    aurora_auto = os.environ.get("AURORA_AUTO_PROMOTE", "false").lower() == "true"
+    redis_auto = os.environ.get("ELASTICACHE_AUTO_PROMOTE", "false").lower() == "true"
     return {
-        "aurora_present": bool(AURORA_CLUSTER_ID),
-        "aurora_auto":    bool(AURORA_CLUSTER_ID) and AURORA_AUTO_PROMOTE,
-        "redis_present":  bool(ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID),
-        "redis_auto":     bool(ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID) and ELASTICACHE_AUTO_PROMOTE,
+        "aurora_present": bool(aurora_id),
+        "aurora_auto":    bool(aurora_id) and aurora_auto,
+        "redis_present":  bool(redis_id),
+        "redis_auto":     bool(redis_id) and redis_auto,
     }
 
 
@@ -3003,30 +3008,90 @@ def _handle_active_region(state: dict, active_region: str,
 
         if not aurora_handled:
             # Manual Aurora promotion (default, or auto-promote failed)
-            aurora_commands = build_aurora_promotion_commands(target_region, "app_failure")
-            elasticache_commands = build_elasticache_promotion_commands(target_region)
-
-            send_notification(
-                subject=f"FAILOVER: DNS moved to {target_region} - PROMOTE DATA TIER NOW",
-                message=(
-                    f"Automated DNS failover triggered.\n\n"
-                    f"From: {active_region}\n"
-                    f"To: {target_region}\n"
-                    f"Time: {now.isoformat()}\n"
-                    f"Decision: {health.get('decision_reason', 'N/A')}\n\n"
-                    f"DNS has been moved. Route 53 is now routing traffic to {target_region}.\n\n"
-                    f"ACTION REQUIRED: Data tier must be promoted MANUALLY.\n"
-                    f"Your app in {target_region} CANNOT WRITE until promotion completes.\n\n"
-                    f"{aurora_commands}\n"
-                    f"{elasticache_commands}\n\n"
-                    f"Latch is ENGAGED. {active_region} will remain marked unhealthy.\n"
-                    f"You will receive reminders every "
-                    f"{AURORA_PROMOTION_REMINDER_INTERVAL_MINUTES} minutes until "
-                    f"promotion is detected automatically.\n\n"
-                    f"Signals:\n{json.dumps(health['signals'], indent=2, default=str)}"
-                    f"{ai_appendix}"
-                ),
+            cfg = detect_data_tier_config()
+            aurora_commands = (
+                build_aurora_promotion_commands(target_region, "app_failure")
+                if cfg["aurora_present"] else ""
             )
+            elasticache_commands = (
+                build_elasticache_promotion_commands(target_region)
+                if cfg["redis_present"] else ""
+            )
+
+            # Journey reflects which manual steps the operator must do.
+            journey_lines = ["[✓] Threshold reached", "[✓] Failover (DNS moved)"]
+            if cfg["aurora_present"] and not cfg["aurora_auto"]:
+                journey_lines.append("[→] Aurora — operator action required")
+            elif cfg["aurora_present"]:
+                journey_lines.append("[→] Aurora — auto-promote attempted but failed")
+            if cfg["redis_present"] and not cfg["redis_auto"]:
+                journey_lines.append("[→] Redis — operator action required")
+            elif cfg["redis_present"]:
+                journey_lines.append("[→] Redis — auto-promote attempted but failed")
+            journey_lines.append("[ ] Latch released (after failback)")
+
+            ctx = {
+                "From region": active_region,
+                "To region": target_region,
+                "Decision": health.get("decision_reason", "N/A"),
+            }
+            if cfg["aurora_present"]:
+                ctx["Aurora cluster"] = AURORA_CLUSTER_ID or "(local cluster)"
+                ctx["Aurora action"] = (
+                    "MANUAL — promotion required (see commands below)"
+                    if not cfg["aurora_auto"]
+                    else "auto-promote FAILED — manual recovery required"
+                )
+            if cfg["redis_present"]:
+                ctx["ElastiCache RG"] = ELASTICACHE_REPLICATION_GROUP_ID or "(local RG)"
+                ctx["ElastiCache action"] = (
+                    "MANUAL — failover required (see commands below)"
+                    if not cfg["redis_auto"]
+                    else "auto-failover FAILED — manual recovery required"
+                )
+            signals_brief = ", ".join(
+                f"{s['signal']}={'OK' if s.get('healthy') else 'FAIL'}"
+                for s in health.get("signals", [])
+                if not s.get("skipped")
+            )
+            if signals_brief:
+                ctx["Health signals"] = signals_brief
+
+            # next_step embeds the actual CLI commands so the operator can
+            # copy/paste from the email without leaving the inbox.
+            next_step_parts = [
+                f"DNS has moved to {target_region} but the data tier is NOT ready. "
+                f"Your app in {target_region} CANNOT WRITE until you complete the steps below."
+            ]
+            if aurora_commands:
+                next_step_parts.append("\n--- Step 1: Promote Aurora ---\n" + aurora_commands)
+            if elasticache_commands:
+                step_n = 2 if aurora_commands else 1
+                next_step_parts.append(f"\n--- Step {step_n}: Promote ElastiCache ---\n" + elasticache_commands)
+            next_step_parts.append(
+                f"\nThe orchestrator polls every minute and will detect promotion automatically. "
+                f"You will receive a confirmation email per tier when each completes. The latch "
+                f"is ENGAGED — {active_region} stays marked unhealthy until you run failback."
+            )
+            next_step = "\n".join(next_step_parts) + (ai_appendix or "")
+
+            subject, body = compose_message(
+                severity=SEVERITY_CRITICAL,
+                what=f"Failover triggered — promote data tier in {target_region} now",
+                why=(
+                    f"{health.get('decision_reason', 'health check failed')}. "
+                    f"DNS was moved automatically but data-tier auto-promote is "
+                    f"disabled (or failed), so the operator must promote Aurora "
+                    f"and/or ElastiCache manually before the new active region "
+                    f"can serve writes."
+                ),
+                next_step=next_step,
+                context=ctx,
+                journey=journey_lines,
+                source="failover-orchestrator",
+                region=CURRENT_REGION,
+            )
+            send_notification(subject, body)
 
         return {
             "statusCode": 200,

--- a/failover_orchestrator_v3.py
+++ b/failover_orchestrator_v3.py
@@ -2018,17 +2018,42 @@ def _handle_aurora_promotion_reminder(state: dict) -> dict:
     # Aurora not yet promoted - send periodic reminders
     # -----------------------------------------------------------------
     if int(minutes_since_failover) % AURORA_PROMOTION_REMINDER_INTERVAL_MINUTES == 0:
-        failed_region = PRIMARY_REGION if active_region == SECONDARY_REGION else SECONDARY_REGION
-
-        send_notification(
-            subject=f"REMINDER: Aurora promotion still pending ({int(minutes_since_failover)}m)",
-            message=(
-                f"DNS failover to {active_region} occurred {int(minutes_since_failover)} "
-                f"minutes ago but Aurora has NOT been promoted yet.\n\n"
-                f"Your app in {active_region} CANNOT WRITE to the database.\n\n"
-                f"{build_aurora_promotion_commands(active_region, 'app_failure')}"
-            ),
+        elapsed = int(minutes_since_failover)
+        cmds = build_aurora_promotion_commands(active_region, "app_failure")
+        next_step = (
+            f"Promote Aurora to {active_region} now using the commands below. "
+            f"Until you do, every write attempt against the database will fail. "
+            f"The orchestrator polls every minute and will detect promotion "
+            f"automatically — you'll receive a confirmation email and this "
+            f"reminder will stop firing.\n\n{cmds}"
         )
+        subject, body = compose_message(
+            severity=SEVERITY_CRITICAL,
+            what=f"Aurora promotion still pending after {elapsed} min — operator action required",
+            why=(
+                f"DNS failover to {active_region} occurred {elapsed} minutes ago "
+                f"but the Aurora Global Database has not been promoted to "
+                f"{active_region} yet. Until promotion completes, the app in "
+                f"{active_region} CANNOT WRITE to the database. This reminder "
+                f"will fire every {AURORA_PROMOTION_REMINDER_INTERVAL_MINUTES} "
+                f"minutes until promotion is detected."
+            ),
+            next_step=next_step,
+            context={
+                "Active region": active_region,
+                "Aurora cluster": AURORA_CLUSTER_ID or "(local cluster)",
+                "Time since failover": f"{elapsed} min",
+                "Reminder interval": f"every {AURORA_PROMOTION_REMINDER_INTERVAL_MINUTES} min",
+            },
+            journey=[
+                "[✓] Failover (DNS moved)",
+                "[→] Aurora — operator action required",
+                "[ ] Latch released (after failback)",
+            ],
+            source="failover-orchestrator",
+            region=CURRENT_REGION,
+        )
+        send_notification(subject, body)
 
     # Keep publishing ourselves as healthy for Route 53.
     # The failed region's metric is handled by the CW alarm's TreatMissingData=breaching
@@ -2112,15 +2137,42 @@ def _handle_elasticache_promotion_reminder(state: dict) -> dict:
 
     # ElastiCache not yet promoted - send periodic reminders
     if int(minutes_since_failover) % AURORA_PROMOTION_REMINDER_INTERVAL_MINUTES == 0:
-        send_notification(
-            subject=f"REMINDER: ElastiCache promotion still pending ({int(minutes_since_failover)}m)",
-            message=(
-                f"DNS failover to {active_region} occurred {int(minutes_since_failover)} "
-                f"minutes ago but ElastiCache has NOT been promoted yet.\n\n"
-                f"Your app in {active_region} CANNOT WRITE to Redis.\n\n"
-                f"{build_elasticache_promotion_commands(active_region)}"
-            ),
+        elapsed = int(minutes_since_failover)
+        cmds = build_elasticache_promotion_commands(active_region)
+        next_step = (
+            f"Promote ElastiCache to {active_region} now using the commands below. "
+            f"Until you do, every cache operation against the current writer will "
+            f"go cross-region (or fail). The orchestrator polls every minute and "
+            f"will detect promotion automatically — you'll receive a confirmation "
+            f"email and this reminder will stop firing.\n\n{cmds}"
         )
+        subject, body = compose_message(
+            severity=SEVERITY_CRITICAL,
+            what=f"ElastiCache promotion still pending after {elapsed} min — operator action required",
+            why=(
+                f"DNS failover to {active_region} occurred {elapsed} minutes ago "
+                f"but the ElastiCache Global Datastore has not been promoted to "
+                f"{active_region} yet. Until promotion completes, the app in "
+                f"{active_region} CANNOT WRITE to Redis locally. This reminder "
+                f"will fire every {AURORA_PROMOTION_REMINDER_INTERVAL_MINUTES} "
+                f"minutes until promotion is detected."
+            ),
+            next_step=next_step,
+            context={
+                "Active region": active_region,
+                "ElastiCache RG": ELASTICACHE_REPLICATION_GROUP_ID or "(local RG)",
+                "Time since failover": f"{elapsed} min",
+                "Reminder interval": f"every {AURORA_PROMOTION_REMINDER_INTERVAL_MINUTES} min",
+            },
+            journey=[
+                "[✓] Failover (DNS moved)",
+                "[→] Redis — operator action required",
+                "[ ] Latch released (after failback)",
+            ],
+            source="failover-orchestrator",
+            region=CURRENT_REGION,
+        )
+        send_notification(subject, body)
 
     return {"statusCode": 200, "body": "Waiting for ElastiCache promotion"}
 
@@ -2571,17 +2623,49 @@ def _handle_passive_region(state: dict, active_region: str) -> dict:
 
     if not our_health["healthy"]:
         logger.warning(f"PASSIVE region {CURRENT_REGION} is NOT healthy!")
-        send_warning_notification(
-            subject=f"WARNING: Passive region {CURRENT_REGION} unhealthy",
-            message=(
-                f"The passive/standby region {CURRENT_REGION} is reporting unhealthy.\n"
-                f"If the active region ({active_region}) fails, failover will route traffic "
-                f"to an unhealthy region.\n\n"
-                f"Decision: {our_health.get('decision_reason', 'N/A')}\n"
-                f"Signals:\n{json.dumps(our_health['signals'], indent=2, default=str)}"
-            ),
-            state=state,
+        signals_brief = ", ".join(
+            f"{s['signal']}={'OK' if s.get('healthy') else 'FAIL'}"
+            for s in our_health.get("signals", [])
+            if not s.get("skipped")
         )
+        ctx = {
+            "Active region": active_region,
+            "Standby region (this Lambda)": CURRENT_REGION,
+            "Standby decision": our_health.get("decision_reason", "N/A"),
+        }
+        if signals_brief:
+            ctx["Standby signals"] = signals_brief
+        next_step = (
+            f"Investigate {CURRENT_REGION} now — even though traffic is still "
+            f"flowing to {active_region}, you have lost your failover safety net. "
+            f"If {active_region} fails right now, the orchestrator's dual-region "
+            f"circuit breaker will HALT failover (better to keep app down in one "
+            f"region than route to two unhealthy regions). Common causes: ECS "
+            f"deploy in progress in standby, ALB target group config issue, or "
+            f"the standby region's app was never wired to a healthcheck endpoint "
+            f"that returns 200 when warm."
+        )
+        subject, body = compose_message(
+            severity=SEVERITY_WARNING,
+            what=f"Standby region {CURRENT_REGION} is unhealthy — failover would be unsafe",
+            why=(
+                f"The standby region {CURRENT_REGION} is reporting unhealthy "
+                f"({our_health.get('decision_reason', 'health check failed')}). "
+                f"Traffic is still flowing normally to {active_region}, but the "
+                f"failover safety net is gone — if {active_region} fails before "
+                f"this is fixed, the orchestrator will refuse to fail over."
+            ),
+            next_step=next_step,
+            context=ctx,
+            journey=[
+                "[ ] Active region: serving (no failure detected)",
+                f"[⚠] Standby region {CURRENT_REGION}: UNHEALTHY",
+                "[⏸] Failover safety net DOWN until standby recovers",
+            ],
+            source="failover-orchestrator",
+            region=CURRENT_REGION,
+        )
+        send_warning_notification(subject, body, state)
 
     return {"statusCode": 200, "body": "Passive region check complete"}
 
@@ -2795,19 +2879,49 @@ def _handle_active_region(state: dict, active_region: str,
             f"{'UNHEALTHY' if not peer_healthy else 'STALE'}. Halting failover."
         )
         publish_region_health_metric(CURRENT_REGION, True)  # Desperate attempt to keep DNS somewhere
-        send_notification(
-            subject=f"CRITICAL: Dual-Region Outage Detected ({APP_NAME})",
-            message=(
-                f"Region {CURRENT_REGION} has hit the failover threshold, BUT "
-                f"the target region {target_region} is ALSO unhealthy.\n\n"
-                f"Failover has been HALTED to prevent an infinite loop.\n"
-                f"Manual intervention is REQUIRED immediately.\n\n"
-                f"Current region health: UNHEALTHY\n"
-                f"Target region ({target_region}) health: "
-                f"{'UNHEALTHY' if not peer_healthy else 'STALE (Last heartbeat: ' + peer_ts_str + ')'}\n\n"
-                f"Decision: {health.get('decision_reason', 'N/A')}"
-            ),
+        peer_state = "UNHEALTHY" if not peer_healthy else f"STALE (last heartbeat: {peer_ts_str})"
+        next_step = (
+            "**APP IS DOWN.** This is NOT a failover candidate — moving DNS to "
+            f"{target_region} would route traffic to a region that also cannot "
+            "serve it. Steps:\n"
+            "  1. Page the on-call DBA and SRE immediately.\n"
+            f"  2. Investigate {CURRENT_REGION} (current decision below) AND "
+            f"{target_region} (peer is {('unhealthy' if not peer_healthy else 'stale heartbeat')}).\n"
+            "  3. Check Aurora, ElastiCache, and any cross-region dependencies — "
+            "a shared-fate failure (e.g., a global IAM/STS/Route53 issue) is the "
+            "most common cause of dual-region outage.\n"
+            "  4. Once at least one region is restored, the orchestrator will "
+            "auto-recover on the next 60s cycle. No operator action is needed "
+            "at this Lambda level."
         )
+        subject, body = compose_message(
+            severity=SEVERITY_CRITICAL,
+            what=f"Dual-region outage — failover HALTED, {APP_NAME or 'app'} is DOWN",
+            why=(
+                f"Region {CURRENT_REGION} hit the failover threshold ("
+                f"{health.get('decision_reason', 'health check failed')}), but "
+                f"the orchestrator's circuit breaker also detected that "
+                f"{target_region} is {peer_state.lower()}. Failing over would "
+                f"route traffic to an equally unhealthy region, so the "
+                f"orchestrator HALTED the failover to prevent infinite-loop flapping."
+            ),
+            next_step=next_step,
+            context={
+                f"{CURRENT_REGION} health": "UNHEALTHY (current region)",
+                f"{target_region} health": peer_state,
+                "Current decision": health.get("decision_reason", "N/A"),
+                "App name": APP_NAME or "(not set)",
+            },
+            journey=[
+                "[✓] Threshold reached",
+                "[✗] Circuit breaker — both regions unhealthy",
+                "[⏸] Failover HALTED",
+                "[ ] Auto-recovery on next cycle (when one region returns)",
+            ],
+            source="failover-orchestrator",
+            region=CURRENT_REGION,
+        )
+        send_notification(subject, body)
         return {"statusCode": 200, "body": "Dual-region outage, failover halted"}
 
     # In manual mode, notify but don't execute. The operator reviews
@@ -2822,26 +2936,55 @@ def _handle_active_region(state: dict, active_region: str,
         # Use throttled notification - in manual mode, the threshold stays
         # reached and this code runs every minute. The operator got the first
         # alert immediately, subsequent ones are throttled.
-        send_warning_notification(
-            subject=f"FAILOVER RECOMMENDED: {CURRENT_REGION} -> {target_region} (manual mode)",
-            message=(
-                f"The failover threshold has been reached but FAILOVER_MODE is set to 'manual'.\n"
-                f"DNS has NOT been moved. Traffic is still going to {CURRENT_REGION}.\n\n"
-                f"From: {active_region}\n"
-                f"To: {target_region}\n"
-                f"Decision: {health.get('decision_reason', 'N/A')}\n\n"
-                f"ACTION REQUIRED - Execute failover:\n\n"
-                f"  aws lambda invoke \\\n"
-                f"    --function-name {os.environ.get('AWS_LAMBDA_FUNCTION_NAME', 'failover-orchestrator')} \\\n"
-                f"    --payload '{{\"execute_failover\": true}}' \\\n"
-                f"    --region {CURRENT_REGION} \\\n"
-                f"    response.json\n\n"
-                f"This will move DNS to {target_region} and send Aurora promotion commands.\n\n"
-                f"To switch to automatic failover, change FAILOVER_MODE from 'manual' to 'auto'.\n\n"
-                f"Health Signals:\n{json.dumps(health['signals'], indent=2, default=str)}"
-            ),
-            state=state,
+        fn_name = os.environ.get("AWS_LAMBDA_FUNCTION_NAME", "failover-orchestrator")
+        signals_brief = ", ".join(
+            f"{s['signal']}={'OK' if s.get('healthy') else 'FAIL'}"
+            for s in health.get("signals", [])
+            if not s.get("skipped")
         )
+        ctx = {
+            "From region": active_region,
+            "To region": target_region,
+            "Decision": health.get("decision_reason", "N/A"),
+            "FAILOVER_MODE": "manual (auto-failover blocked by config)",
+        }
+        if signals_brief:
+            ctx["Health signals"] = signals_brief
+        next_step = (
+            "**Operator decision required.** Execute the failover with this command:\n\n"
+            f"  aws lambda invoke \\\n"
+            f"    --function-name {fn_name} \\\n"
+            f"    --payload '{{\"execute_failover\": true}}' \\\n"
+            f"    --region {CURRENT_REGION} \\\n"
+            f"    response.json\n\n"
+            f"This will move DNS to {target_region} and send Aurora promotion "
+            f"commands. To switch to automatic failover for future incidents, "
+            f"set the FAILOVER_MODE env var on this Lambda from 'manual' to 'auto'."
+        )
+        subject, body = compose_message(
+            severity=SEVERITY_WARNING,
+            what=f"Failover RECOMMENDED but blocked — FAILOVER_MODE is manual",
+            why=(
+                f"{health.get('decision_reason', 'health check failed')}. "
+                f"The failover threshold has been reached, but FAILOVER_MODE is "
+                f"set to 'manual' so the orchestrator did NOT move DNS. Traffic "
+                f"is still going to {CURRENT_REGION} (which is unhealthy). This "
+                f"alert will repeat every "
+                f"{WARNING_NOTIFICATION_COOLDOWN_MINUTES} min until the operator "
+                f"executes the failover or restores {CURRENT_REGION}."
+            ),
+            next_step=next_step,
+            context=ctx,
+            journey=[
+                "[✓] First failure",
+                "[✓] Sustained — threshold reached",
+                "[⏸] Awaiting operator (manual mode)",
+                "[ ] Failover",
+            ],
+            source="failover-orchestrator",
+            region=CURRENT_REGION,
+        )
+        send_warning_notification(subject, body, state)
 
         return {
             "statusCode": 200,

--- a/failover_orchestrator_v3.py
+++ b/failover_orchestrator_v3.py
@@ -58,6 +58,12 @@ from botocore.exceptions import (
 )
 
 from state_backend import create_backend, ConditionalCheckFailedError
+from notifications import (
+    compose_message,
+    SEVERITY_INFO,
+    SEVERITY_WARNING,
+    SEVERITY_CRITICAL,
+)
 
 # AI modules are imported lazily inside functions to support v1.0 mode
 # (where AI_RCA_ENABLED=false and AI modules may not be needed)
@@ -2571,20 +2577,69 @@ def _handle_active_region(state: dict, active_region: str,
 
     if new_failure_count < CONSECUTIVE_FAILURES_THRESHOLD:
         publish_region_health_metric(CURRENT_REGION, True)
-        send_warning_notification(
-            subject=(
-                f"WARNING: {CURRENT_REGION} degraded "
-                f"({new_failure_count}/{CONSECUTIVE_FAILURES_THRESHOLD})"
-            ),
-            message=(
-                f"Region {CURRENT_REGION} health check failed.\n"
-                f"Consecutive failures: {new_failure_count}/{CONSECUTIVE_FAILURES_THRESHOLD}\n"
-                f"Decision: {health.get('decision_reason', 'N/A')}\n\n"
-                f"Failover triggers at {CONSECUTIVE_FAILURES_THRESHOLD} consecutive failures.\n\n"
-                f"Signals:\n{json.dumps(health['signals'], indent=2, default=str)}"
-            ),
-            state=state,
+        target_region = SECONDARY_REGION if active_region == PRIMARY_REGION else PRIMARY_REGION
+        is_first = new_failure_count == 1
+        if is_first:
+            what = (
+                f"Region {CURRENT_REGION} reported its FIRST health failure "
+                f"(1 of {CONSECUTIVE_FAILURES_THRESHOLD})"
+            )
+            why = (
+                f"{health.get('decision_reason', 'health check failed')}. "
+                f"This is the first failure of an incident — traffic is still flowing "
+                f"normally to {CURRENT_REGION}."
+            )
+            next_step = (
+                f"No action required. The orchestrator will keep evaluating health "
+                f"every 60s. You will receive a follow-up email if the failure "
+                f"persists. If {CONSECUTIVE_FAILURES_THRESHOLD} consecutive failures occur "
+                f"and the cooldown window has expired, traffic will move to "
+                f"{target_region} automatically."
+            )
+        else:
+            what = (
+                f"Region {CURRENT_REGION} health failure "
+                f"{new_failure_count} of {CONSECUTIVE_FAILURES_THRESHOLD} — "
+                f"sustained but below threshold"
+            )
+            why = (
+                f"{health.get('decision_reason', 'health check failed')}. "
+                f"This is failure {new_failure_count} in a row — one more and the "
+                f"orchestrator will move traffic to {target_region}."
+            )
+            next_step = (
+                f"Investigate the root cause in {CURRENT_REGION} now. If the next "
+                f"cycle (in ~60s) also fails, automatic failover will fire."
+            )
+        ctx = {
+            "Active region": CURRENT_REGION,
+            "Standby region": target_region,
+            "Consecutive failures": f"{new_failure_count} of {CONSECUTIVE_FAILURES_THRESHOLD}",
+            "Decision": health.get("decision_reason", "N/A"),
+        }
+        signals_brief = ", ".join(
+            f"{s['signal']}={'OK' if s.get('healthy') else 'FAIL'}"
+            for s in health.get("signals", [])
+            if not s.get("skipped")
         )
+        if signals_brief:
+            ctx["Health signals"] = signals_brief
+        journey = [
+            f"[{'1' if is_first else '✓'}] First failure",
+            f"[{'→' if not is_first else ' '}] Sustained ({new_failure_count}/{CONSECUTIVE_FAILURES_THRESHOLD})",
+            "[ ] Failover",
+        ]
+        subject, body = compose_message(
+            severity=SEVERITY_WARNING,
+            what=what,
+            why=why,
+            next_step=next_step,
+            context=ctx,
+            journey=journey,
+            source="failover-orchestrator",
+            region=CURRENT_REGION,
+        )
+        send_warning_notification(subject, body, state, bypass_throttle=is_first)
         return {"statusCode": 200, "body": "Below threshold, monitoring"}
 
     last_ts = datetime.fromisoformat(last_failover_ts.replace("Z", "+00:00"))
@@ -2594,18 +2649,53 @@ def _handle_active_region(state: dict, active_region: str,
         remaining = (cooldown_expiry - now).total_seconds() / 60
         logger.warning(f"Cooldown active, {remaining:.1f} min remaining. NOT failing over.")
         publish_region_health_metric(CURRENT_REGION, True)
-        send_warning_notification(
-            subject=f"CRITICAL: {CURRENT_REGION} unhealthy, cooldown active",
-            message=(
-                f"Region {CURRENT_REGION} has hit the failure threshold but cooldown "
-                f"prevents failover.\n"
-                f"Cooldown expires in {remaining:.1f} minutes.\n"
-                f"Manual intervention may be required.\n\n"
-                f"Decision: {health.get('decision_reason', 'N/A')}\n"
-                f"Signals:\n{json.dumps(health['signals'], indent=2, default=str)}"
-            ),
-            state=state,
+        target_region = SECONDARY_REGION if active_region == PRIMARY_REGION else PRIMARY_REGION
+        what = (
+            f"Region {CURRENT_REGION} unhealthy but failover blocked by cooldown "
+            f"({remaining:.0f} min remaining)"
         )
+        why = (
+            f"{health.get('decision_reason', 'health check failed')}. The "
+            f"{CONSECUTIVE_FAILURES_THRESHOLD}-failure threshold has been reached, "
+            f"but a previous failover happened within the {COOLDOWN_MINUTES}-minute "
+            f"cooldown window so the orchestrator will NOT fail over again right now."
+        )
+        next_step = (
+            f"Investigate {CURRENT_REGION} immediately — the app is degraded but "
+            f"traffic is still routed here. If the region cannot be restored before "
+            f"the cooldown expires (in {remaining:.0f} min), failover will fire on "
+            f"the next cycle. To override the cooldown, an operator can manually "
+            f"invoke the failover Lambda with {{\"execute_failover\": true}}."
+        )
+        ctx = {
+            "Active region": CURRENT_REGION,
+            "Standby region": target_region,
+            "Cooldown remaining": f"{remaining:.0f} min",
+            "Decision": health.get("decision_reason", "N/A"),
+        }
+        signals_brief = ", ".join(
+            f"{s['signal']}={'OK' if s.get('healthy') else 'FAIL'}"
+            for s in health.get("signals", [])
+            if not s.get("skipped")
+        )
+        if signals_brief:
+            ctx["Health signals"] = signals_brief
+        journey = [
+            "[✓] First failure",
+            f"[✓] Sustained ({CONSECUTIVE_FAILURES_THRESHOLD}/{CONSECUTIVE_FAILURES_THRESHOLD})",
+            "[⏸] Cooldown — failover deferred",
+        ]
+        subject, body = compose_message(
+            severity=SEVERITY_WARNING,
+            what=what,
+            why=why,
+            next_step=next_step,
+            context=ctx,
+            journey=journey,
+            source="failover-orchestrator",
+            region=CURRENT_REGION,
+        )
+        send_warning_notification(subject, body, state)
         return {"statusCode": 200, "body": "Cooldown active"}
 
     # =====================================================================

--- a/failover_orchestrator_v3.py
+++ b/failover_orchestrator_v3.py
@@ -1962,17 +1962,49 @@ def _handle_aurora_promotion_reminder(state: dict) -> dict:
         )
         update_failover_state({"aurora_promotion_pending": False})
 
-        send_notification(
-            subject=f"Aurora promotion confirmed - {active_region} is writer",
-            message=(
-                f"The Aurora Global Database has been promoted.\n\n"
-                f"Region {active_region} is now the writer.\n"
-                f"aurora_promotion_pending has been automatically cleared.\n"
-                f"The orchestrator will transition to steady state on the next cycle.\n\n"
-                f"Time: {now.isoformat()}\n"
-                f"Minutes since failover: {int(minutes_since_failover)}"
+        cfg = detect_data_tier_config()
+        redis_pending = bool(state.get("redis_promotion_pending"))
+        # Journey: Aurora is done; Redis step shown only when Redis is configured.
+        if cfg["redis_present"]:
+            journey = [
+                "[✓] Aurora promoted",
+                f"[{'→' if redis_pending else '✓'}] Redis promoting",
+                "[ ] Latch released",
+            ]
+            next_step = (
+                "No action — Aurora is ready. The orchestrator is now waiting for "
+                "ElastiCache promotion. You'll receive another email when Redis "
+                "completes (and a CRITICAL alert if it gets stuck)."
+                if redis_pending else
+                "No action — both data tiers are promoted. The orchestrator will "
+                "transition to SECONDARY_ACTIVE on the next cycle."
+            )
+        else:
+            journey = ["[✓] Aurora promoted", "[ ] Latch released"]
+            next_step = (
+                "No action — Aurora is ready. The orchestrator will transition to "
+                "SECONDARY_ACTIVE on the next cycle and the failover will be complete."
+            )
+
+        subject, body = compose_message(
+            severity=SEVERITY_INFO,
+            what=f"Aurora is now writer in {active_region}",
+            why=(
+                f"The Aurora Global Database promotion to {active_region} completed "
+                f"after {int(minutes_since_failover)} minute(s). Your app can now "
+                f"write to the database from this region."
             ),
+            next_step=next_step,
+            context={
+                "Active region": active_region,
+                "Aurora cluster": AURORA_CLUSTER_ID or "(not configured)",
+                "Promotion took": f"~{int(minutes_since_failover)} min from failover",
+            },
+            journey=journey,
+            source="failover-orchestrator",
+            region=CURRENT_REGION,
         )
+        send_notification(subject, body)
 
         publish_region_health_metric(CURRENT_REGION, True)
         return {"statusCode": 200, "body": "Aurora promotion detected and confirmed"}
@@ -2028,16 +2060,49 @@ def _handle_elasticache_promotion_reminder(state: dict) -> dict:
         )
         update_failover_state({"redis_promotion_pending": False})
 
-        send_notification(
-            subject=f"ElastiCache promotion confirmed - {active_region} is primary",
-            message=(
-                f"The ElastiCache Global Datastore has been promoted.\n\n"
-                f"Region {active_region} is now the primary.\n"
-                f"redis_promotion_pending has been automatically cleared.\n\n"
-                f"Time: {now.isoformat()}\n"
-                f"Minutes since failover: {int(minutes_since_failover)}"
+        cfg = detect_data_tier_config()
+        aurora_pending = bool(state.get("aurora_promotion_pending"))
+        # Journey: Redis is done; show Aurora step only if Aurora is configured.
+        if cfg["aurora_present"]:
+            journey = [
+                f"[{'→' if aurora_pending else '✓'}] Aurora promoting",
+                "[✓] Redis promoted",
+                "[ ] Latch released",
+            ]
+            next_step = (
+                "No action — Redis is ready. The orchestrator is now waiting for "
+                "Aurora promotion. You'll receive another email when Aurora "
+                "completes (and a CRITICAL alert if it gets stuck)."
+                if aurora_pending else
+                "No action — both data tiers are promoted. The orchestrator will "
+                "transition to SECONDARY_ACTIVE on the next cycle."
+            )
+        else:
+            journey = ["[✓] Redis promoted", "[ ] Latch released"]
+            next_step = (
+                "No action — Redis is ready. The orchestrator will transition to "
+                "SECONDARY_ACTIVE on the next cycle and the failover will be complete."
+            )
+
+        subject, body = compose_message(
+            severity=SEVERITY_INFO,
+            what=f"ElastiCache is now primary in {active_region}",
+            why=(
+                f"The ElastiCache Global Datastore promotion to {active_region} "
+                f"completed after {int(minutes_since_failover)} minute(s). Cache "
+                f"writes from this region are now served locally."
             ),
+            next_step=next_step,
+            context={
+                "Active region": active_region,
+                "ElastiCache RG": ELASTICACHE_REPLICATION_GROUP_ID or "(not configured)",
+                "Promotion took": f"~{int(minutes_since_failover)} min from failover",
+            },
+            journey=journey,
+            source="failover-orchestrator",
+            region=CURRENT_REGION,
         )
+        send_notification(subject, body)
         return {"statusCode": 200, "body": "ElastiCache promotion detected and confirmed"}
 
     # ElastiCache not yet promoted - send periodic reminders
@@ -2870,26 +2935,60 @@ def _handle_active_region(state: dict, active_region: str,
             aurora_result = _auto_promote_aurora(target_region, "app_failure")
             if aurora_result["success"]:
                 aurora_handled = True
-                send_notification(
-                    subject=f"FAILOVER: DNS moved to {target_region} - Aurora {aurora_result['method']} initiated",
-                    message=(
-                        f"Automated DNS failover triggered.\n\n"
-                        f"From: {active_region}\n"
-                        f"To: {target_region}\n"
-                        f"Time: {now.isoformat()}\n"
-                        f"Decision: {health.get('decision_reason', 'N/A')}\n\n"
-                        f"DNS has been moved. Route 53 is now routing traffic to {target_region}.\n\n"
-                        f"Aurora {aurora_result['method']} has been initiated AUTOMATICALLY.\n"
-                        f"Monitor progress with:\n\n"
-                        f"  aws rds describe-db-clusters \\\n"
-                        f"    --db-cluster-identifier {AURORA_CLUSTER_ID} \\\n"
-                        f"    --query 'DBClusters[0].{{Status:Status,ReplicationSource:ReplicationSourceIdentifier}}' \\\n"
-                        f"    --region {target_region}\n\n"
-                        f"Latch is ENGAGED. {active_region} will remain marked unhealthy.\n\n"
-                        f"Signals:\n{json.dumps(health['signals'], indent=2, default=str)}"
-                        f"{ai_appendix}"
-                    ),
+                cfg = detect_data_tier_config()
+                # Journey: failover step is happening NOW; data-tier steps follow.
+                journey_lines = ["[✓] Threshold reached", "[→] Failover IN PROGRESS"]
+                if cfg["aurora_present"]:
+                    journey_lines.append("[→] Aurora promoting")
+                if cfg["redis_present"]:
+                    journey_lines.append("[ ] Redis promoting" if cfg["redis_auto"]
+                                          else "[ ] Redis (manual — operator)")
+                ctx = {
+                    "From region": active_region,
+                    "To region": target_region,
+                    "Decision": health.get("decision_reason", "N/A"),
+                    "Aurora cluster": AURORA_CLUSTER_ID or "(not configured)",
+                    "Aurora action": f"{aurora_result['method']} (auto, in progress)",
+                }
+                if cfg["redis_present"]:
+                    ctx["ElastiCache action"] = (
+                        "failover (auto, in progress)" if cfg["redis_auto"]
+                        else "MANUAL — see follow-up email"
+                    )
+                signals_brief = ", ".join(
+                    f"{s['signal']}={'OK' if s.get('healthy') else 'FAIL'}"
+                    for s in health.get("signals", [])
+                    if not s.get("skipped")
                 )
+                if signals_brief:
+                    ctx["Health signals"] = signals_brief
+                next_step = (
+                    f"No immediate action. Aurora {aurora_result['method']} is in "
+                    f"flight; you'll receive a confirmation email when it completes "
+                    f"(typically 1–5 min). The latch is ENGAGED — once {target_region} "
+                    f"is fully active, traffic will stay there until you run failback "
+                    f"manually. Monitor Aurora progress with:\n"
+                    f"  aws rds describe-db-clusters --db-cluster-identifier "
+                    f"{AURORA_CLUSTER_ID or '<cluster-id>'} "
+                    f"--query 'DBClusters[0].{{Status:Status,ReplicationSource:ReplicationSourceIdentifier}}' "
+                    f"--region {target_region}"
+                )
+                subject, body = compose_message(
+                    severity=SEVERITY_CRITICAL,
+                    what=f"Failover triggered — traffic moving from {active_region} to {target_region}",
+                    why=(
+                        f"{health.get('decision_reason', 'health check failed')}. "
+                        f"This was the third consecutive failure and the cooldown "
+                        f"window had expired, so the orchestrator triggered an "
+                        f"automatic DNS failover."
+                    ),
+                    next_step=next_step + (ai_appendix or ""),
+                    context=ctx,
+                    journey=journey_lines,
+                    source="failover-orchestrator",
+                    region=CURRENT_REGION,
+                )
+                send_notification(subject, body)
             else:
                 logger.warning(
                     f"Auto Aurora promotion failed: {aurora_result['error']}. "

--- a/manual_failback_v2.py
+++ b/manual_failback_v2.py
@@ -45,6 +45,12 @@ from botocore.config import Config as BotoConfig
 from botocore.exceptions import ClientError
 
 from state_backend import create_backend, S3StateBackend
+from notifications import (
+    compose_message,
+    SEVERITY_INFO,
+    SEVERITY_WARNING,
+    SEVERITY_CRITICAL,
+)
 
 # AI modules imported lazily inside functions to support v1.0 mode
 
@@ -210,13 +216,20 @@ def detect_data_tier_config() -> dict:
     (aurora_confirmed, redis_confirmed, etc.) and to suppress notifications
     for absent tiers.
 
+    Reads os.environ directly so per-invocation env changes (and per-test
+    patch.dict overrides) take effect without re-importing the module.
+
     See failover_orchestrator_v3.py:detect_data_tier_config for full docs.
     """
+    aurora_id = os.environ.get("AURORA_CLUSTER_ID", "")
+    redis_id = os.environ.get("ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", "")
+    aurora_auto = os.environ.get("AURORA_AUTO_PROMOTE", "false").lower() == "true"
+    redis_auto = os.environ.get("ELASTICACHE_AUTO_PROMOTE", "false").lower() == "true"
     return {
-        "aurora_present": bool(AURORA_CLUSTER_ID),
-        "aurora_auto":    bool(AURORA_CLUSTER_ID) and AURORA_AUTO_PROMOTE,
-        "redis_present":  bool(ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID),
-        "redis_auto":     bool(ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID) and ELASTICACHE_AUTO_PROMOTE,
+        "aurora_present": bool(aurora_id),
+        "aurora_auto":    bool(aurora_id) and aurora_auto,
+        "redis_present":  bool(redis_id),
+        "redis_auto":     bool(redis_id) and redis_auto,
     }
 
 
@@ -621,19 +634,42 @@ def handler(event, context):
             )
 
             if verdict == "NO_GO":
-                msg = (
-                    f"AI readiness assessment: NO GO (confidence: {assessment.get('confidence')}%)\n\n"
-                    f"Reasoning: {assessment.get('reasoning', 'N/A')}\n\n"
-                    f"Risks:\n"
-                    + "\n".join(f"  - {r}" for r in assessment.get("risks", []))
-                    + "\n\nTo override, set skip_readiness_check=true in the payload."
+                risks_lines = "\n".join(f"  • {r}" for r in assessment.get("risks", []))
+                next_step = (
+                    "Address the risks above, OR re-invoke the failback Lambda with "
+                    "`skip_readiness_check=true` in the payload to override the AI "
+                    "veto if you have human-verified that failback is safe.\n"
+                    + (readiness_appendix or "")
                 )
                 logger.warning(f"Failback blocked by AI readiness: {verdict}")
-                send_notification(
-                    f"FAILBACK BLOCKED: AI readiness assessment says NO GO",
-                    msg + readiness_appendix,
+                subject, body = compose_message(
+                    severity=SEVERITY_CRITICAL,
+                    what="Failback BLOCKED — AI readiness assessment says NO GO",
+                    why=(
+                        f"The AI failback-readiness check returned NO GO with "
+                        f"{assessment.get('confidence')}% confidence. "
+                        f"Reasoning: {assessment.get('reasoning', 'N/A')}"
+                    ),
+                    next_step=next_step,
+                    context={
+                        "Operator": operator,
+                        "Target region": target_region,
+                        "AI verdict": verdict,
+                        "AI confidence": f"{assessment.get('confidence')}%",
+                        "Risks":
+                            f"\n{risks_lines}" if risks_lines else "(none reported)",
+                    },
+                    journey=[
+                        "[✓] Failback requested",
+                        "[✗] AI readiness gate — NO GO",
+                        "[ ] Aurora switchover",
+                        "[ ] Latch released",
+                    ],
+                    source="failover-failback",
+                    region=CURRENT_REGION,
                 )
-                return {"statusCode": 400, "body": msg}
+                send_notification(subject, body)
+                return {"statusCode": 400, "body": body}
         except Exception as e:
             logger.error(f"AI readiness assessment failed (non-blocking): {e}")
             # Continue with failback — AI failure should not block
@@ -645,18 +681,45 @@ def handler(event, context):
         logger.info("Step 3: Validating target region health...")
         health = validate_target_region_health(target_region)
         if not health["healthy"]:
-            msg = (
-                f"Target region {target_region} is NOT healthy. Issues:\n"
-                + "\n".join(f"  - {i}" for i in health["issues"])
-                + "\n\nTo override, set skip_health_check=true in the payload."
-                + "\nIf Aurora is not the writer, you must switchover Aurora "
-                + "first."
+            issue_lines = "\n".join(f"  • {i}" for i in health["issues"])
+            msg_for_log = (
+                f"Target region {target_region} is NOT healthy. Issues:\n{issue_lines}"
             )
-            logger.error(msg)
-            send_notification(
-                f"FAILBACK BLOCKED: {target_region} not ready", msg
+            logger.error(msg_for_log)
+            next_step = (
+                f"Resolve each issue above in {target_region} before re-invoking "
+                f"failback. Common causes: ECS tasks not yet healthy, Aurora not "
+                f"yet the writer in {target_region} (run `switchover-global-cluster` "
+                f"first), or app /healthcheck endpoint returning non-200. "
+                f"To override the gate (only after you've human-verified target "
+                f"readiness), re-invoke with `skip_health_check=true` in the payload."
             )
-            return {"statusCode": 400, "body": msg}
+            subject, body = compose_message(
+                severity=SEVERITY_CRITICAL,
+                what=f"Failback BLOCKED — target region {target_region} is not ready",
+                why=(
+                    f"The pre-flight health check for {target_region} found "
+                    f"{len(health['issues'])} issue(s). Failback would route traffic "
+                    f"to a region that cannot serve it, so the orchestrator refused "
+                    f"to release the latch."
+                ),
+                next_step=next_step,
+                context={
+                    "Operator": operator,
+                    "Target region": target_region,
+                    "Issues found": f"\n{issue_lines}",
+                },
+                journey=[
+                    "[✓] Failback requested",
+                    "[✗] Target region health gate — FAILED",
+                    "[ ] Aurora switchover",
+                    "[ ] Latch released",
+                ],
+                source="failover-failback",
+                region=CURRENT_REGION,
+            )
+            send_notification(subject, body)
+            return {"statusCode": 400, "body": body}
         logger.info(f"All health checks passed for {target_region}")
     else:
         logger.warning(
@@ -705,27 +768,81 @@ def handler(event, context):
         })
 
         logger.info("  4d: Sending confirmation notification...")
-        msg = (
-            f"Manual failback completed successfully.\n\n"
-            f"Operator: {operator}\n"
-            f"From: {active_region}\n"
-            f"To: {target_region}\n"
-            f"Time: {now.isoformat()}\n\n"
-            f"Latch has been RELEASED. Automated health monitoring is active.\n"
-            f"The orchestrator Lambda will resume normal health evaluation."
+        cfg = detect_data_tier_config()
+        # Journey: failback is the inverse of failover. All earlier journey
+        # steps map to "✓" and the lifecycle is back at PRIMARY_ACTIVE.
+        journey = ["[✓] Failback requested", "[✓] Aurora switchover (operator)"]
+        if cfg["redis_present"]:
+            journey.append("[✓] Redis switchover (operator)")
+        journey.append("[✓] Latch released — system back to PRIMARY_ACTIVE")
+        next_step = (
+            f"No action required. The orchestrator's automated health monitoring "
+            f"is active again in both regions. Confirm Route 53 traffic is flowing "
+            f"to {target_region} and watch for any sustained-failure WARNINGs in "
+            f"the next 5–10 minutes to verify the underlying issue is resolved."
+            + (readiness_appendix or "")
         )
-        send_notification(f"FAILBACK COMPLETE: -> {target_region}", msg + readiness_appendix)
+        subject, body = compose_message(
+            severity=SEVERITY_CRITICAL,
+            what=f"Failback COMPLETE — traffic returned to {target_region}",
+            why=(
+                f"Operator {operator} initiated and completed manual failback "
+                f"from {active_region} back to {target_region}. The orchestrator "
+                f"validated target health, released the latch, and updated state "
+                f"to PRIMARY_ACTIVE."
+            ),
+            next_step=next_step,
+            context={
+                "Operator": operator,
+                "From region": active_region,
+                "To region": target_region,
+                "New state": new_state,
+                "Latch": "RELEASED",
+            },
+            journey=journey,
+            source="failover-failback",
+            region=CURRENT_REGION,
+        )
+        send_notification(subject, body)
+        msg_for_return = body  # full body for any caller that logs it
 
         logger.info(f"FAILBACK COMPLETE: {active_region} -> {target_region}")
-        return {"statusCode": 200, "body": msg}
+        return {"statusCode": 200, "body": msg_for_return}
 
     except Exception as e:
         logger.error(
             f"FAILBACK FAILED at step 4: {type(e).__name__}: {e}"
         )
-        send_notification(
-            f"FAILBACK FAILED: -> {target_region}",
-            f"Manual failback failed.\nError: {str(e)}\n\n"
-            f"Manual intervention required.",
+        next_step = (
+            "Manual intervention required. Inspect the Lambda's CloudWatch logs "
+            "for the full traceback. Common causes: state backend write failure "
+            "(check IAM + DynamoDB/S3 health), CloudWatch PutMetricData failure "
+            "(check IAM), or Aurora describe-db-clusters returning unexpected "
+            "shape. Once the root cause is fixed, re-invoke the failback Lambda "
+            "with the same payload."
         )
+        subject, body = compose_message(
+            severity=SEVERITY_CRITICAL,
+            what=f"Failback FAILED — {target_region} did not regain control",
+            why=(
+                f"The failback Lambda threw {type(e).__name__} during the "
+                f"DNS/state update step (after health checks passed). Error: {e}"
+            ),
+            next_step=next_step,
+            context={
+                "Operator": operator,
+                "Target region": target_region,
+                "Error type": type(e).__name__,
+                "Error detail": str(e)[:200],
+            },
+            journey=[
+                "[✓] Failback requested",
+                "[✓] Health gate passed",
+                "[✗] DNS/state update — FAILED",
+                "[ ] Latch released",
+            ],
+            source="failover-failback",
+            region=CURRENT_REGION,
+        )
+        send_notification(subject, body)
         raise

--- a/tests/test_config_detection.py
+++ b/tests/test_config_detection.py
@@ -132,14 +132,26 @@ _CONFIG_MATRIX = [
 ]
 
 
+def _env_for(aurora_id, aurora_auto, redis_id, redis_auto):
+    """Build the os.environ patch dict for a configuration row."""
+    return {
+        "AURORA_CLUSTER_ID": aurora_id,
+        "AURORA_AUTO_PROMOTE": "true" if aurora_auto else "false",
+        "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID": redis_id,
+        "ELASTICACHE_AUTO_PROMOTE": "true" if redis_auto else "false",
+    }
+
+
 @pytest.mark.parametrize("cid,aurora_id,aurora_auto,redis_id,redis_auto,expected",
                          _CONFIG_MATRIX, ids=[c[0] for c in _CONFIG_MATRIX])
 def test_detect_data_tier_config_orchestrator(cid, aurora_id, aurora_auto, redis_id, redis_auto, expected):
-    """Orchestrator's detect_data_tier_config returns correct flags for C1–C9."""
-    with patch.object(orch, "AURORA_CLUSTER_ID", aurora_id), \
-         patch.object(orch, "AURORA_AUTO_PROMOTE", aurora_auto), \
-         patch.object(orch, "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", redis_id), \
-         patch.object(orch, "ELASTICACHE_AUTO_PROMOTE", redis_auto):
+    """Orchestrator's detect_data_tier_config returns correct flags for C1–C9.
+
+    PR3c: helper now reads os.environ at call time so portal env-var flips
+    take effect without a Lambda cold start (and so per-test patches don't
+    require module attribute manipulation).
+    """
+    with patch.dict(os.environ, _env_for(aurora_id, aurora_auto, redis_id, redis_auto)):
         assert orch.detect_data_tier_config() == expected
 
 
@@ -147,17 +159,14 @@ def test_detect_data_tier_config_orchestrator(cid, aurora_id, aurora_auto, redis
                          _CONFIG_MATRIX, ids=[c[0] for c in _CONFIG_MATRIX])
 def test_detect_data_tier_config_failback(cid, aurora_id, aurora_auto, redis_id, redis_auto, expected):
     """Failback Lambda's helper must match the orchestrator exactly."""
-    with patch.object(failback, "AURORA_CLUSTER_ID", aurora_id), \
-         patch.object(failback, "AURORA_AUTO_PROMOTE", aurora_auto), \
-         patch.object(failback, "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", redis_id), \
-         patch.object(failback, "ELASTICACHE_AUTO_PROMOTE", redis_auto):
+    with patch.dict(os.environ, _env_for(aurora_id, aurora_auto, redis_id, redis_auto)):
         assert failback.detect_data_tier_config() == expected
 
 
 def test_aurora_auto_requires_aurora_present():
     """AURORA_AUTO_PROMOTE=true with empty AURORA_CLUSTER_ID → aurora_auto=False (defensive)."""
-    with patch.object(orch, "AURORA_CLUSTER_ID", ""), \
-         patch.object(orch, "AURORA_AUTO_PROMOTE", True):
+    with patch.dict(os.environ, {"AURORA_CLUSTER_ID": "",
+                                  "AURORA_AUTO_PROMOTE": "true"}):
         cfg = orch.detect_data_tier_config()
         assert cfg["aurora_present"] is False
         assert cfg["aurora_auto"] is False  # cannot auto-promote a tier that isn't there
@@ -165,8 +174,8 @@ def test_aurora_auto_requires_aurora_present():
 
 def test_redis_auto_requires_redis_present():
     """ELASTICACHE_AUTO_PROMOTE=true with empty global RG ID → redis_auto=False."""
-    with patch.object(orch, "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", ""), \
-         patch.object(orch, "ELASTICACHE_AUTO_PROMOTE", True):
+    with patch.dict(os.environ, {"ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID": "",
+                                  "ELASTICACHE_AUTO_PROMOTE": "true"}):
         cfg = orch.detect_data_tier_config()
         assert cfg["redis_present"] is False
         assert cfg["redis_auto"] is False

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -597,7 +597,8 @@ class TestFailoverTrigger:
         # Warning notification with recommendation
         mock_warn.assert_called_once()
         subject_arg = mock_warn.call_args[0][0] if mock_warn.call_args[0] else mock_warn.call_args[1].get("subject", "")
-        assert "FAILOVER RECOMMENDED" in subject_arg
+        # v1.6 wording: "Failover RECOMMENDED but blocked — FAILOVER_MODE is manual"
+        assert "RECOMMENDED" in subject_arg and "manual" in subject_arg.lower()
 
     @patch.object(orch, "_run_rca_analysis", return_value="")
     @patch.object(orch, "_emit_failover_event")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -565,8 +565,12 @@ class TestFailoverTrigger:
         mock_publish.assert_any_call("us-east-1", False)
         # Notification sent
         mock_notify.assert_called_once()
-        subject = mock_notify.call_args[1].get("subject", "")
-        assert "PROMOTE DATA TIER" in subject or "PROMOTE AURORA" in subject
+        # v1.6 compose_message-based path uses positional args (subject, body).
+        subject = mock_notify.call_args.args[0] if mock_notify.call_args.args else \
+                  mock_notify.call_args.kwargs.get("subject", "")
+        # v1.6 wording is config-aware; the manual data-tier path uses
+        # "operator action required to promote data tier".
+        assert "promote" in subject.lower() and "data tier" in subject.lower()
 
     @patch.object(orch, "_run_rca_analysis", return_value="")
     @patch.object(orch, "send_warning_notification")

--- a/tests/test_sns_notifications_failover.py
+++ b/tests/test_sns_notifications_failover.py
@@ -441,9 +441,8 @@ class TestSNSRegionRecovery:
     def test_region_recovered_active_active(
         self, mock_sns, mock_health, mock_emit, mock_inc, mock_pub, mock_upd
     ):
-        """Active/active: RECOVERED notification sent when region returns to healthy."""
+        """v1.6: Active/active recovery → INFO with rejoin journey."""
         mock_health.return_value = _healthy_health()
-        # consecutive_failures=3 means it was at threshold (unhealthy), now recovering
         state = _make_state(consecutive_failures=3)
 
         with config_variant(routing="active-active"):
@@ -451,11 +450,13 @@ class TestSNSRegionRecovery:
 
         assert mock_sns.publish.called
         subject = _get_sns_subject(mock_sns)
-        assert "RECOVERED" in subject
-        assert "us-east-1" in subject
-        assert "rejoining" in subject.lower() or "healthy" in subject.lower()
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[SentinelFO] INFO:")
+        assert "us-east-1 recovered" in subject
+        assert "rejoining traffic pool" in subject
         assert len(subject) <= 100
+
+        body = _get_sns_message(mock_sns)
+        assert "[✓] Rejoined Route 53 traffic pool" in body
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "publish_region_health_metric")
@@ -507,7 +508,7 @@ class TestSNSRegionRecovery:
     def test_degraded_warning_active_active_below_threshold(
         self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd
     ):
-        """Active/active: WARNING notification when below threshold (line 1314)."""
+        """v1.6: Active/active degradation → WARNING with active-active framing."""
         mock_health.return_value = _unhealthy_health()
         state = _make_state(consecutive_failures=1)
 
@@ -515,9 +516,9 @@ class TestSNSRegionRecovery:
             orch._handle_active_active(state)
 
         subject = _get_sns_subject(mock_sns)
-        assert "WARNING" in subject
-        assert "degraded" in subject
-        assert "2/3" in subject
+        assert subject.startswith("[SentinelFO] WARNING:")
+        assert "(active-active)" in subject
+        assert "2 of 3" in subject
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "publish_region_health_metric")
@@ -819,15 +820,20 @@ class TestSNSFailoverExecution:
             with pytest.raises(Exception, match="CloudWatch unavailable"):
                 orch._handle_active_region(state, "us-east-1", 2, "1970-01-01T00:00:00Z")
 
-        # FAILOVER FAILED notification must have been sent
+        # v1.6: subject is "Auto-failover FAILED — X → Y did not complete"
         failed_calls = [
             c for c in mock_sns.publish.call_args_list
-            if "FAILOVER FAILED" in c[1].get("Subject", "")
+            if "Auto-failover FAILED" in c[1].get("Subject", "")
         ]
         assert len(failed_calls) == 1
         subject = failed_calls[0][1]["Subject"]
         assert "us-east-1" in subject
         assert "us-east-2" in subject
+
+        # Body explains the state was reverted and what to investigate.
+        body = failed_calls[0][1]["Message"]
+        assert "[✗] Failover handler FAILED" in body
+        assert "state reverted" in body.lower()
 
 
 # ===========================================================================

--- a/tests/test_sns_notifications_failover.py
+++ b/tests/test_sns_notifications_failover.py
@@ -190,15 +190,30 @@ def config_variant(
     routing: str = "failover",
     failover_mode: str = "auto",
 ):
-    """Apply per-test module-level patches for config variants."""
+    """Apply per-test module-level patches for config variants.
+
+    PR3c: also patches os.environ since detect_data_tier_config() now reads
+    env directly. Both module-attr and env patches are kept in lockstep so
+    the orchestrator's lazy-read paths (config_aware notifications) and
+    eager-read paths (existing imports) see consistent values.
+    """
+    redis_global = "my-global-redis" if elasticache else ""
+    redis_local = "my-redis-rg" if elasticache else ""
+    apigw = "my-api-gw-id" if api_gw else ""
+    env_patch = {
+        "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID": redis_global,
+        "ELASTICACHE_REPLICATION_GROUP_ID": redis_local,
+        "API_GW_NAME": apigw,
+        "ROUTING_MODE": routing,
+        "FAILOVER_MODE": failover_mode,
+    }
     patches = [
-        patch.object(orch, "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID",
-                     "my-global-redis" if elasticache else ""),
-        patch.object(orch, "ELASTICACHE_REPLICATION_GROUP_ID",
-                     "my-redis-rg" if elasticache else ""),
-        patch.object(orch, "API_GW_NAME", "my-api-gw-id" if api_gw else ""),
+        patch.object(orch, "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", redis_global),
+        patch.object(orch, "ELASTICACHE_REPLICATION_GROUP_ID", redis_local),
+        patch.object(orch, "API_GW_NAME", apigw),
         patch.object(orch, "ROUTING_MODE", routing),
         patch.object(orch, "FAILOVER_MODE", failover_mode),
+        patch.dict(os.environ, env_patch),
     ]
     with ExitStack() as stack:
         for p in patches:
@@ -537,7 +552,13 @@ class TestSNSFailoverExecution:
 
     def _run_failover(self, mock_sns, mock_health, mock_pub, mock_upd,
                       elasticache=True, region_health_override=None):
-        """Common helper: set up mocks and trigger failover in _handle_active_region."""
+        """Common helper: set up mocks and trigger failover in _handle_active_region.
+
+        PR3c: pins AURORA_CLUSTER_ID in os.environ so detect_data_tier_config()
+        sees Aurora as present. Other test files may have setdefault-ed
+        AURORA_CLUSTER_ID="" before this file's _ENV ran, so we have to patch
+        explicitly here rather than relying on module-load env state.
+        """
         mock_health.return_value = _unhealthy_health()
         state = _make_state(
             consecutive_failures=2,
@@ -550,6 +571,13 @@ class TestSNSFailoverExecution:
             stack.enter_context(patch.object(orch, "_emit_failover_event"))
             stack.enter_context(patch.object(orch, "_run_rca_analysis", return_value=""))
             stack.enter_context(patch.object(orch, "_run_aurora_advisor", return_value=("", None)))
+            # Pin Aurora env explicitly — _ENV setdefault doesn't override
+            # values another test file already set during pytest's collection
+            # phase, so we have to be explicit here.
+            stack.enter_context(patch.dict(os.environ, {
+                "AURORA_CLUSTER_ID": "my-aurora-w1",
+                "AURORA_AUTO_PROMOTE": "false",
+            }))
             stack.enter_context(config_variant(elasticache=elasticache))
 
             orch._handle_active_region(state, "us-east-1", 2, "1970-01-01T00:00:00Z")
@@ -561,28 +589,32 @@ class TestSNSFailoverExecution:
     def test_failover_s3_ec_includes_elasticache_commands(
         self, mock_sns, mock_health, mock_pub, mock_upd
     ):
-        """S3+ElastiCache: failover message includes ElastiCache CLI commands."""
+        """S3+ElastiCache, AURORA_AUTO_PROMOTE=false: v1.6 manual data-tier email
+        embeds Redis failover-global CLI command in the WHAT TO DO NEXT section."""
         self._run_failover(mock_sns, mock_health, mock_pub, mock_upd, elasticache=True)
 
         assert mock_sns.publish.called
-        # Find the FAILOVER notification (may be preceded by other calls)
+        # The v1.6 manual path uses "operator action required to promote data tier".
         failover_calls = [
             c for c in mock_sns.publish.call_args_list
-            if "FAILOVER" in c[1].get("Subject", "")
+            if "promote data tier" in c[1].get("Subject", "")
         ]
-        assert len(failover_calls) >= 1
+        assert len(failover_calls) == 1
         subject = failover_calls[-1][1]["Subject"]
         message = failover_calls[-1][1]["Message"]
 
-        assert "FAILOVER" in subject
+        assert subject.startswith("[SentinelFO] CRITICAL:")
         assert "us-east-2" in subject
-        assert "PROMOTE DATA TIER NOW" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert "data tier" in subject.lower()
         assert len(subject) <= 100
 
+        # Body has the structured shape; CLI commands embedded in next-step.
+        assert "WHAT TO DO NEXT" in message
         assert "failover-global-replication-group" in message
         assert "my-global-redis" in message
-        assert "ELASTICACHE PROMOTION REQUIRED" in message
+        # Journey distinguishes Aurora vs Redis manual steps.
+        assert "Aurora — operator action required" in message
+        assert "Redis — operator action required" in message
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "publish_region_health_metric")
@@ -609,20 +641,22 @@ class TestSNSFailoverExecution:
     def test_failover_no_ec_excludes_elasticache_commands(
         self, mock_sns, mock_health, mock_pub, mock_upd
     ):
-        """Without ElastiCache: failover message does NOT include ElastiCache CLI."""
+        """Without ElastiCache (C2 config): v1.6 message has no Redis content."""
         self._run_failover(mock_sns, mock_health, mock_pub, mock_upd, elasticache=False)
 
         failover_calls = [
             c for c in mock_sns.publish.call_args_list
-            if "FAILOVER" in c[1].get("Subject", "")
+            if "promote data tier" in c[1].get("Subject", "")
         ]
-        assert len(failover_calls) >= 1
+        assert len(failover_calls) == 1
         message = failover_calls[-1][1]["Message"]
 
+        # No ElastiCache in body; no Redis row in journey.
         assert "failover-global-replication-group" not in message
-        assert "ELASTICACHE PROMOTION REQUIRED" not in message
-        # Aurora commands are still present
+        assert "Redis" not in message
+        # Aurora commands and journey row still present.
         assert "switchover-global-cluster" in message or "aurora" in message.lower()
+        assert "Aurora — operator action required" in message
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "publish_region_health_metric")
@@ -704,11 +738,11 @@ class TestSNSFailoverExecution:
 
         failover_calls = [
             c for c in mock_sns.publish.call_args_list
-            if "FAILOVER" in c[1].get("Subject", "")
+            if "promote data tier" in c[1].get("Subject", "")
         ]
-        assert len(failover_calls) >= 1
+        assert len(failover_calls) == 1
         message = failover_calls[-1][1]["Message"]
-        # API GW decision reason surfaced in message body
+        # API GW decision reason surfaced in message body (Decision context line).
         assert "api_gw_5xx" in message or "75.0%" in message
 
     @patch.object(orch, "update_failover_state")
@@ -718,18 +752,18 @@ class TestSNSFailoverExecution:
     def test_failover_ddb_same_sns_format(
         self, mock_sns, mock_health, mock_pub, mock_upd
     ):
-        """DynamoDB backend: failover SNS subject/message format identical to S3."""
+        """DynamoDB backend: v1.6 manual data-tier subject identical to S3 (state
+        backend doesn't affect notification template)."""
         self._run_failover(mock_sns, mock_health, mock_pub, mock_upd)
 
         failover_calls = [
             c for c in mock_sns.publish.call_args_list
-            if "FAILOVER" in c[1].get("Subject", "")
+            if "promote data tier" in c[1].get("Subject", "")
         ]
-        assert len(failover_calls) >= 1
+        assert len(failover_calls) == 1
         subject = failover_calls[-1][1]["Subject"]
-        assert "FAILOVER" in subject
-        assert "PROMOTE DATA TIER NOW" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[SentinelFO] CRITICAL:")
+        assert "data tier" in subject.lower()
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "publish_region_health_metric")
@@ -1419,7 +1453,9 @@ class TestSNSFailback:
     def test_failback_blocked_region_not_ready(
         self, mock_sns, mock_get_state, mock_upd, mock_pub, mock_validate, mock_cb
     ):
-        """Region not healthy: FAILBACK BLOCKED notification sent (line 623)."""
+        """v1.6: Failback blocked when target region health gate fails. Subject says
+        'BLOCKED — target region X is not ready'; body lists every issue and tells
+        the operator the override flag."""
         mock_cb.return_value = MagicMock()
         mock_get_state.return_value = _make_failback_state()
         mock_validate.return_value = {
@@ -1434,11 +1470,19 @@ class TestSNSFailback:
         assert result["statusCode"] == 400
         assert mock_sns.publish.called
         subject = _get_sns_subject(mock_sns)
-        assert "FAILBACK BLOCKED" in subject
-        assert "us-east-1" in subject
-        assert "not ready" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[SentinelFO] CRITICAL:")
+        assert "Failback BLOCKED" in subject
+        assert "us-east-1 is not ready" in subject
         assert len(subject) <= 100
+
+        body = _get_sns_message(mock_sns)
+        # Both issues are listed in the CONTEXT block.
+        assert "HTTP health check failed" in body
+        assert "ECS tasks: 0/2 running" in body
+        # Operator gets the explicit override path in WHAT TO DO NEXT.
+        assert "skip_health_check=true" in body
+        # Journey shows we failed at the health gate, before Aurora switchover.
+        assert "[✗] Target region health gate" in body
 
     @patch.object(failback, "create_backend")
     @patch.object(failback, "publish_region_health_metric")
@@ -1448,7 +1492,8 @@ class TestSNSFailback:
     def test_failback_complete_sends_critical(
         self, mock_sns, mock_get_state, mock_upd, mock_pub, mock_cb
     ):
-        """Successful failback: FAILBACK COMPLETE notification sent (line 684)."""
+        """v1.6: Successful failback emits CRITICAL completion email with full
+        journey breadcrumb showing every recovery step is done."""
         mock_cb.return_value = MagicMock()
         mock_get_state.return_value = _make_failback_state()
 
@@ -1457,14 +1502,17 @@ class TestSNSFailback:
         assert result["statusCode"] == 200
         assert mock_sns.publish.called
         subject = _get_sns_subject(mock_sns)
-        assert "FAILBACK COMPLETE" in subject
+        assert subject.startswith("[SentinelFO] CRITICAL:")
+        assert "Failback COMPLETE" in subject
         assert "us-east-1" in subject
-        assert subject.startswith("[SentinelFO]")
         assert len(subject) <= 100
 
-        message = _get_sns_message(mock_sns)
-        assert "Latch" in message or "latch" in message
-        assert "RELEASED" in message or "released" in message
+        body = _get_sns_message(mock_sns)
+        # Latch released and full journey arc shown.
+        assert "Latch" in body and "RELEASED" in body
+        assert "[✓] Latch released" in body
+        # Next-step tells operator what to watch for after recovery.
+        assert "Confirm Route 53" in body or "confirm route 53" in body.lower()
 
     @patch.object(failback, "create_backend")
     @patch.object(failback, "publish_region_health_metric")
@@ -1492,12 +1540,17 @@ class TestSNSFailback:
 
         failed_calls = [
             c for c in mock_sns.publish.call_args_list
-            if "FAILBACK FAILED" in c[1].get("Subject", "")
+            if "Failback FAILED" in c[1].get("Subject", "")
         ]
         assert len(failed_calls) == 1
         subject = failed_calls[0][1]["Subject"]
         assert "us-east-1" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[SentinelFO] CRITICAL:")
+        body = failed_calls[0][1]["Message"]
+        # Body explains the failure happened AFTER the health gate passed,
+        # so the operator knows where to focus debugging.
+        assert "[✓] Health gate passed" in body
+        assert "[✗] DNS/state update — FAILED" in body
 
     @patch.object(failback, "create_backend")
     @patch.object(failback, "publish_region_health_metric")
@@ -1507,7 +1560,8 @@ class TestSNSFailback:
     def test_failback_complete_s3_backend_same_format(
         self, mock_sns, mock_get_state, mock_upd, mock_pub, mock_cb
     ):
-        """S3 backend: FAILBACK COMPLETE SNS format identical to DynamoDB variant."""
+        """S3 backend: failback complete subject identical to DynamoDB variant
+        (state backend is invisible to the notification template)."""
         mock_cb.return_value = MagicMock()
         mock_get_state.return_value = _make_failback_state()
 
@@ -1519,6 +1573,6 @@ class TestSNSFailback:
 
         assert result["statusCode"] == 200
         subject = _get_sns_subject(mock_sns)
-        assert "FAILBACK COMPLETE" in subject
+        assert subject.startswith("[SentinelFO] CRITICAL:")
+        assert "Failback COMPLETE" in subject
         assert "us-east-1" in subject
-        assert subject.startswith("[SentinelFO]")

--- a/tests/test_sns_notifications_failover.py
+++ b/tests/test_sns_notifications_failover.py
@@ -628,6 +628,59 @@ class TestSNSFailoverExecution:
     @patch.object(orch, "publish_region_health_metric")
     @patch.object(orch, "evaluate_region_health")
     @patch.object(orch, "sns")
+    def test_failover_auto_promote_v16_template(
+        self, mock_sns, mock_health, mock_pub, mock_upd
+    ):
+        """v1.6 PR3b: AURORA_AUTO_PROMOTE=true path emits the new structured template.
+
+        Subject is severity-prefixed with "From → To" framing; body has the
+        WHAT/WHY/CONTEXT/JOURNEY/NEXT shape and explains the latch + monitor command.
+        """
+        mock_health.return_value = _unhealthy_health()
+        state = _make_state(consecutive_failures=2)
+        aurora_result = {"success": True, "method": "switchover"}
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(orch, "try_increment_failures", return_value=True))
+            stack.enter_context(patch.object(orch, "try_claim_failover", return_value=True))
+            stack.enter_context(patch.object(orch, "_emit_failover_event"))
+            stack.enter_context(patch.object(orch, "_run_rca_analysis", return_value=""))
+            stack.enter_context(patch.object(orch, "_run_aurora_advisor", return_value=("", None)))
+            stack.enter_context(patch.object(orch, "_auto_promote_aurora", return_value=aurora_result))
+            stack.enter_context(patch.dict(os.environ, {"AURORA_AUTO_PROMOTE": "true"}))
+            stack.enter_context(config_variant(elasticache=True))
+
+            orch._handle_active_region(state, "us-east-1", 2, "1970-01-01T00:00:00Z")
+
+        failover_calls = [
+            c for c in mock_sns.publish.call_args_list
+            if "Failover triggered" in c[1].get("Subject", "")
+        ]
+        assert len(failover_calls) == 1, "Exactly one v1.6-templated failover email expected"
+        subject = failover_calls[0][1]["Subject"]
+        body = failover_calls[0][1]["Message"]
+
+        # Subject: severity prefix + From→To framing.
+        assert subject.startswith("[SentinelFO] CRITICAL:")
+        assert "us-east-1 to us-east-2" in subject
+        assert len(subject) <= 100
+
+        # Body has all four required sections in order.
+        for heading in ("WHAT IS HAPPENING", "WHERE WE ARE IN THE INCIDENT",
+                        "CONTEXT", "WHAT TO DO NEXT"):
+            assert heading in body, f"Missing section: {heading}"
+
+        # Journey breadcrumb shows we're at the failover step.
+        assert "[→] Failover IN PROGRESS" in body
+        # Next-step gives the operator the actual monitor command.
+        assert "describe-db-clusters" in body
+        # Latch context surfaced explicitly so operator knows traffic stays put.
+        assert "latch is engaged" in body.lower()
+
+    @patch.object(orch, "update_failover_state")
+    @patch.object(orch, "publish_region_health_metric")
+    @patch.object(orch, "evaluate_region_health")
+    @patch.object(orch, "sns")
     def test_failover_with_api_gw_decision_reason_in_message(
         self, mock_sns, mock_health, mock_pub, mock_upd
     ):
@@ -755,10 +808,12 @@ class TestSNSAuroraPromotionReminders:
     @patch.object(orch, "publish_region_health_metric")
     @patch.object(orch, "_check_if_aurora_writer", return_value=True)
     @patch.object(orch, "sns")
-    def test_aurora_confirmed_sends_critical(
+    def test_aurora_confirmed_sends_info(
         self, mock_sns, mock_check, mock_pub, mock_upd
     ):
-        """Aurora promotion confirmed: CRITICAL notification sent (line 1872)."""
+        """v1.6: Aurora promotion confirmed is INFO (was CRITICAL — promotion success
+        is good news, not an alert). Subject names the new writer; body explains
+        the app can write again."""
         state = _make_state(
             active_region="us-east-2",
             state="WAITING_AURORA_PROMOTION",
@@ -771,12 +826,15 @@ class TestSNSAuroraPromotionReminders:
 
         assert mock_sns.publish.called
         subject = _get_sns_subject(mock_sns)
-        assert "Aurora promotion confirmed" in subject
-        assert "us-east-2" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[SentinelFO] INFO:")
+        assert "Aurora is now writer in us-east-2" in subject
         assert len(subject) <= 100
         # Flag must be cleared
         mock_upd.assert_called_with({"aurora_promotion_pending": False})
+
+        body = _get_sns_message(mock_sns)
+        assert "your app can now write" in body.lower()
+        assert "[✓] Aurora promoted" in body
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "publish_region_health_metric")
@@ -862,8 +920,9 @@ class TestSNSElasticachePromotionReminders:
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "_check_if_elasticache_primary", return_value=True)
     @patch.object(orch, "sns")
-    def test_ec_confirmed_sends_critical(self, mock_sns, mock_check, mock_upd):
-        """ElastiCache confirmed: CRITICAL notification sent (line 1938)."""
+    def test_ec_confirmed_sends_info(self, mock_sns, mock_check, mock_upd):
+        """v1.6: ElastiCache promotion confirmed is INFO (was CRITICAL — same
+        rationale as Aurora confirmed)."""
         state = _make_state(
             active_region="us-east-2",
             state="WAITING_AURORA_PROMOTION",
@@ -876,11 +935,14 @@ class TestSNSElasticachePromotionReminders:
 
         assert mock_sns.publish.called
         subject = _get_sns_subject(mock_sns)
-        assert "ElastiCache promotion confirmed" in subject
-        assert "us-east-2" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[SentinelFO] INFO:")
+        assert "ElastiCache is now primary in us-east-2" in subject
         assert len(subject) <= 100
         mock_upd.assert_called_with({"redis_promotion_pending": False})
+
+        body = _get_sns_message(mock_sns)
+        assert "[✓] Redis promoted" in body
+        assert "served locally" in body.lower()
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "_check_if_elasticache_primary", return_value=False)

--- a/tests/test_sns_notifications_failover.py
+++ b/tests/test_sns_notifications_failover.py
@@ -235,8 +235,10 @@ class TestSNSDegradationWarnings:
     @patch.object(orch, "try_increment_failures", return_value=True)
     @patch.object(orch, "evaluate_region_health")
     @patch.object(orch, "sns")
-    def test_degraded_warning_s3_ec(self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd):
-        """S3+ElastiCache: WARNING sent when failure count is 2/3 (below threshold)."""
+    def test_degraded_warning_subsequent_failure_s3_ec(
+        self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd
+    ):
+        """v1.6: subsequent failure (2 of 3) — subject says 'health failure 2 of 3'."""
         mock_health.return_value = _unhealthy_health()
         state = _make_state(consecutive_failures=1)
 
@@ -244,12 +246,43 @@ class TestSNSDegradationWarnings:
 
         assert mock_sns.publish.called
         subject = _get_sns_subject(mock_sns)
-        assert "WARNING" in subject
-        assert "degraded" in subject
-        assert "2/3" in subject
+        assert subject.startswith("[SentinelFO] WARNING:")
         assert "us-east-1" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert "2 of 3" in subject
+        assert "sustained" in subject.lower()
         assert len(subject) <= 100
+
+        # Body contains the v1.6 journey breadcrumb and explicit next-step.
+        body = _get_sns_message(mock_sns)
+        assert "WHAT IS HAPPENING" in body
+        assert "WHERE WE ARE IN THE INCIDENT" in body
+        assert "WHAT TO DO NEXT" in body
+        assert "[✓] First failure" in body
+        assert "Sustained (2/3)" in body
+        assert "investigate" in body.lower() or "Investigate" in body
+
+    @patch.object(orch, "update_failover_state")
+    @patch.object(orch, "publish_region_health_metric")
+    @patch.object(orch, "try_increment_failures", return_value=True)
+    @patch.object(orch, "evaluate_region_health")
+    @patch.object(orch, "sns")
+    def test_degraded_warning_first_failure_explicit(
+        self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd
+    ):
+        """v1.6: first failure (1 of 3) — subject says 'FIRST health failure'."""
+        mock_health.return_value = _unhealthy_health()
+        state = _make_state(consecutive_failures=0)
+
+        orch._handle_active_region(state, "us-east-1", 0, "1970-01-01T00:00:00Z")
+
+        subject = _get_sns_subject(mock_sns)
+        assert "FIRST" in subject
+        assert "1 of 3" in subject
+
+        body = _get_sns_message(mock_sns)
+        assert "first failure of an incident" in body
+        # First-failure journey breadcrumb shows "[1]" for the active step.
+        assert "[1] First failure" in body
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "publish_region_health_metric")
@@ -257,18 +290,16 @@ class TestSNSDegradationWarnings:
     @patch.object(orch, "evaluate_region_health")
     @patch.object(orch, "sns")
     def test_degraded_warning_ddb_ec(self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd):
-        """DynamoDB+ElastiCache: WARNING format identical to S3 variant."""
+        """DynamoDB+ElastiCache: same v1.6 contract as S3 variant."""
         mock_health.return_value = _unhealthy_health()
         state = _make_state(consecutive_failures=1)
 
-        # DynamoDB variant: same SNS format, only state backend differs
         with patch.object(orch, "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", "my-global-redis"):
             orch._handle_active_region(state, "us-east-1", 1, "1970-01-01T00:00:00Z")
 
         subject = _get_sns_subject(mock_sns)
+        assert "2 of 3" in subject
         assert "WARNING" in subject
-        assert "degraded" in subject
-        assert "2/3" in subject
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "publish_region_health_metric")
@@ -276,7 +307,7 @@ class TestSNSDegradationWarnings:
     @patch.object(orch, "evaluate_region_health")
     @patch.object(orch, "sns")
     def test_degraded_warning_no_elasticache(self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd):
-        """S3, ElastiCache disabled: WARNING format unchanged when ElastiCache absent."""
+        """S3, ElastiCache disabled: warning body has no ElastiCache content."""
         mock_health.return_value = _unhealthy_health()
         state = _make_state(consecutive_failures=1)
 
@@ -285,9 +316,7 @@ class TestSNSDegradationWarnings:
 
         subject = _get_sns_subject(mock_sns)
         assert "WARNING" in subject
-        assert "degraded" in subject
-        assert "2/3" in subject
-        # No ElastiCache content in degradation warning
+        assert "2 of 3" in subject
         message = _get_sns_message(mock_sns)
         assert "elasticache" not in message.lower()
 
@@ -297,7 +326,7 @@ class TestSNSDegradationWarnings:
     @patch.object(orch, "evaluate_region_health")
     @patch.object(orch, "sns")
     def test_degraded_warning_with_api_gw(self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd):
-        """API GW configured: WARNING format unchanged; API GW failure appears in decision reason."""
+        """API GW configured: decision reason (incl. API GW) flows into the body."""
         mock_health.return_value = {
             "healthy": False,
             "decision_reason": "api_gw_5xx: error rate 75.0% > 50.0%",
@@ -312,8 +341,7 @@ class TestSNSDegradationWarnings:
 
         subject = _get_sns_subject(mock_sns)
         assert "WARNING" in subject
-        assert "degraded" in subject
-        # Decision reason (including API GW) is included in message body
+        assert "2 of 3" in subject
         message = _get_sns_message(mock_sns)
         assert "api_gw_5xx" in message or "75%" in message
 
@@ -322,19 +350,25 @@ class TestSNSDegradationWarnings:
     @patch.object(orch, "try_increment_failures", return_value=True)
     @patch.object(orch, "evaluate_region_health")
     @patch.object(orch, "sns")
-    def test_cooldown_active_sends_critical_subject(self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd):
-        """Threshold reached + cooldown active: subject is 'CRITICAL: ... cooldown active'."""
+    def test_cooldown_active_warning_subject(self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd):
+        """v1.6: cooldown-blocking-failover is WARNING (not CRITICAL — that label was misleading)."""
         mock_health.return_value = _unhealthy_health()
-        # Recent failover keeps cooldown alive
         recent_ts = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
         state = _make_state(consecutive_failures=2)
 
         orch._handle_active_region(state, "us-east-1", 2, recent_ts)
 
         subject = _get_sns_subject(mock_sns)
-        assert "CRITICAL" in subject
+        assert "WARNING" in subject
         assert "cooldown" in subject.lower()
         assert "us-east-1" in subject
+        assert "blocked" in subject.lower()
+
+        body = _get_sns_message(mock_sns)
+        # Journey explicitly tells operator we're at the cooldown phase.
+        assert "Cooldown — failover deferred" in body
+        # Next-step explains the override path so operator isn't stuck guessing.
+        assert "execute_failover" in body
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "publish_region_health_metric")

--- a/tests/test_sns_notifications_failover.py
+++ b/tests/test_sns_notifications_failover.py
@@ -877,7 +877,7 @@ class TestSNSAuroraPromotionReminders:
     def test_aurora_reminder_fires_at_interval(
         self, mock_sns, mock_check, mock_pub, mock_upd
     ):
-        """REMINDER sent when elapsed minutes is divisible by interval (line 1893)."""
+        """v1.6: Aurora promotion reminder fires every N min while pending."""
         # 5 minutes elapsed → int(5) % 5 == 0 → fires
         last_failover_ts = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
         state = _make_state(
@@ -887,16 +887,34 @@ class TestSNSAuroraPromotionReminders:
             last_failover_ts=last_failover_ts,
         )
 
-        with patch.object(orch, "CURRENT_REGION", "us-east-2"):
+        # Pin Aurora env so build_aurora_promotion_commands renders an actual
+        # CLI rather than "no commands available". _ENV's setdefault may have
+        # been beaten by another file's import-time env priming.
+        env_overrides = {
+            "AURORA_GLOBAL_CLUSTER_ID": "my-aurora-global",
+            "AURORA_CLUSTER_ID": "my-aurora-w1",
+            "TARGET_AURORA_CLUSTER_ID": "my-aurora-w2",
+        }
+        with patch.object(orch, "CURRENT_REGION", "us-east-2"), \
+             patch.dict(os.environ, env_overrides), \
+             patch.object(orch, "AURORA_GLOBAL_CLUSTER_ID", "my-aurora-global"), \
+             patch.object(orch, "AURORA_CLUSTER_ID", "my-aurora-w1"), \
+             patch.object(orch, "TARGET_AURORA_CLUSTER_ID", "my-aurora-w2"):
             orch._handle_aurora_promotion_reminder(state)
 
         assert mock_sns.publish.called
         subject = _get_sns_subject(mock_sns)
-        assert "REMINDER" in subject
-        assert "Aurora" in subject
-        assert "pending" in subject
-        assert "5m" in subject
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[SentinelFO] CRITICAL:")
+        assert "Aurora promotion still pending" in subject
+        assert "5 min" in subject
+        assert "operator action required" in subject
+
+        body = _get_sns_message(mock_sns)
+        # Body explains DB writes are blocked + embeds the actual CLI command.
+        assert "CANNOT WRITE" in body
+        assert "switchover-global-cluster" in body
+        # Journey shows we're stuck waiting on operator.
+        assert "[→] Aurora — operator action required" in body
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "publish_region_health_metric")
@@ -996,10 +1014,16 @@ class TestSNSElasticachePromotionReminders:
 
         assert mock_sns.publish.called
         subject = _get_sns_subject(mock_sns)
-        assert "REMINDER" in subject
-        assert "ElastiCache" in subject
-        assert "pending" in subject
-        assert "5m" in subject
+        assert subject.startswith("[SentinelFO] CRITICAL:")
+        assert "ElastiCache promotion still pending" in subject
+        assert "5 min" in subject
+        assert "operator action required" in subject
+
+        body = _get_sns_message(mock_sns)
+        # Body explains writes go cross-region + embeds CLI.
+        assert "CANNOT WRITE" in body
+        assert "failover-global-replication-group" in body
+        assert "[→] Redis — operator action required" in body
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "_check_if_elasticache_primary", return_value=False)
@@ -1089,10 +1113,12 @@ class TestSNSPassiveRegionNotifications:
     def test_passive_unhealthy_sends_warning(
         self, mock_sns, mock_health, mock_staleness, mock_pub, mock_upd
     ):
-        """Passive region unhealthy: WARNING notification sent (line 2411)."""
+        """v1.6: Passive region unhealthy → WARNING explaining the failover safety
+        net is gone. Subject says 'Standby region X is unhealthy — failover would
+        be unsafe'."""
         mock_health.return_value = _unhealthy_health("ECS tasks below minimum")
         state = _make_state(
-            active_region="us-east-1",  # us-east-1 is active
+            active_region="us-east-1",
             latch_engaged=False,
             last_warning_notification_ts="1970-01-01T00:00:00Z",
         )
@@ -1103,12 +1129,14 @@ class TestSNSPassiveRegionNotifications:
 
         assert mock_sns.publish.called
         subject = _get_sns_subject(mock_sns)
-        assert "WARNING" in subject
-        assert "Passive" in subject
-        assert "us-east-2" in subject
-        assert "unhealthy" in subject.lower()
-        assert subject.startswith("[SentinelFO]")
+        assert subject.startswith("[SentinelFO] WARNING:")
+        assert "Standby region us-east-2 is unhealthy" in subject
+        assert "failover would be unsafe" in subject.lower()
         assert len(subject) <= 100
+
+        body = _get_sns_message(mock_sns)
+        assert "[⚠] Standby region us-east-2: UNHEALTHY" in body
+        assert "Failover safety net DOWN" in body
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "publish_region_health_metric")
@@ -1141,9 +1169,9 @@ class TestSNSPassiveRegionNotifications:
     def test_dual_region_outage_sends_critical(
         self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd
     ):
-        """Both regions unhealthy: Dual-Region Outage CRITICAL notification (line 2551)."""
+        """v1.6: Both regions unhealthy → CRITICAL with 'app is DOWN' framing,
+        explicit 'NOT a failover candidate' next-step, and the on-call escalation."""
         mock_health.return_value = _unhealthy_health()
-        # Target (us-east-2) is marked unhealthy in region_health map
         target_ts = datetime.now(timezone.utc).isoformat()
         state = _make_state(
             consecutive_failures=2,
@@ -1156,14 +1184,20 @@ class TestSNSPassiveRegionNotifications:
 
         outage_calls = [
             c for c in mock_sns.publish.call_args_list
-            if "Dual-Region" in c[1].get("Subject", "")
+            if "Dual-region" in c[1].get("Subject", "")
         ]
         assert len(outage_calls) == 1
         subject = outage_calls[0][1]["Subject"]
-        assert "CRITICAL" in subject
-        assert "Dual-Region" in subject
-        assert "Outage" in subject
-        assert subject.startswith("[SentinelFO]")
+        body = outage_calls[0][1]["Message"]
+        assert subject.startswith("[SentinelFO] CRITICAL:")
+        assert "Dual-region outage" in subject
+        assert "DOWN" in subject
+
+        # Body explicitly tells the operator NOT to failover.
+        assert "NOT a failover candidate" in body
+        assert "Page the on-call DBA and SRE" in body
+        # Journey makes the halt visible.
+        assert "[⏸] Failover HALTED" in body
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "publish_region_health_metric")
@@ -1173,7 +1207,8 @@ class TestSNSPassiveRegionNotifications:
     def test_failover_recommended_manual_mode(
         self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd
     ):
-        """FAILOVER_MODE=manual: FAILOVER RECOMMENDED warning sent (line 2578)."""
+        """v1.6: FAILOVER_MODE=manual sends WARNING explaining the threshold was
+        reached but DNS was NOT moved; body embeds the exact override Lambda invoke."""
         mock_health.return_value = _unhealthy_health()
         state = _make_state(consecutive_failures=2)
 
@@ -1182,10 +1217,16 @@ class TestSNSPassiveRegionNotifications:
 
         assert mock_sns.publish.called
         subject = _get_sns_subject(mock_sns)
-        assert "FAILOVER RECOMMENDED" in subject
-        assert "manual mode" in subject
-        assert "us-east-1" in subject
-        assert "us-east-2" in subject
+        assert subject.startswith("[SentinelFO] WARNING:")
+        assert "RECOMMENDED" in subject
+        assert "FAILOVER_MODE is manual" in subject
+
+        body = _get_sns_message(mock_sns)
+        # Override command embedded in next-step.
+        assert "execute_failover" in body
+        assert "lambda invoke" in body
+        # Journey shows we're awaiting operator decision.
+        assert "[⏸] Awaiting operator (manual mode)" in body
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "publish_region_health_metric")
@@ -1213,9 +1254,8 @@ class TestSNSPassiveRegionNotifications:
             orch._handle_passive_region(state, "us-east-1")
 
         subject = _get_sns_subject(mock_sns)
-        assert "WARNING" in subject
-        assert "Passive" in subject
-        assert "us-east-2" in subject
+        assert subject.startswith("[SentinelFO] WARNING:")
+        assert "Standby region us-east-2 is unhealthy" in subject
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Rewrites every operator-facing SNS notification in both Lambdas (29 sites) to PR2's structured template. Five commits on this branch (PR3a–e), reviewable in chunks but shipping as one merge unit:

| Commit | Sites | Focus |
|---|---|---|
| 2db6ec7 (PR3a) | 2 | WARNING-path: first failure / sustained / cooldown |
| 0f431d2 (PR3b) | 3 | Failover trigger + Aurora/Redis promotion-confirmed |
| ed52d24 (PR3c) | 5 | Manual data-tier failover + 4 failback Lambda emails |
| b40a92f (PR3d) | 5 | Reminders + dual-region outage + passive unhealthy + manual mode |
| 0956af5 (PR3e) | 14 | Active-active + manual-trigger + region-failure + AI-advised + exceptions |

\`detect_data_tier_config()\` from PR1 changed to read \`os.environ\` at call time (was reading module-level globals). Fixes a real test-isolation issue and makes portal env-var flips effective without a Lambda cold start.

## Test plan

- [x] All 5 commits independently keep CI green; final tip: 330 passed, 0 regressions
- [x] Updated ~25 existing tests in lockstep with the rewrites
- [ ] Visual: deploy to fo-v10x-s1 and confirm a real incident produces the new email shape (deferred to v1.6 drill validation)

## Stack

- Base: \`feature/v1.6-notification-template\` (#76)
- Builds on #76 (compose_message helper) and transitively #72 (config detection).
- Merge order: #72 → #76 → this.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)