### PR TITLE
v1.6 PR5 (F5): config-aware Aurora + Redis gates in failback Lambda

### DIFF
--- a/manual_failback_v2.py
+++ b/manual_failback_v2.py
@@ -522,6 +522,138 @@ STEP 3: Then run this Lambda IN THE TARGET REGION with aurora_confirmed=true:
 """
 
 
+def build_redis_failover_commands(target_region: str) -> str:
+    """Build the ElastiCache Global Datastore failover commands for the operator.
+
+    Mirror of build_aurora_switchover_commands. Used by the Redis manual gate
+    in C4/C5/C8 configs (Redis present, ELASTICACHE_AUTO_PROMOTE=false).
+    """
+    if not ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID:
+        return "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID not configured."
+
+    target_rg_id = ELASTICACHE_REPLICATION_GROUP_ID or "<TARGET_RG_ID>"
+    # Suffix swap when target_rg appears to be the local-region RG and we're
+    # invoking from the other region's perspective (mirror of the Aurora trick).
+    if target_rg_id != "<TARGET_RG_ID>":
+        if target_region == "us-west-2" and target_rg_id.endswith("-w1"):
+            target_rg_id = target_rg_id[:-3] + "-w2"
+        elif target_region == "us-west-1" and target_rg_id.endswith("-w2"):
+            target_rg_id = target_rg_id[:-3] + "-w1"
+
+    return f"""
+========================================================================
+ELASTICACHE FAILOVER COMMANDS - RUN THESE BEFORE FAILBACK
+========================================================================
+
+STEP 1: Failover ElastiCache Global Datastore to {target_region}:
+
+  aws elasticache failover-global-replication-group \\
+    --global-replication-group-id {ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID} \\
+    --primary-region {target_region} \\
+    --primary-replication-group-id {target_rg_id}
+
+STEP 2: Wait for failover to complete. Monitor with:
+
+  aws elasticache describe-global-replication-groups \\
+    --global-replication-group-id {ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID} \\
+    --show-member-info
+
+  When the member in {target_region} shows Role=PRIMARY, failover is complete.
+
+STEP 3: Then re-invoke this Lambda with redis_confirmed=true (alongside
+        aurora_confirmed=true if Aurora is also configured):
+
+  aws lambda invoke \\
+    --function-name {os.environ.get('AWS_LAMBDA_FUNCTION_NAME', 'failover-manual-failback')} \\
+    --payload '{{"target_region": "{target_region}", "operator": "YOUR_NAME", "aurora_confirmed": true, "redis_confirmed": true}}' \\
+    --region {target_region} \\
+    response.json
+
+========================================================================
+"""
+
+
+def _auto_switchover_aurora(target_region: str) -> dict:
+    """Trigger Aurora switchover-global-cluster from the failback Lambda itself.
+
+    Used in the C3/C6/C9 paths where AURORA_AUTO_PROMOTE=true. Mirror of the
+    orchestrator's _auto_promote_aurora but tailored to failback (planned
+    switchover, never failover-with-data-loss).
+
+    Returns: ``{"success": bool, "error": str}``.
+    """
+    if not AURORA_GLOBAL_CLUSTER_ID:
+        return {"success": False, "error": "AURORA_GLOBAL_CLUSTER_ID not configured"}
+
+    target_cluster_id = TARGET_AURORA_CLUSTER_ID or AURORA_CLUSTER_ID
+    if not TARGET_AURORA_CLUSTER_ID and target_cluster_id:
+        if target_region == "us-west-2" and target_cluster_id.endswith("-w1"):
+            target_cluster_id = target_cluster_id[:-3] + "-w2"
+        elif target_region == "us-west-1" and target_cluster_id.endswith("-w2"):
+            target_cluster_id = target_cluster_id[:-3] + "-w1"
+
+    if not target_cluster_id or not _AWS_ACCOUNT_ID:
+        return {"success": False, "error": "Cannot determine target cluster ARN"}
+
+    target_arn = (
+        f"arn:aws:rds:{target_region}:{_AWS_ACCOUNT_ID}:cluster:{target_cluster_id}"
+    )
+    try:
+        rds = boto3.client("rds", region_name=CURRENT_REGION, config=_client_config)
+        rds.switchover_global_cluster(
+            GlobalClusterIdentifier=AURORA_GLOBAL_CLUSTER_ID,
+            TargetDbClusterIdentifier=target_arn,
+        )
+        logger.info(
+            f"Aurora switchover initiated: {AURORA_GLOBAL_CLUSTER_ID} → {target_arn}"
+        )
+        return {"success": True, "error": ""}
+    except ClientError as e:
+        msg = f"Aurora switchover-global-cluster API failed: {e}"
+        logger.error(msg)
+        return {"success": False, "error": msg}
+
+
+def _auto_failover_redis(target_region: str) -> dict:
+    """Trigger ElastiCache Global Datastore failover from the failback Lambda.
+
+    Used in the C7/C8/C9 paths where ELASTICACHE_AUTO_PROMOTE=true. Mirror of
+    the orchestrator's _auto_promote_elasticache.
+
+    Returns: ``{"success": bool, "error": str}``.
+    """
+    if not ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID:
+        return {"success": False, "error": "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID not configured"}
+
+    target_rg_id = ELASTICACHE_REPLICATION_GROUP_ID
+    # Suffix swap when ELASTICACHE_REPLICATION_GROUP_ID is the local-region RG.
+    if target_rg_id:
+        if target_region == "us-west-2" and target_rg_id.endswith("-w1"):
+            target_rg_id = target_rg_id[:-3] + "-w2"
+        elif target_region == "us-west-1" and target_rg_id.endswith("-w2"):
+            target_rg_id = target_rg_id[:-3] + "-w1"
+
+    if not target_rg_id:
+        return {"success": False, "error": "Cannot determine target RG ID"}
+
+    try:
+        ec = boto3.client("elasticache", region_name=CURRENT_REGION, config=_client_config)
+        ec.failover_global_replication_group(
+            GlobalReplicationGroupId=ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID,
+            PrimaryRegion=target_region,
+            PrimaryReplicationGroupId=target_rg_id,
+        )
+        logger.info(
+            f"ElastiCache failover initiated: "
+            f"{ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID} → {target_region}/{target_rg_id}"
+        )
+        return {"success": True, "error": ""}
+    except ClientError as e:
+        msg = f"ElastiCache failover-global-replication-group API failed: {e}"
+        logger.error(msg)
+        return {"success": False, "error": msg}
+
+
 def _reload_dynamic_config():
     """Re-read config that the portal may change between invocations."""
     global _state_backend, _remote_state_backend, _REMOTE_STATE_BUCKET
@@ -548,7 +680,19 @@ def handler(event, context):
         "target_region": "us-east-1",
         "skip_health_check": false,
         "operator": "enrique",
-        "aurora_confirmed": true    <-- REQUIRED: operator confirms Aurora is switched
+
+        # Aurora gates (only checked when Aurora is configured per
+        # detect_data_tier_config). If AURORA_AUTO_PROMOTE=true the Lambda
+        # performs the switchover itself and aurora_confirmed is not needed;
+        # if AURORA_AUTO_PROMOTE=false the operator must run the switchover
+        # manually first and pass aurora_confirmed=true.
+        "aurora_confirmed": true,         # required when Aurora present + manual
+        "skip_aurora_check": false,       # break-glass for the Aurora gate
+
+        # Redis gates (only checked when ElastiCache is configured). Same
+        # auto-vs-manual contract as Aurora. New in v1.6 (PR5/F5).
+        "redis_confirmed": true,          # required when Redis present + manual
+        "skip_redis_check": false,        # break-glass for the Redis gate
     }
     """
     _reload_dynamic_config()
