### PR TITLE
v1.7.1: failback Lambda waits for promotion completion (F10)

### DIFF
--- a/cfn/failover.yaml
+++ b/cfn/failover.yaml
@@ -260,7 +260,12 @@ Resources:
       Runtime: python3.12
       Handler: manual_failback_v2.handler
       Role: !GetAtt LambdaRole.Arn
-      Timeout: 120
+      # v1.7.1 (F10): bumped from 120s to 600s. The Lambda now polls inline
+      # for Aurora switchover + ElastiCache failover completion (via
+      # FAILBACK_PROMOTION_WAIT_TIMEOUT_SECONDS, default 480s) so the
+      # validate_target_region_health step doesn't run before the data tier
+      # has actually flipped.
+      Timeout: 600
       MemorySize: 256
       Code:
         ZipFile: |

--- a/manual_failback_v2.py
+++ b/manual_failback_v2.py
@@ -36,6 +36,7 @@ import os
 import json
 import logging
 import ssl
+import time
 from datetime import datetime, timezone
 from typing import Optional
 from urllib.request import urlopen, Request
@@ -623,17 +624,23 @@ def _resolve_target_aurora_arn(target_region: str) -> Optional[str]:
 
 
 def _auto_switchover_aurora(target_region: str) -> dict:
-    """Trigger Aurora switchover-global-cluster from the failback Lambda itself.
+    """Trigger Aurora switchover-global-cluster AND wait for completion.
 
     Used in the C3/C6/C9 paths where AURORA_AUTO_PROMOTE=true. Mirror of the
     orchestrator's _auto_promote_aurora but tailored to failback (planned
     switchover, never failover-with-data-loss).
 
