### PR TITLE
v1.6 PR4 (F4): default failback HEALTH_ENDPOINT to /healthcheck

### DIFF
--- a/manual_failback_v2.py
+++ b/manual_failback_v2.py
@@ -83,7 +83,12 @@ APP_NAME = os.environ.get("APP_NAME", "")
 ENVIRONMENT = os.environ.get("ENVIRONMENT", "")
 
 HEALTH_CHECK_URL = os.environ.get("HEALTH_CHECK_URL", "")
-HEALTH_ENDPOINT = os.environ.get("HEALTH_ENDPOINT", "/actuator/health")
+# Default to /healthcheck (shallow, app-only) per CLAUDE.md recommendation.
+# /actuator/health and /deep-healthcheck typically include DB connectivity
+# checks, which can return 503 from DB-config issues unrelated to the actual
+# app health — those false positives blocked the v1.5 drill's failback step.
+# Operators who genuinely want deep validation can override via env var.
+HEALTH_ENDPOINT = os.environ.get("HEALTH_ENDPOINT", "/healthcheck")
 HEALTH_CHECK_TIMEOUT_SECONDS = int(os.environ.get("HEALTH_CHECK_TIMEOUT_SECONDS", "5"))
 ECS_CLUSTER_NAME = os.environ.get("ECS_CLUSTER_NAME", "")
 ECS_SERVICE_NAME = os.environ.get("ECS_SERVICE_NAME", "")

--- a/tests/test_config_detection.py
+++ b/tests/test_config_detection.py
@@ -179,3 +179,27 @@ def test_redis_auto_requires_redis_present():
         cfg = orch.detect_data_tier_config()
         assert cfg["redis_present"] is False
         assert cfg["redis_auto"] is False
+
+
+# ---------------------------------------------------------------------------
+# F4 (PR4): failback Lambda's HEALTH_ENDPOINT default
+# ---------------------------------------------------------------------------
+
+def test_failback_health_endpoint_default_is_shallow():
+    """v1.6 F4: failback Lambda defaults HEALTH_ENDPOINT to /healthcheck (shallow).
+
+    The previous default `/actuator/health` is Spring Boot-specific and typically
+    includes DB connectivity checks. CLAUDE.md recommends `/healthcheck` (app-only)
+    to avoid the false-positives from DB-config issues that blocked the v1.5 drill's
+    failback step. Operators who genuinely want deep validation can override via env.
+    """
+    # Module-level constant reflects the default at import time (no env var set).
+    # Since other test files may have set HEALTH_ENDPOINT via setdefault, we
+    # verify the source-of-truth: the default literal in the os.environ.get call.
+    import inspect
+    src = inspect.getsource(failback)
+    # Look for the default in the literal getter (one line, deterministic).
+    assert 'os.environ.get("HEALTH_ENDPOINT", "/healthcheck")' in src, (
+        "Failback Lambda's HEALTH_ENDPOINT default must be /healthcheck per F4. "
+        "If you intentionally changed it, update this test."
+    )


### PR DESCRIPTION
## Summary

1-line fix closing **F4** from the v1.5 drill report. Changes \`manual_failback_v2.py:86\` default for \`HEALTH_ENDPOINT\` from \`/actuator/health\` (Spring Boot specific, often DB-coupled) to \`/healthcheck\` (shallow, app-only) per CLAUDE.md guidance.

## Test plan

- [x] \`pytest tests/ -v\` — 331 passed (330 + 1 new), 0 regressions
- [x] Source-inspection test added to avoid load-order pollution from \`os.environ.setdefault\` in other test files

## Note for orchestrator

The orchestrator's \`HEALTH_ENDPOINT\` default is left at \`/actuator/health\` for now — touching it would change behavior for any deployment relying on the historical default. Out of scope for this F4-failback fix; can be a separate small PR if symmetric defaults are desired.

## Stack

- Base: \`feature/v1.6-notification-rewrite\` (#78)
- Merge order: #72 → #76 → #78 → this.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)