@@ -557,13 +701,19 @@ def handler(event, context):
     skip_health_check = event.get("skip_health_check", False)
     operator = event.get("operator", "unknown")
     aurora_confirmed = event.get("aurora_confirmed", False)
+    skip_aurora_check = event.get("skip_aurora_check", False)
+    redis_confirmed = event.get("redis_confirmed", False)
+    skip_redis_check = event.get("skip_redis_check", False)
+    cfg = detect_data_tier_config()
     now = datetime.now(timezone.utc)
 
     logger.info(
         f"Manual failback initiated by {operator} to {target_region} | "
         f"skip_health_check={skip_health_check}, "
-        f"aurora_confirmed={aurora_confirmed}, "
-        f"current_region={CURRENT_REGION}"
+        f"aurora_confirmed={aurora_confirmed}, skip_aurora_check={skip_aurora_check}, "
+        f"redis_confirmed={redis_confirmed}, skip_redis_check={skip_redis_check}, "
+        f"current_region={CURRENT_REGION}, "
+        f"data_tier_config={cfg}"
     )
 
     # Step 1: Validate current state
@@ -595,20 +745,98 @@ def handler(event, context):
         logger.error(msg)
         return {"statusCode": 409, "body": msg}
 
-    # Step 2: Check if Aurora has been confirmed by the operator
-    logger.info("Step 2: Checking Aurora confirmation...")
-    if not aurora_confirmed:
-        commands = build_aurora_switchover_commands(target_region)
-        msg = (
-            f"Aurora switchover has NOT been confirmed.\n\n"
-            f"You must switchover Aurora BEFORE running failback.\n\n"
-            f"{commands}\n\n"
-            f"Once Aurora switchover is complete, run this Lambda again "
-            f"with aurora_confirmed=true."
-        )
-        logger.info("Aurora not confirmed, returning switchover commands")
-        return {"statusCode": 400, "body": msg}
-    logger.info("Aurora confirmed by operator")
+    # Step 2: Config-aware data-tier gates (PR5 / F5)
+    #
+    # The failback Lambda has to behave differently for each of the 9 baseline
+    # configurations (C1–C9). detect_data_tier_config() returns the four flags
+    # that drive the per-tier branching below:
+    #
+    #   aurora_present + aurora_auto      → Lambda runs switchover itself
+    #   aurora_present + not aurora_auto  → require aurora_confirmed=true
+    #   not aurora_present                → no Aurora gate at all
+    #   (same shape for Redis)
+    #
+    # Either tier can be overridden with skip_*_check=true as a break-glass
+    # when the operator has human-verified the data tier is ready and just
+    # wants the latch released.
+
+    # Aurora gate
+    if cfg["aurora_present"]:
+        if cfg["aurora_auto"] and not aurora_confirmed and not skip_aurora_check:
+            logger.info("Step 2a: Aurora auto-switchover from failback Lambda...")
+            result = _auto_switchover_aurora(target_region)
+            if not result["success"]:
+                msg = (
+                    f"Aurora auto-switchover FAILED.\n"
+                    f"Error: {result['error']}\n\n"
+                    f"Either restore Aurora's switchover capability and re-invoke "
+                    f"this Lambda, or run the switchover manually and re-invoke "
+                    f"with aurora_confirmed=true (or skip_aurora_check=true to "
+                    f"bypass the gate entirely).\n\n"
+                    f"{build_aurora_switchover_commands(target_region)}"
+                )
+                logger.error(msg)
+                return {"statusCode": 500, "body": msg}
+            logger.info("Aurora auto-switchover initiated by Lambda")
+            aurora_confirmed = True  # we just did it
+        elif not cfg["aurora_auto"] and not aurora_confirmed and not skip_aurora_check:
+            commands = build_aurora_switchover_commands(target_region)
+            msg = (
+                f"Aurora switchover has NOT been confirmed and "
+                f"AURORA_AUTO_PROMOTE is not enabled.\n\n"
+                f"You must switchover Aurora manually BEFORE running failback, "
+                f"OR pass skip_aurora_check=true if you have human-verified "
+                f"that Aurora is already in {target_region}.\n\n"
+                f"{commands}"
+            )
+            logger.info("Aurora not confirmed (manual mode), returning switchover commands")
+            return {"statusCode": 400, "body": msg}
+        else:
+            logger.info(
+                f"Aurora gate cleared "
+                f"(aurora_confirmed={aurora_confirmed}, skip_aurora_check={skip_aurora_check})"
+            )
+    else:
+        logger.info("Aurora gate skipped — Aurora not configured")
+
+    # Redis gate (mirror of Aurora). Only fires when ElastiCache is configured.
+    if cfg["redis_present"]:
+        if cfg["redis_auto"] and not redis_confirmed and not skip_redis_check:
+            logger.info("Step 2b: Redis auto-failover from failback Lambda...")
+            result = _auto_failover_redis(target_region)
+            if not result["success"]:
+                msg = (
+                    f"ElastiCache auto-failover FAILED.\n"
+                    f"Error: {result['error']}\n\n"
+                    f"Either restore ElastiCache's failover capability and "
+                    f"re-invoke this Lambda, or run the failover manually and "
+                    f"re-invoke with redis_confirmed=true (or skip_redis_check="
+                    f"true to bypass the gate entirely).\n\n"
+                    f"{build_redis_failover_commands(target_region)}"
+                )
+                logger.error(msg)
+                return {"statusCode": 500, "body": msg}
+            logger.info("ElastiCache auto-failover initiated by Lambda")
+            redis_confirmed = True  # we just did it
+        elif not cfg["redis_auto"] and not redis_confirmed and not skip_redis_check:
+            commands = build_redis_failover_commands(target_region)
+            msg = (
+                f"ElastiCache failover has NOT been confirmed and "
+                f"ELASTICACHE_AUTO_PROMOTE is not enabled.\n\n"
+                f"You must failover ElastiCache manually BEFORE running "
+                f"failback, OR pass skip_redis_check=true if you have human-"
+                f"verified that ElastiCache is already primary in {target_region}.\n\n"
+                f"{commands}"
+            )
+            logger.info("Redis not confirmed (manual mode), returning failover commands")
+            return {"statusCode": 400, "body": msg}
+        else:
+            logger.info(
+                f"Redis gate cleared "
+                f"(redis_confirmed={redis_confirmed}, skip_redis_check={skip_redis_check})"
+            )
+    else:
+        logger.info("Redis gate skipped — ElastiCache not configured")
 
     # Step 2.5: AI Failback Readiness Assessment (non-blocking)
     readiness_appendix = ""