-    Returns: ``{"success": bool, "error": str}``.
+    v1.7.1 (F10): now blocks on writer-flip completion before returning. The
+    SwitchoverGlobalCluster API returns immediately, but the actual writer
+    role flip takes 1–3 minutes — without this, validate_target_region_health
+    runs too early and refuses the failback. Configurable timeout via
+    FAILBACK_PROMOTION_WAIT_TIMEOUT_SECONDS (default 480s).
+
+    Returns: ``{"success": bool, "error": str, "elapsed_seconds": int}``.
     """
     target_arn = _resolve_target_aurora_arn(target_region)
     if not target_arn:
-        return {"success": False, "error": "Cannot determine target cluster ARN — set AURORA_GLOBAL_CLUSTER_ID + AURORA_CLUSTER_ID"}
+        return {"success": False, "error": "Cannot determine target cluster ARN — set AURORA_GLOBAL_CLUSTER_ID + AURORA_CLUSTER_ID", "elapsed_seconds": 0}
 
     try:
         rds = boto3.client("rds", region_name=CURRENT_REGION, config=_client_config)
@@ -644,11 +651,66 @@ def _auto_switchover_aurora(target_region: str) -> dict:
         logger.info(
             f"Aurora switchover initiated: {AURORA_GLOBAL_CLUSTER_ID} → {target_arn}"
         )
-        return {"success": True, "error": ""}
     except ClientError as e:
-        msg = f"Aurora switchover-global-cluster API failed: {e}"
-        logger.error(msg)
-        return {"success": False, "error": msg}
+        # Idempotency: if a switchover to this same target is already running
+        # (e.g. operator re-invoked the Lambda), treat it as success and fall
+        # through to the wait loop — it'll converge naturally.
+        msg = str(e)
+        if "already switching over" in msg.lower():
+            logger.info(
+                f"Aurora switchover to {target_arn} is already in progress; "
+                f"falling through to wait-for-completion."
+            )
+        else:
+            full_msg = f"Aurora switchover-global-cluster API failed: {e}"
+            logger.error(full_msg)
+            return {"success": False, "error": full_msg, "elapsed_seconds": 0}
+
+    # Block until target_region is the writer (or until timeout).
+    timeout = int(os.environ.get("FAILBACK_PROMOTION_WAIT_TIMEOUT_SECONDS", "480"))
+    return wait_for_aurora_writer(target_region, timeout)
+
+
+def wait_for_aurora_writer(target_region: str, timeout_seconds: int) -> dict:
+    """Poll the global cluster until target_region's member is writer.
+
+    F10 (v1.7.1): SwitchoverGlobalCluster returns immediately but the actual
+    writer flip takes 1-3 minutes. Without this wait,
+    validate_target_region_health runs too early and refuses the failback.
+
+    Returns: ``{"success": bool, "elapsed_seconds": int, "error": str}``.
+    """
+    if not AURORA_GLOBAL_CLUSTER_ID:
+        return {"success": False, "elapsed_seconds": 0,
+                "error": "AURORA_GLOBAL_CLUSTER_ID not configured"}
+
+    deadline = time.monotonic() + timeout_seconds
+    start = time.monotonic()
+    poll_interval = 10  # seconds
+    rds = boto3.client("rds", region_name=CURRENT_REGION, config=_client_config)
+
+    while True:
+        try:
+            resp = rds.describe_global_clusters(GlobalClusterIdentifier=AURORA_GLOBAL_CLUSTER_ID)
+            for gc in resp.get("GlobalClusters", []):
+                for member in gc.get("GlobalClusterMembers", []):
+                    arn = member.get("DBClusterArn", "")
+                    if f":{target_region}:" in arn and member.get("IsWriter"):
+                        elapsed = int(time.monotonic() - start)
+                        logger.info(
+                            f"Aurora writer is now in {target_region} after {elapsed}s"
+                        )
+                        return {"success": True, "elapsed_seconds": elapsed, "error": ""}
+        except ClientError as e:
+            logger.warning(f"describe_global_clusters during wait: {e}")
+
+        if time.monotonic() >= deadline:
+            elapsed = int(time.monotonic() - start)
+            return {
+                "success": False, "elapsed_seconds": elapsed,
+                "error": f"Aurora switchover did not complete in {elapsed}s",
+            }
+        time.sleep(poll_interval)
 
 
 def _auto_failover_redis(target_region: str) -> dict:
@@ -684,11 +746,66 @@ def _auto_failover_redis(target_region: str) -> dict:
             f"ElastiCache failover initiated: "
             f"{ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID} → {target_region}/{target_rg_id}"
         )
-        return {"success": True, "error": ""}
     except ClientError as e:
-        msg = f"ElastiCache failover-global-replication-group API failed: {e}"
-        logger.error(msg)
-        return {"success": False, "error": msg}
+        # Idempotency: if target region is already primary, treat as success
+        # and let wait_for_redis_primary confirm.
+        msg = str(e)
+        if "already primary" in msg.lower() or "in-eligible" in msg.lower():
+            logger.info(
+                f"ElastiCache target region {target_region} is already primary; "
+                f"falling through to wait-for-completion."
+            )
+        else:
+            full_msg = f"ElastiCache failover-global-replication-group API failed: {e}"
+            logger.error(full_msg)
+            return {"success": False, "error": full_msg, "elapsed_seconds": 0}
+
+    timeout = int(os.environ.get("FAILBACK_PROMOTION_WAIT_TIMEOUT_SECONDS", "480"))
+    return wait_for_redis_primary(target_region, timeout)
+
+
+def wait_for_redis_primary(target_region: str, timeout_seconds: int) -> dict:
+    """Poll the Global Datastore until target_region's RG has Role=PRIMARY.
+
+    F10 (v1.7.1): same shape as wait_for_aurora_writer — failover_global_replication_group
+    returns immediately but the role flip takes 30s-3min.
+
+    Returns: ``{"success": bool, "elapsed_seconds": int, "error": str}``.
+    """
+    if not ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID:
+        return {"success": False, "elapsed_seconds": 0,
+                "error": "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID not configured"}
+
+    deadline = time.monotonic() + timeout_seconds
+    start = time.monotonic()
+    poll_interval = 10
+    ec = boto3.client("elasticache", region_name=CURRENT_REGION, config=_client_config)
+
+    while True:
+        try:
+            resp = ec.describe_global_replication_groups(
+                GlobalReplicationGroupId=ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID,
+                ShowMemberInfo=True,
+            )
+            for grg in resp.get("GlobalReplicationGroups", []):
+                for member in grg.get("Members", []):
+                    if (member.get("ReplicationGroupRegion") == target_region
+                            and member.get("Role") == "PRIMARY"):
+                        elapsed = int(time.monotonic() - start)
+                        logger.info(
+                            f"ElastiCache primary is now in {target_region} after {elapsed}s"
+                        )
+                        return {"success": True, "elapsed_seconds": elapsed, "error": ""}
+        except ClientError as e:
+            logger.warning(f"describe_global_replication_groups during wait: {e}")
+
+        if time.monotonic() >= deadline:
+            elapsed = int(time.monotonic() - start)
+            return {
+                "success": False, "elapsed_seconds": elapsed,
+                "error": f"ElastiCache failover did not complete in {elapsed}s",
+            }
+        time.sleep(poll_interval)
 
 
 def _reload_dynamic_config():
@@ -801,8 +918,16 @@ def handler(event, context):
     if cfg["aurora_present"]:
         if cfg["aurora_auto"] and not aurora_confirmed and not skip_aurora_check:
             logger.info("Step 2a: Aurora auto-switchover from failback Lambda...")
+            # _auto_switchover_aurora now blocks until the switchover completes
+            # (F10 / v1.7.1). It returns success only after target_region is the
+            # writer per describe_global_clusters, or fails with a 504-style
+            # timeout error if the flip didn't happen in
+            # FAILBACK_PROMOTION_WAIT_TIMEOUT_SECONDS (default 480s).
             result = _auto_switchover_aurora(target_region)
             if not result["success"]:
+                # Distinguish initiate-failure vs wait-timeout for status code.
+                is_timeout = "did not complete" in result.get("error", "")
+                status_code = 504 if is_timeout else 500
                 msg = (
                     f"Aurora auto-switchover FAILED.\n"
                     f"Error: {result['error']}\n\n"
@@ -813,9 +938,12 @@ def handler(event, context):
                     f"{build_aurora_switchover_commands(target_region)}"
                 )
                 logger.error(msg)
-                return {"statusCode": 500, "body": msg}
-            logger.info("Aurora auto-switchover initiated by Lambda")
-            aurora_confirmed = True  # we just did it
+                return {"statusCode": status_code, "body": msg}
+            logger.info(
+                f"Aurora switchover confirmed in "
+                f"{result.get('elapsed_seconds', 0)}s"
+            )
+            aurora_confirmed = True  # we just did it AND verified completion
         elif not cfg["aurora_auto"] and not aurora_confirmed and not skip_aurora_check:
             commands = build_aurora_switchover_commands(target_region)
             msg = (
@@ -853,8 +981,11 @@ def handler(event, context):
                 )
                 logger.error(msg)
                 return {"statusCode": 500, "body": msg}
-            logger.info("ElastiCache auto-failover initiated by Lambda")
-            redis_confirmed = True  # we just did it
+            logger.info(
+                f"ElastiCache failover confirmed in "
+                f"{result.get('elapsed_seconds', 0)}s"
+            )
+            redis_confirmed = True  # we just did it AND verified completion
         elif not cfg["redis_auto"] and not redis_confirmed and not skip_redis_check:
             commands = build_redis_failover_commands(target_region)
             msg = (

--- a/tests/test_v171_failback_wait.py
+++ b/tests/test_v171_failback_wait.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""
+v1.7.1 (F10) tests for failback Lambda wait-for-promotion-completion logic.
+
+The v1.7 drill surfaced F10: SwitchoverGlobalCluster and FailoverGlobalReplicationGroup
+return immediately, but the actual writer/primary flip takes 1-3 minutes. The previous
+failback flow ran validate_target_region_health right after the API call, saw the data
+tier still in the wrong region, and refused with a 400 — even though the auto-promote
+was correctly in flight.
+
+The fix: _auto_switchover_aurora and _auto_failover_redis now block on the writer/primary
+flip via wait_for_aurora_writer / wait_for_redis_primary before returning. Configurable
+timeout via FAILBACK_PROMOTION_WAIT_TIMEOUT_SECONDS (default 480s).
+
+Run: python3 -m pytest tests/test_v171_failback_wait.py -v
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_MIN_ENV = {
+    "SNS_TOPIC_ARN": "arn:aws:sns:us-east-1:123456789012:failover-alerts",
+    "AWS_REGION": "us-east-1",
+    "PRIMARY_REGION": "us-east-1",
+    "SECONDARY_REGION": "us-east-2",
+    "STATE_BACKEND": "s3",
+    "STATE_BUCKET": "test-bucket",
+    "AURORA_GLOBAL_CLUSTER_ID": "test-aurora-global",
+    "AURORA_CLUSTER_ID": "test-aurora-e1",
+    "TARGET_AURORA_CLUSTER_ID": "test-aurora-e2",
+    "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID": "test-redis-global",
+    "ELASTICACHE_REPLICATION_GROUP_ID": "test-redis-e1",
+}
+for k, v in _MIN_ENV.items():
+    os.environ.setdefault(k, v)
+
+_mock_boto3 = patch("boto3.client")
+_mock_boto3.start()
+_mock_create_backend = patch("state_backend.create_backend")
+_mock_create_backend.start()
+
+import manual_failback_v2 as failback  # noqa: E402
+
+_mock_boto3.stop()
+_mock_create_backend.stop()
+
+
+# ---------------------------------------------------------------------------
+# wait_for_aurora_writer
+# ---------------------------------------------------------------------------
+
+class TestWaitForAuroraWriter:
+    def test_returns_success_immediately_when_writer_already_correct(self):
+        """The very first poll sees the writer in target_region — return fast."""
+        rds = MagicMock()
+        rds.describe_global_clusters.return_value = {
+            "GlobalClusters": [{
+                "GlobalClusterMembers": [
+                    {"DBClusterArn": "arn:aws:rds:us-east-2:account:cluster:c-e2", "IsWriter": False},
+                    {"DBClusterArn": "arn:aws:rds:us-east-1:account:cluster:c-e1", "IsWriter": True},
+                ]
+            }]
+        }
+        with patch("boto3.client", return_value=rds), \
+             patch.object(failback, "AURORA_GLOBAL_CLUSTER_ID", "test-aurora-global"), \
+             patch.object(failback, "CURRENT_REGION", "us-east-1"):
+            result = failback.wait_for_aurora_writer("us-east-1", timeout_seconds=10)
+        assert result["success"] is True
+        assert result["elapsed_seconds"] >= 0
+        rds.describe_global_clusters.assert_called()
+
+    def test_returns_failure_on_timeout(self):
+        """Writer never flips → returns success=False with elapsed and error."""
+        rds = MagicMock()
+        # Writer stays in us-east-2 forever
+        rds.describe_global_clusters.return_value = {
+            "GlobalClusters": [{
+                "GlobalClusterMembers": [
+                    {"DBClusterArn": "arn:aws:rds:us-east-1:account:cluster:c-e1", "IsWriter": False},
+                    {"DBClusterArn": "arn:aws:rds:us-east-2:account:cluster:c-e2", "IsWriter": True},
+                ]
+            }]
+        }
+        with patch("boto3.client", return_value=rds), \
+             patch.object(failback, "AURORA_GLOBAL_CLUSTER_ID", "test-aurora-global"), \
+             patch.object(failback, "CURRENT_REGION", "us-east-1"), \
+             patch.object(failback.time, "sleep"):  # don't actually sleep
+            result = failback.wait_for_aurora_writer("us-east-1", timeout_seconds=1)
+        assert result["success"] is False
+        assert "did not complete" in result["error"]
+
+    def test_returns_failure_when_global_cluster_id_unset(self):
+        with patch.object(failback, "AURORA_GLOBAL_CLUSTER_ID", ""):
+            result = failback.wait_for_aurora_writer("us-east-1", timeout_seconds=1)
+        assert result["success"] is False
+        assert "AURORA_GLOBAL_CLUSTER_ID" in result["error"]
+
+    def test_swallows_clienterror_and_keeps_polling(self):
+        """A transient describe_global_clusters error shouldn't kill the wait."""
+        from botocore.exceptions import ClientError
+        rds = MagicMock()
+        first = ClientError(
+            {"Error": {"Code": "Throttling", "Message": "rate"}}, "DescribeGlobalClusters"
+        )
+        success_resp = {
+            "GlobalClusters": [{
+                "GlobalClusterMembers": [
+                    {"DBClusterArn": "arn:aws:rds:us-east-1:account:cluster:c-e1", "IsWriter": True},
+                ]
+            }]
+        }
+        rds.describe_global_clusters.side_effect = [first, success_resp]
+        with patch("boto3.client", return_value=rds), \
+             patch.object(failback, "AURORA_GLOBAL_CLUSTER_ID", "test-aurora-global"), \
+             patch.object(failback, "CURRENT_REGION", "us-east-1"), \
+             patch.object(failback.time, "sleep"):
+            result = failback.wait_for_aurora_writer("us-east-1", timeout_seconds=30)
+        assert result["success"] is True
+        assert rds.describe_global_clusters.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# wait_for_redis_primary
+# ---------------------------------------------------------------------------
+
+class TestWaitForRedisPrimary:
+    def test_returns_success_when_target_is_primary(self):
+        ec = MagicMock()
+        ec.describe_global_replication_groups.return_value = {
+            "GlobalReplicationGroups": [{
+                "Members": [
+                    {"ReplicationGroupRegion": "us-east-2", "Role": "SECONDARY"},
+                    {"ReplicationGroupRegion": "us-east-1", "Role": "PRIMARY"},
+                ]
+            }]
+        }
+        with patch("boto3.client", return_value=ec), \
+             patch.object(failback, "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", "test-rg"), \
+             patch.object(failback, "CURRENT_REGION", "us-east-1"):
+            result = failback.wait_for_redis_primary("us-east-1", timeout_seconds=10)
+        assert result["success"] is True
+
+    def test_returns_failure_on_timeout(self):
+        ec = MagicMock()
+        ec.describe_global_replication_groups.return_value = {
+            "GlobalReplicationGroups": [{
+                "Members": [
+                    {"ReplicationGroupRegion": "us-east-1", "Role": "SECONDARY"},
+                    {"ReplicationGroupRegion": "us-east-2", "Role": "PRIMARY"},
+                ]
+            }]
+        }
+        with patch("boto3.client", return_value=ec), \
+             patch.object(failback, "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", "test-rg"), \
+             patch.object(failback, "CURRENT_REGION", "us-east-1"), \
+             patch.object(failback.time, "sleep"):
+            result = failback.wait_for_redis_primary("us-east-1", timeout_seconds=1)
+        assert result["success"] is False
+        assert "did not complete" in result["error"]
+
+    def test_returns_failure_when_global_rg_id_unset(self):
+        with patch.object(failback, "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", ""):
+            result = failback.wait_for_redis_primary("us-east-1", timeout_seconds=1)
+        assert result["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# _auto_switchover_aurora composes initiate + wait
+# ---------------------------------------------------------------------------
+
+class TestAutoSwitchoverAuroraComposesWait:
+    def test_initiate_then_wait_success(self):
+        """End-to-end: API call succeeds, wait sees writer flip, return success."""
+        rds = MagicMock()
+        # First switchover_global_cluster succeeds
+        rds.switchover_global_cluster.return_value = {}
+        # Then describe_global_clusters in wait_for_aurora_writer sees writer in target
+        rds.describe_global_clusters.return_value = {
+            "GlobalClusters": [{
+                "GlobalClusterMembers": [
+                    {"DBClusterArn": "arn:aws:rds:us-east-1:account:cluster:c-e1", "IsWriter": True},
+                ]
+            }]
+        }
+        with patch("boto3.client", return_value=rds), \
+             patch.object(failback, "AURORA_GLOBAL_CLUSTER_ID", "test-aurora-global"), \
+             patch.object(failback, "AURORA_CLUSTER_ID", "test-aurora-e1"), \
+             patch.object(failback, "_AWS_ACCOUNT_ID", "123456789012"), \
+             patch.object(failback, "CURRENT_REGION", "us-east-1"):
+            result = failback._auto_switchover_aurora("us-east-1")
+        assert result["success"] is True
+        assert "elapsed_seconds" in result
+        rds.switchover_global_cluster.assert_called_once()
+
+    def test_initiate_failure_returns_immediately_no_wait(self):
+        from botocore.exceptions import ClientError
+        rds = MagicMock()
+        rds.switchover_global_cluster.side_effect = ClientError(
+            {"Error": {"Code": "InvalidParameterValue", "Message": "bad request"}},
+            "SwitchoverGlobalCluster",
+        )
+        with patch("boto3.client", return_value=rds), \
+             patch.object(failback, "AURORA_GLOBAL_CLUSTER_ID", "test-aurora-global"), \
+             patch.object(failback, "AURORA_CLUSTER_ID", "test-aurora-e1"), \
+             patch.object(failback, "_AWS_ACCOUNT_ID", "123456789012"), \
+             patch.object(failback, "CURRENT_REGION", "us-east-1"):
+            result = failback._auto_switchover_aurora("us-east-1")
+        assert result["success"] is False
+        assert "InvalidParameterValue" in result["error"] or "bad request" in result["error"]
+        # No wait happened. _resolve_target_aurora_arn does call describe_global_clusters
+        # once to find the ARN, but the wait loop never runs — total calls == 1.
+        assert rds.describe_global_clusters.call_count == 1
+
+    def test_idempotent_already_switching_over_falls_through_to_wait(self):
+        """If switchover is already running, treat as success and let wait converge."""
+        from botocore.exceptions import ClientError
+        rds = MagicMock()
+        rds.switchover_global_cluster.side_effect = ClientError(
+            {"Error": {"Code": "InvalidParameterCombination",
+                       "Message": "The global cluster is already switching over"}},
+            "SwitchoverGlobalCluster",
+        )
+        rds.describe_global_clusters.return_value = {
+            "GlobalClusters": [{
+                "GlobalClusterMembers": [
+                    {"DBClusterArn": "arn:aws:rds:us-east-1:account:cluster:c-e1", "IsWriter": True},
+                ]
+            }]
+        }
+        with patch("boto3.client", return_value=rds), \
+             patch.object(failback, "AURORA_GLOBAL_CLUSTER_ID", "test-aurora-global"), \
+             patch.object(failback, "AURORA_CLUSTER_ID", "test-aurora-e1"), \
+             patch.object(failback, "_AWS_ACCOUNT_ID", "123456789012"), \
+             patch.object(failback, "CURRENT_REGION", "us-east-1"):
+            result = failback._auto_switchover_aurora("us-east-1")
+        assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# _auto_failover_redis composes initiate + wait
+# ---------------------------------------------------------------------------
+
+class TestAutoFailoverRedisComposesWait:
+    def test_initiate_then_wait_success(self):
+        ec = MagicMock()
+        ec.failover_global_replication_group.return_value = {}
+        ec.describe_global_replication_groups.return_value = {
+            "GlobalReplicationGroups": [{
+                "Members": [
+                    {"ReplicationGroupRegion": "us-east-1", "Role": "PRIMARY"},
+                ]
+            }]
+        }
+        with patch("boto3.client", return_value=ec), \
+             patch.object(failback, "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", "test-rg"), \
+             patch.object(failback, "ELASTICACHE_REPLICATION_GROUP_ID", "test-redis-e1"), \
+             patch.object(failback, "CURRENT_REGION", "us-east-1"):
+            result = failback._auto_failover_redis("us-east-1")
+        assert result["success"] is True
+
+    def test_idempotent_already_primary_falls_through_to_wait(self):
+        from botocore.exceptions import ClientError
+        ec = MagicMock()
+        ec.failover_global_replication_group.side_effect = ClientError(
+            {"Error": {"Code": "InvalidParameterValue",
+                       "Message": "Region us-east-1 is already primary"}},
+            "FailoverGlobalReplicationGroup",
+        )
+        ec.describe_global_replication_groups.return_value = {
+            "GlobalReplicationGroups": [{
+                "Members": [
+                    {"ReplicationGroupRegion": "us-east-1", "Role": "PRIMARY"},
+                ]
+            }]
+        }
+        with patch("boto3.client", return_value=ec), \
+             patch.object(failback, "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", "test-rg"), \
+             patch.object(failback, "ELASTICACHE_REPLICATION_GROUP_ID", "test-redis-e1"), \
+             patch.object(failback, "CURRENT_REGION", "us-east-1"):
+            result = failback._auto_failover_redis("us-east-1")
+        assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Configurable timeout via env
+# ---------------------------------------------------------------------------
+
+def test_promotion_wait_timeout_respects_env_var():
+    """FAILBACK_PROMOTION_WAIT_TIMEOUT_SECONDS controls the wait timeout."""
+    rds = MagicMock()
+    rds.switchover_global_cluster.return_value = {}
+    # Writer never flips
+    rds.describe_global_clusters.return_value = {
+        "GlobalClusters": [{
+            "GlobalClusterMembers": [
+                {"DBClusterArn": "arn:aws:rds:us-east-2:account:cluster:c-e2", "IsWriter": True},
+            ]
+        }]
+    }
+    with patch("boto3.client", return_value=rds), \
+         patch.dict(os.environ, {"FAILBACK_PROMOTION_WAIT_TIMEOUT_SECONDS": "1"}), \
+         patch.object(failback, "AURORA_GLOBAL_CLUSTER_ID", "test-aurora-global"), \
+         patch.object(failback, "AURORA_CLUSTER_ID", "test-aurora-e1"), \
+         patch.object(failback, "_AWS_ACCOUNT_ID", "123456789012"), \
+         patch.object(failback, "CURRENT_REGION", "us-east-1"), \
+         patch.object(failback.time, "sleep"):
+        result = failback._auto_switchover_aurora("us-east-1")
+    assert result["success"] is False
+    # Timeout error message
+    assert "did not complete" in result["error"]


### PR DESCRIPTION
## Summary

Fixes **F10** — the failback Lambda's pre-flight validation ran *before* Aurora switchover / Redis failover had time to complete, refusing healthy systems with a 400. Surfaced during the v1.7 drill on us-east-1/us-east-2.

## Root cause

`SwitchoverGlobalCluster` and `FailoverGlobalReplicationGroup` return immediately, but the actual writer/primary flip takes 1–3 minutes. The previous failback flow:

```
auto_promote_aurora()       → returns immediately (API initiated)
auto_promote_redis()        → returns immediately (API initiated)
validate_target_region_health()  → checks Aurora writer + Redis primary  ← runs too early
```

Saw the data tier still in the *other* region and 400-refused.

## Fix

Fold the wait inside the auto-promote functions:

```python
# _auto_switchover_aurora now blocks until the writer flip is observable
result = _auto_switchover_aurora(target_region)
# success = AWS confirmed the writer is in target_region
```

Two new helpers:
- `wait_for_aurora_writer(region, timeout)` — polls `describe_global_clusters` every 10s
- `wait_for_redis_primary(region, timeout)` — polls `describe_global_replication_groups` every 10s

Configurable timeout via `FAILBACK_PROMOTION_WAIT_TIMEOUT_SECONDS` (default 480s). Lambda timeout bumped 120s → 600s in `cfn/failover.yaml`.

Idempotency: if SwitchoverGlobalCluster returns "already switching over" or FailoverGlobalReplicationGroup returns "already primary", treat as success and let the wait converge.

## Live drill validation

Re-ran on `fo-v16-drill` infrastructure (still standing from v1.7 drill):

1. ECS scale-to-zero in us-east-1 → automatic failover to us-east-2 (already validated by v1.7)
2. Restore us-east-1 ECS, invoke failback with `aurora_confirmed=false, redis_confirmed=false, skip_readiness_check=true`
3. Failback Lambda log:
   ```
   Aurora writer is now in us-east-1 after 60s
   Aurora switchover confirmed in 60s
   ElastiCache primary is now in us-east-1 after 40s
   ElastiCache failover confirmed in 40s
   All health checks passed for us-east-1
   FAILBACK COMPLETE: us-east-2 -> us-east-1
   Duration: 104891.61 ms (~105s wall-clock)
   ```
4. Final state: `PRIMARY_ACTIVE`, `latch=false`, Aurora writer in us-east-1, Redis primary in us-east-1.

**One-shot. No operator overrides.**

## Tests

- **446 passing**, 30 skipped (was 433)
- 13 new tests in `tests/test_v171_failback_wait.py`:
  - wait helpers: success path, timeout, ClientError swallowed, missing config refused
  - composition: initiate then wait, initiate fails returns immediately, idempotency on already-running
  - configurable timeout via env var

## Test plan

- [x] Full pytest suite passes (446 / 30 skipped)
- [x] Live drill: Phase 1 + Phase 2 completed end-to-end with no operator overrides
- [x] CFN Lambda timeout bumped (any operator deploying via CFN gets the bump automatically)
- [ ] Code review

## Related

- Builds on v1.7 (#93). Ships as a **point release** because it only touches the failback path, not the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)