--- a/tests/test_sns_notifications_failover.py
+++ b/tests/test_sns_notifications_failover.py
@@ -1622,3 +1622,208 @@ class TestSNSFailback:
         assert subject.startswith("[SentinelFO] CRITICAL:")
         assert "Failback COMPLETE" in subject
         assert "us-east-1" in subject
+
+
+# ===========================================================================
+# 9. TestSNSFailbackRedisGate (PR5 / F5)
+#    Tests the new Redis-confirmed / auto-failover gates added in v1.6.
+# ===========================================================================
+
+class TestSNSFailbackRedisGate:
+    """v1.6 PR5: failback Lambda's config-aware Redis gate.
+
+    Mirror of the Aurora gate. Required when ElastiCache is configured;
+    skipped entirely when it isn't (C1/C2/C3 stacks).
+    """
+
+    # C5 (Aurora manual + Redis manual): require BOTH _confirmed flags
+    _C5_ENV = {
+        "AURORA_CLUSTER_ID": "my-aurora-w1",
+        "AURORA_AUTO_PROMOTE": "false",
+        "AURORA_GLOBAL_CLUSTER_ID": "my-aurora-global",
+        "TARGET_AURORA_CLUSTER_ID": "my-aurora-w2",
+        "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID": "my-global-redis",
+        "ELASTICACHE_REPLICATION_GROUP_ID": "my-redis-rg",
+        "ELASTICACHE_AUTO_PROMOTE": "false",
+    }
+
+    # C9 (Aurora auto + Redis auto): no _confirmed flags needed
+    _C9_ENV = {
+        **_C5_ENV,
+        "AURORA_AUTO_PROMOTE": "true",
+        "ELASTICACHE_AUTO_PROMOTE": "true",
+    }
+
+    @patch.object(failback, "create_backend")
+    @patch.object(failback, "publish_region_health_metric")
+    @patch.object(failback, "update_failover_state")
+    @patch.object(failback, "get_failover_state")
+    @patch.object(failback, "sns")
+    def test_redis_gate_rejects_when_redis_not_confirmed(
+        self, mock_sns, mock_get_state, mock_upd, mock_pub, mock_cb
+    ):
+        """C5 (both manual): aurora_confirmed=true alone is NOT enough — failback
+        must reject with the Redis failover commands until redis_confirmed=true."""
+        mock_cb.return_value = MagicMock()
+        mock_get_state.return_value = _make_failback_state()
+
+        with patch.dict(os.environ, self._C5_ENV):
+            result = failback.handler({
+                "target_region": "us-east-1",
+                "operator": "test",
+                "aurora_confirmed": True,
+                "skip_health_check": True,
+                "skip_readiness_check": True,
+                # redis_confirmed missing → should reject
+            }, None)
+
+        assert result["statusCode"] == 400
+        body = result["body"]
+        assert "ElastiCache failover has NOT been confirmed" in body
+        assert "failover-global-replication-group" in body
+        assert "redis_confirmed=true" in body or "skip_redis_check=true" in body
+
+    @patch.object(failback, "create_backend")
+    @patch.object(failback, "publish_region_health_metric")
+    @patch.object(failback, "update_failover_state")
+    @patch.object(failback, "get_failover_state")
+    @patch.object(failback, "sns")
+    def test_redis_gate_passes_when_redis_confirmed(
+        self, mock_sns, mock_get_state, mock_upd, mock_pub, mock_cb
+    ):
+        """C5: aurora_confirmed=true + redis_confirmed=true → failback proceeds."""
+        mock_cb.return_value = MagicMock()
+        mock_get_state.return_value = _make_failback_state()
+
+        with patch.dict(os.environ, self._C5_ENV):
+            result = failback.handler({
+                "target_region": "us-east-1",
+                "operator": "test",
+                "aurora_confirmed": True,
+                "redis_confirmed": True,
+                "skip_health_check": True,
+                "skip_readiness_check": True,
+            }, None)
+
+        assert result["statusCode"] == 200
+        subject = _get_sns_subject(mock_sns)
+        assert "Failback COMPLETE" in subject
+
+    @patch.object(failback, "create_backend")
+    @patch.object(failback, "publish_region_health_metric")
+    @patch.object(failback, "update_failover_state")
+    @patch.object(failback, "get_failover_state")
+    @patch.object(failback, "sns")
+    def test_skip_redis_check_break_glass(
+        self, mock_sns, mock_get_state, mock_upd, mock_pub, mock_cb
+    ):
+        """skip_redis_check=true bypasses the Redis gate even without redis_confirmed.
+
+        Use case: operator has manually verified Redis is in target_region but
+        doesn't want to bother with the explicit confirmation flag (e.g., Redis
+        was already in target_region from the start of the incident)."""
+        mock_cb.return_value = MagicMock()
+        mock_get_state.return_value = _make_failback_state()
+
+        with patch.dict(os.environ, self._C5_ENV):
+            result = failback.handler({
+                "target_region": "us-east-1",
+                "operator": "test",
+                "aurora_confirmed": True,
+                "skip_redis_check": True,  # break-glass
+                "skip_health_check": True,
+                "skip_readiness_check": True,
+            }, None)
+
+        assert result["statusCode"] == 200
+
+    @patch.object(failback, "_auto_failover_redis")
+    @patch.object(failback, "_auto_switchover_aurora")
+    @patch.object(failback, "create_backend")
+    @patch.object(failback, "publish_region_health_metric")
+    @patch.object(failback, "update_failover_state")
+    @patch.object(failback, "get_failover_state")
+    @patch.object(failback, "sns")
+    def test_c9_lambda_does_both_data_tier_actions_itself(
+        self, mock_sns, mock_get_state, mock_upd, mock_pub, mock_cb,
+        mock_aurora, mock_redis,
+    ):
+        """C9 (both auto): no _confirmed flags needed. Lambda invokes the
+        switchover-global-cluster + failover-global-replication-group APIs
+        itself."""
+        mock_cb.return_value = MagicMock()
+        mock_get_state.return_value = _make_failback_state()
+        mock_aurora.return_value = {"success": True, "error": ""}
+        mock_redis.return_value = {"success": True, "error": ""}
+
+        with patch.dict(os.environ, self._C9_ENV):
+            result = failback.handler({
+                "target_region": "us-east-1",
+                "operator": "test",
+                "skip_health_check": True,
+                "skip_readiness_check": True,
+                # No aurora_confirmed or redis_confirmed — Lambda handles both.
+            }, None)
+
+        assert result["statusCode"] == 200
+        # Lambda made both API calls itself.
+        mock_aurora.assert_called_once_with("us-east-1")
+        mock_redis.assert_called_once_with("us-east-1")
+
+    @patch.object(failback, "_auto_failover_redis")
+    @patch.object(failback, "_auto_switchover_aurora")
+    @patch.object(failback, "create_backend")
+    @patch.object(failback, "publish_region_health_metric")
+    @patch.object(failback, "update_failover_state")
+    @patch.object(failback, "get_failover_state")
+    @patch.object(failback, "sns")
+    def test_c9_redis_auto_failure_rejects_with_500(
+        self, mock_sns, mock_get_state, mock_upd, mock_pub, mock_cb,
+        mock_aurora, mock_redis,
+    ):
+        """C9: when the Redis auto-failover API call fails, Lambda must reject
+        with a 500 status code rather than silently complete the failback —
+        otherwise the F5 problem (Redis split-brain after failback) returns."""
+        mock_cb.return_value = MagicMock()
+        mock_get_state.return_value = _make_failback_state()
+        mock_aurora.return_value = {"success": True, "error": ""}
+        mock_redis.return_value = {"success": False, "error": "API timeout"}
+
+        with patch.dict(os.environ, self._C9_ENV):
+            result = failback.handler({
+                "target_region": "us-east-1",
+                "operator": "test",
+                "skip_health_check": True,
+                "skip_readiness_check": True,
+            }, None)
+
+        assert result["statusCode"] == 500
+        assert "ElastiCache auto-failover FAILED" in result["body"]
+        # Operator gets the manual override path in the rejection body.
+        assert "redis_confirmed=true" in result["body"] or "skip_redis_check=true" in result["body"]
+
+    @patch.object(failback, "create_backend")
+    @patch.object(failback, "publish_region_health_metric")
+    @patch.object(failback, "update_failover_state")
+    @patch.object(failback, "get_failover_state")
+    @patch.object(failback, "sns")
+    def test_c1_no_data_tier_no_gates(
+        self, mock_sns, mock_get_state, mock_upd, mock_pub, mock_cb
+    ):
+        """C1 (no Aurora, no Redis): app-only stack. Failback should succeed
+        without ANY confirmation flags — there's nothing to confirm."""
+        mock_cb.return_value = MagicMock()
+        mock_get_state.return_value = _make_failback_state()
+
+        with patch.dict(os.environ, {
+            "AURORA_CLUSTER_ID": "",
+            "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID": "",
+        }):
+            result = failback.handler({
+                "target_region": "us-east-1",
+                "operator": "test",
+                "skip_health_check": True,
+                "skip_readiness_check": True,
+            }, None)
+
+        assert result["statusCode"] == 200


### PR DESCRIPTION
## Summary

Closes **F5**. Failback no longer silently completes without touching ElastiCache. The Lambda now has parallel gates for Aurora + Redis driven by \`detect_data_tier_config()\` (PR1), so each of the 9 baseline configurations C1–C9 gets the right operator contract.

## Behavior change

Three states per tier (absent / present+manual / present+auto):
- **manual** path requires \`aurora_confirmed=true\` / \`redis_confirmed=true\` (with \`skip_*_check=true\` break-glass)
- **auto** path: Lambda invokes \`switchover-global-cluster\` / \`failover-global-replication-group\` itself
- **absent** path: no gate

The F5 fix specifically: **auto-failover API failure now returns HTTP 500**. Previously a transient Redis API error during failback let the failback complete silently — Redis split-brain.

## Test plan

- [x] \`pytest tests/test_sns_notifications_failover.py::TestSNSFailbackRedisGate -v\` — 6 new cases pass
- [x] \`pytest tests/ -v\` — 337 passed (331 + 6 new), 0 regressions
- [ ] PR7 will add 49 cross-config matrix tests that further exercise the gate

## Stack

- Base: \`feature/v1.6-failback-health-default\` (#80)
- Merge order: #72 → #76 → #78 → #80 → this.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)