### PR TITLE
v1.7.2: F11 retry + notification UX (awareness + back-to-normal)

### DIFF
--- a/failover_orchestrator_v3.py
+++ b/failover_orchestrator_v3.py
@@ -3430,6 +3430,65 @@ def _handle_active_region(state: dict, active_region: str,
         )
         update_failover_state({"state": new_state})
 
+        # v1.7.2: send an explicit "all stable on secondary" notification.
+        # This used to be silent — operator only knew failover was complete by
+        # noticing the absence of further reminder emails. Now we send one INFO
+        # email summarising the new steady state.
+        try:
+            origin_region = PRIMARY_REGION if active_region == SECONDARY_REGION else SECONDARY_REGION
+            cfg = detect_data_tier_config()
+            data_tier_summary = []
+            if cfg.get("aurora_present"):
+                data_tier_summary.append(f"Aurora writer: {active_region}")
+            if cfg.get("redis_present"):
+                data_tier_summary.append(f"Redis primary: {active_region}")
+            ctx = {
+                "Active region": active_region,
+                "Failed-over from": origin_region,
+                "State": new_state,
+                "Latch": "engaged (failback required to clear)",
+            }
+            if data_tier_summary:
+                ctx["Data tier"] = " · ".join(data_tier_summary)
+            subject, body = compose_message(
+                severity=SEVERITY_INFO,
+                what=(
+                    f"All stable on {active_region} — failover complete, "
+                    f"app fully running on the secondary"
+                ),
+                why=(
+                    f"The orchestrator confirmed Aurora and ElastiCache promotions "
+                    f"completed successfully. Traffic has moved from {origin_region} "
+                    f"to {active_region}, the data tier is in the right place, and "
+                    f"the system is in steady state ({new_state}). The latch is "
+                    f"engaged to prevent flip-flop — running in {active_region} until "
+                    f"manual failback."
+                ),
+                next_step=(
+                    f"No action required. Confirm Route 53 traffic is flowing to "
+                    f"{active_region} (DNS TTL ~60s after the failover claim). When "
+                    f"the underlying issue in {origin_region} is resolved and you "
+                    f"want traffic back, run the manual failback Lambda. Until then, "
+                    f"the system is stable here."
+                ),
+                context=ctx,
+                journey=[
+                    "[✓] Failover triggered",
+                    "[✓] Data tier promoted",
+                    f"[✓] All stable on {active_region}",
+                    "[ ] Failback (manual when ready)",
+                ],
+                source="failover-orchestrator",
+                region=CURRENT_REGION,
+            )
+            send_notification(subject, body)
+        except Exception as e:
+            # Notification failure must NOT block state transition.
+            logger.warning(
+                f"Failed to send 'all stable on secondary' notification "
+                f"(non-fatal): {type(e).__name__}: {e}"
+            )
+
     update_failover_state({
         "last_active_metric_ts": now.isoformat(),
     })
@@ -3460,24 +3519,33 @@ def _handle_active_region(state: dict, active_region: str,
         publish_region_health_metric(CURRENT_REGION, True)
         target_region = SECONDARY_REGION if active_region == PRIMARY_REGION else PRIMARY_REGION
         is_first = new_failure_count == 1
+        # v1.7.2: notification ladder
+        #   1st failure = INFO (awareness only — no action needed)
+        #   2nd...N-1 failures = WARNING (sustained, escalating)
+        #   Nth failure = CRITICAL failover (handled in the cf-threshold branch below)
+        # The user explicitly asked for the first one to read as "for awareness".
         if is_first:
+            severity = SEVERITY_INFO
             what = (
-                f"Region {CURRENT_REGION} reported its FIRST health failure "
-                f"(1 of {CONSECUTIVE_FAILURES_THRESHOLD})"
+                f"AWARENESS: {CURRENT_REGION} reported its first health failure "
+                f"(1 of {CONSECUTIVE_FAILURES_THRESHOLD}) — no action needed yet"
             )
             why = (
                 f"{health.get('decision_reason', 'health check failed')}. "
-                f"This is the first failure of an incident — traffic is still flowing "
-                f"normally to {CURRENT_REGION}."
+                f"This is the FIRST failure of an incident. Traffic is still flowing "
+                f"normally to {CURRENT_REGION}, and most first failures clear on their "
+                f"own. This email is awareness-only so you know the orchestrator is "
+                f"watching."
             )
             next_step = (
-                f"No action required. The orchestrator will keep evaluating health "
-                f"every 60s. You will receive a follow-up email if the failure "
-                f"persists. If {CONSECUTIVE_FAILURES_THRESHOLD} consecutive failures occur "
-                f"and the cooldown window has expired, traffic will move to "
-                f"{target_region} automatically."
+                f"No action needed yet. The orchestrator continues evaluating every "
+                f"60s. You will receive a separate WARNING email if a 2nd consecutive "
+                f"failure occurs (sustained), and a CRITICAL email if "
+                f"{CONSECUTIVE_FAILURES_THRESHOLD} consecutive failures trigger automatic "
+                f"failover to {target_region}."
             )
         else:
+            severity = SEVERITY_WARNING
             what = (
                 f"Region {CURRENT_REGION} health failure "
                 f"{new_failure_count} of {CONSECUTIVE_FAILURES_THRESHOLD} — "
@@ -3506,12 +3574,12 @@ def _handle_active_region(state: dict, active_region: str,
         if signals_brief:
             ctx["Health signals"] = signals_brief
         journey = [
-            f"[{'1' if is_first else '✓'}] First failure",
+            f"[{'1' if is_first else '✓'}] First failure (awareness)",
             f"[{'→' if not is_first else ' '}] Sustained ({new_failure_count}/{CONSECUTIVE_FAILURES_THRESHOLD})",
             "[ ] Failover",
         ]
         subject, body = compose_message(
-            severity=SEVERITY_WARNING,
+            severity=severity,
             what=what,
             why=why,
             next_step=next_step,
@@ -3520,6 +3588,8 @@ def _handle_active_region(state: dict, active_region: str,
             source="failover-orchestrator",
             region=CURRENT_REGION,
         )
+        # First-failure (INFO/awareness) bypasses the WARNING throttle so the
+        # operator gets it immediately. Sustained warnings respect the throttle.
         send_warning_notification(subject, body, state, bypass_throttle=is_first)
         return {"statusCode": 200, "body": "Below threshold, monitoring"}
 

--- a/manual_failback_v2.py
+++ b/manual_failback_v2.py
@@ -735,30 +735,69 @@ def _auto_failover_redis(target_region: str) -> dict:
     if not target_rg_id:
         return {"success": False, "error": "Cannot determine target RG ID"}
 
-    try:
-        ec = boto3.client("elasticache", region_name=CURRENT_REGION, config=_client_config)
-        ec.failover_global_replication_group(
-            GlobalReplicationGroupId=ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID,
-            PrimaryRegion=target_region,
-            PrimaryReplicationGroupId=target_rg_id,
-        )
-        logger.info(
-            f"ElastiCache failover initiated: "
-            f"{ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID} → {target_region}/{target_rg_id}"
-        )
-    except ClientError as e:
-        # Idempotency: if target region is already primary, treat as success
-        # and let wait_for_redis_primary confirm.
-        msg = str(e)
-        if "already primary" in msg.lower() or "in-eligible" in msg.lower():
-            logger.info(
-                f"ElastiCache target region {target_region} is already primary; "
-                f"falling through to wait-for-completion."
+    # F11 (v1.7.2): Global Datastore can be in a transient "modifying" state for
+    # several minutes after a recent failover/disassociation. The API surfaces
+    # this as InvalidGlobalReplicationGroupState. Retry the API call a few times
+    # with backoff before giving up. The wait loop after the API call still
+    # protects against the role-flip latency once the API accepts the call.
+    max_initiate_attempts = 5
+    initiate_backoff = 30  # seconds between retries on InvalidState
+
+    initiated = False
+    last_invalid_state_error = None
+    ec = boto3.client("elasticache", region_name=CURRENT_REGION, config=_client_config)
+    for attempt in range(1, max_initiate_attempts + 1):
+        try:
+            ec.failover_global_replication_group(
+                GlobalReplicationGroupId=ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID,
+                PrimaryRegion=target_region,
+                PrimaryReplicationGroupId=target_rg_id,
             )
-        else:
+            logger.info(
+                f"ElastiCache failover initiated: "
+                f"{ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID} → {target_region}/{target_rg_id} "
+                f"(attempt {attempt}/{max_initiate_attempts})"
+            )
+            initiated = True
+            break
+        except ClientError as e:
+            msg = str(e)
+            # Idempotency: if target region is already primary, treat as success
+            # and let wait_for_redis_primary confirm.
+            if "already primary" in msg.lower() or "in-eligible" in msg.lower():
+                logger.info(
+                    f"ElastiCache target region {target_region} is already primary; "
+                    f"falling through to wait-for-completion."
+                )
+                initiated = True
+                break
+            # F11: InvalidGlobalReplicationGroupState — transient, the Global
+            # Datastore is still settling from a recent operation. Wait + retry.
+            if "InvalidGlobalReplicationGroupState" in msg or "not in a valid state" in msg.lower():
+                last_invalid_state_error = msg
+                logger.info(
+                    f"ElastiCache Global Datastore in transient state on attempt "
+                    f"{attempt}/{max_initiate_attempts} (will retry in {initiate_backoff}s): {msg}"
+                )
+                if attempt < max_initiate_attempts:
+                    time.sleep(initiate_backoff)
+                    continue
+                # Exhausted retries on InvalidState — give up with a clear error
+                full_msg = (
+                    f"ElastiCache Global Datastore stayed in transient state for "
+                    f"~{(max_initiate_attempts - 1) * initiate_backoff}s "
+                    f"({max_initiate_attempts} retries): {last_invalid_state_error}"
+                )
+                logger.error(full_msg)
+                return {"success": False, "error": full_msg, "elapsed_seconds": 0}
+            # Any other error — fail immediately
             full_msg = f"ElastiCache failover-global-replication-group API failed: {e}"
             logger.error(full_msg)
             return {"success": False, "error": full_msg, "elapsed_seconds": 0}
+
+    if not initiated:
+        # Defensive — should be unreachable
+        return {"success": False, "error": "ElastiCache failover not initiated", "elapsed_seconds": 0}
 
     timeout = int(os.environ.get("FAILBACK_PROMOTION_WAIT_TIMEOUT_SECONDS", "480"))
     return wait_for_redis_primary(target_region, timeout)
@@ -1177,20 +1216,29 @@ def handler(event, context):
             journey.append("[✓] Redis switchover (operator)")
         journey.append("[✓] Latch released — system back to PRIMARY_ACTIVE")
         next_step = (
-            f"No action required. The orchestrator's automated health monitoring "
-            f"is active again in both regions. Confirm Route 53 traffic is flowing "
-            f"to {target_region} and watch for any sustained-failure WARNINGs in "
-            f"the next 5–10 minutes to verify the underlying issue is resolved."
+            f"No action required — the system is fully back to normal. The "
+            f"orchestrator's automated health monitoring is active again in both "
+            f"regions. The latch has been released, so if {target_region} fails "
+            f"again, automatic failover to {active_region} will fire normally. "
+            f"Confirm Route 53 traffic is flowing to {target_region} (DNS TTL "
+            f"~60s) and watch for any sustained-failure WARNINGs in the next "
+            f"5–10 minutes to confirm the underlying issue is fully resolved."
             + (readiness_appendix or "")
         )
         subject, body = compose_message(
-            severity=SEVERITY_CRITICAL,
-            what=f"Failback COMPLETE — traffic returned to {target_region}",
+            severity=SEVERITY_INFO,
+            what=(
+                f"All back to normal — traffic returned to {target_region}, "
+                f"failback complete"
+            ),
             why=(
                 f"Operator {operator} initiated and completed manual failback "
                 f"from {active_region} back to {target_region}. The orchestrator "
-                f"validated target health, released the latch, and updated state "
-                f"to PRIMARY_ACTIVE."
+                f"validated target health (HTTP 200, ECS healthy, Aurora writer in "
+                f"{target_region}, Redis primary in {target_region} where applicable), "
+                f"released the latch, and updated state to PRIMARY_ACTIVE. The "
+                f"system is in steady state with {target_region} fully serving "
+                f"traffic and the failover safety net armed."
             ),
             next_step=next_step,
             context={
@@ -1198,7 +1246,7 @@ def handler(event, context):
                 "From region": active_region,
                 "To region": target_region,
                 "New state": new_state,
-                "Latch": "RELEASED",
+                "Latch": "RELEASED — failover safety net armed",
             },
             journey=journey,
             source="failover-failback",

--- a/tests/test_sns_notifications_failover.py
+++ b/tests/test_sns_notifications_failover.py
@@ -284,20 +284,26 @@ class TestSNSDegradationWarnings:
     def test_degraded_warning_first_failure_explicit(
         self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd
     ):
-        """v1.6: first failure (1 of 3) — subject says 'FIRST health failure'."""
+        """v1.7.2: first failure (1 of 3) is INFO-severity 'AWARENESS' framing —
+        no action needed yet. The subject must read as awareness-only so the
+        operator doesn't pager-respond on a transient blip."""
         mock_health.return_value = _unhealthy_health()
         state = _make_state(consecutive_failures=0)
 
         orch._handle_active_region(state, "us-east-1", 0, "1970-01-01T00:00:00Z")
 
         subject = _get_sns_subject(mock_sns)
-        assert "FIRST" in subject
+        # v1.7.2: severity downgraded WARNING → INFO for first failure.
+        assert "INFO" in subject
+        assert "AWARENESS" in subject.upper()
         assert "1 of 3" in subject
+        assert "no action needed" in subject.lower()
 
         body = _get_sns_message(mock_sns)
-        assert "first failure of an incident" in body
-        # First-failure journey breadcrumb shows "[1]" for the active step.
-        assert "[1] First failure" in body
+        # Body still names this as the first failure of the incident.
+        assert "FIRST failure" in body
+        # Body explicitly tells the operator the email is awareness-only.
+        assert "awareness" in body.lower()
 
     @patch.object(orch, "update_failover_state")
     @patch.object(orch, "publish_region_health_metric")
@@ -1809,25 +1815,36 @@ class TestSNSFailback:
     def test_failback_complete_sends_critical(
         self, mock_sns, mock_get_state, mock_upd, mock_pub, mock_cb
     ):
-        """v1.6: Successful failback emits CRITICAL completion email with full
-        journey breadcrumb showing every recovery step is done."""
+        """v1.7.2: Successful failback emits an INFO 'all back to normal' email.
+
+        Was CRITICAL in v1.6, but failback completion is good news, not an
+        incident — INFO matches the user's notification UX request.
+        """
         mock_cb.return_value = MagicMock()
         mock_get_state.return_value = _make_failback_state()
 
         result = failback.handler(self._run_failback(), None)
 
         assert result["statusCode"] == 200
-        assert mock_sns.publish.called
-        subject = _get_sns_subject(mock_sns)
-        assert subject.startswith("[Vigil] CRITICAL:")
-        assert "Failback COMPLETE" in subject
+        # Find the failback-complete notification (filter out any earlier ones).
+        complete_calls = [
+            c for c in mock_sns.publish.call_args_list
+            if "back to normal" in c[1].get("Subject", "").lower()
+        ]
+        assert len(complete_calls) == 1, "Exactly one 'back to normal' email expected"
+        subject = complete_calls[0][1]["Subject"]
+        # v1.7.2: severity INFO, "All back to normal" framing.
+        assert subject.startswith("[Vigil] INFO:")
+        assert "back to normal" in subject.lower()
         assert "us-east-1" in subject
         assert len(subject) <= 100
 
-        body = _get_sns_message(mock_sns)
+        body = complete_calls[0][1]["Message"]
         # Latch released and full journey arc shown.
         assert "Latch" in body and "RELEASED" in body
         assert "[✓] Latch released" in body
+        # Body explicitly says "back to normal".
+        assert "back to normal" in body.lower()
         # Next-step tells operator what to watch for after recovery.
         assert "Confirm Route 53" in body or "confirm route 53" in body.lower()
 
@@ -1878,7 +1895,10 @@ class TestSNSFailback:
         self, mock_sns, mock_get_state, mock_upd, mock_pub, mock_cb
     ):
         """S3 backend: failback complete subject identical to DynamoDB variant
-        (state backend is invisible to the notification template)."""
+        (state backend is invisible to the notification template).
+
+        v1.7.2: severity is INFO and message reads 'all back to normal'.
+        """
         mock_cb.return_value = MagicMock()
         mock_get_state.return_value = _make_failback_state()
 
@@ -1889,9 +1909,14 @@ class TestSNSFailback:
             result = failback.handler(self._run_failback(), None)
 
         assert result["statusCode"] == 200
-        subject = _get_sns_subject(mock_sns)
-        assert subject.startswith("[Vigil] CRITICAL:")
-        assert "Failback COMPLETE" in subject
+        complete_calls = [
+            c for c in mock_sns.publish.call_args_list
+            if "back to normal" in c[1].get("Subject", "").lower()
+        ]
+        assert len(complete_calls) == 1
+        subject = complete_calls[0][1]["Subject"]
+        assert subject.startswith("[Vigil] INFO:")
+        assert "back to normal" in subject.lower()
         assert "us-east-1" in subject
 
 
@@ -1962,7 +1987,10 @@ class TestSNSFailbackRedisGate:
     def test_redis_gate_passes_when_redis_confirmed(
         self, mock_sns, mock_get_state, mock_upd, mock_pub, mock_cb
     ):
-        """C5: aurora_confirmed=true + redis_confirmed=true → failback proceeds."""
+        """C5: aurora_confirmed=true + redis_confirmed=true → failback proceeds.
+
+        v1.7.2: completion notification re-framed as INFO 'all back to normal'.
+        """
         mock_cb.return_value = MagicMock()
         mock_get_state.return_value = _make_failback_state()
 
@@ -1978,7 +2006,7 @@ class TestSNSFailbackRedisGate:
 
         assert result["statusCode"] == 200
         subject = _get_sns_subject(mock_sns)
-        assert "Failback COMPLETE" in subject
+        assert "back to normal" in subject.lower()
 
     @patch.object(failback, "create_backend")
     @patch.object(failback, "publish_region_health_metric")

--- a/tests/test_v171_failback_wait.py
+++ b/tests/test_v171_failback_wait.py
@@ -284,6 +284,85 @@ class TestAutoFailoverRedisComposesWait:
 
 
 # ---------------------------------------------------------------------------
+# F11: InvalidGlobalReplicationGroupState retry-on-transient-state
+# ---------------------------------------------------------------------------
+
+class TestF11InvalidStateRetry:
+    """v1.7.2: Global Datastore can return InvalidGlobalReplicationGroupState
+    for several minutes after a recent failover. We now retry the API call up
+    to 5 times with 30s backoff before giving up."""
+
+    def test_retries_on_invalid_state_then_succeeds(self):
+        from botocore.exceptions import ClientError
+        ec = MagicMock()
+        # First two calls return InvalidGlobalReplicationGroupState; third succeeds.
+        invalid_state_error = ClientError(
+            {"Error": {"Code": "InvalidGlobalReplicationGroupState",
+                       "Message": "Global Replication Group is not in a valid state"}},
+            "FailoverGlobalReplicationGroup",
+        )
+        ec.failover_global_replication_group.side_effect = [
+            invalid_state_error,
+            invalid_state_error,
+            {},  # third call succeeds
+        ]
+        ec.describe_global_replication_groups.return_value = {
+            "GlobalReplicationGroups": [{
+                "Members": [{"ReplicationGroupRegion": "us-east-1", "Role": "PRIMARY"}]
+            }]
+        }
+        with patch("boto3.client", return_value=ec), \
+             patch.object(failback, "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", "test-rg"), \
+             patch.object(failback, "ELASTICACHE_REPLICATION_GROUP_ID", "test-redis-e1"), \
+             patch.object(failback, "CURRENT_REGION", "us-east-1"), \
+             patch.object(failback.time, "sleep"):
+            result = failback._auto_failover_redis("us-east-1")
+        assert result["success"] is True
+        # API was retried 3 times before succeeding
+        assert ec.failover_global_replication_group.call_count == 3
+
+    def test_returns_failure_after_max_retries_exhausted(self):
+        from botocore.exceptions import ClientError
+        ec = MagicMock()
+        invalid_state_error = ClientError(
+            {"Error": {"Code": "InvalidGlobalReplicationGroupState",
+                       "Message": "Global Replication Group is not in a valid state"}},
+            "FailoverGlobalReplicationGroup",
+        )
+        ec.failover_global_replication_group.side_effect = invalid_state_error
+        with patch("boto3.client", return_value=ec), \
+             patch.object(failback, "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", "test-rg"), \
+             patch.object(failback, "ELASTICACHE_REPLICATION_GROUP_ID", "test-redis-e1"), \
+             patch.object(failback, "CURRENT_REGION", "us-east-1"), \
+             patch.object(failback.time, "sleep"):
+            result = failback._auto_failover_redis("us-east-1")
+        assert result["success"] is False
+        # All 5 attempts were made
+        assert ec.failover_global_replication_group.call_count == 5
+        assert "transient state" in result["error"].lower()
+        assert "5 retries" in result["error"]
+        # No wait loop on failure
+        ec.describe_global_replication_groups.assert_not_called()
+
+    def test_other_clienterror_fails_immediately_no_retry(self):
+        """Non-InvalidState ClientErrors should NOT trigger the retry loop."""
+        from botocore.exceptions import ClientError
+        ec = MagicMock()
+        ec.failover_global_replication_group.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "no perms"}},
+            "FailoverGlobalReplicationGroup",
+        )
+        with patch("boto3.client", return_value=ec), \
+             patch.object(failback, "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID", "test-rg"), \
+             patch.object(failback, "ELASTICACHE_REPLICATION_GROUP_ID", "test-redis-e1"), \
+             patch.object(failback, "CURRENT_REGION", "us-east-1"):
+            result = failback._auto_failover_redis("us-east-1")
+        assert result["success"] is False
+        # AccessDenied should fail on first attempt — no retries
+        assert ec.failover_global_replication_group.call_count == 1
+
+
+# ---------------------------------------------------------------------------
 # Configurable timeout via env
 # ---------------------------------------------------------------------------
 

--- a/tests/test_v172_notifications.py
+++ b/tests/test_v172_notifications.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+v1.7.2 tests for the three notification UX improvements:
+
+1. First-failure notification re-framed as INFO 'AWARENESS' (was WARNING)
+   so operators don't pager-respond on a transient blip.
+
+2. NEW notification when state transitions WAITING_AURORA_PROMOTION → SECONDARY_ACTIVE
+   ('all stable on secondary — failover complete'). Previously this was silent;
+   the operator only knew failover was complete by the absence of further reminder
+   emails.
+
+3. Failback-complete notification re-framed as INFO 'all back to normal'
+   (was CRITICAL). Failback completion is good news, not an incident.
+
+Run: python3 -m pytest tests/test_v172_notifications.py -v
+"""
+
+import os
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_MIN_ENV = {
+    "SNS_TOPIC_ARN": "arn:aws:sns:us-east-1:123456789012:failover-alerts",
+    "AWS_REGION": "us-east-1",
+    "PRIMARY_REGION": "us-east-1",
+    "SECONDARY_REGION": "us-east-2",
+    "STATE_BACKEND": "s3",
+    "STATE_BUCKET": "test-bucket",
+    "AURORA_GLOBAL_CLUSTER_ID": "test-aurora-global",
+    "AURORA_CLUSTER_ID": "test-aurora-e1",
+    "TARGET_AURORA_CLUSTER_ID": "test-aurora-e2",
+    "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID": "test-redis-global",
+    "ELASTICACHE_REPLICATION_GROUP_ID": "test-redis-e1",
+    "APP_NAME": "Vigil",
+    "ENVIRONMENT": "",
+}
+for k, v in _MIN_ENV.items():
+    os.environ.setdefault(k, v)
+
+_p1 = patch("boto3.client")
+_p1.start()
+_p2 = patch("state_backend.create_backend")
+_p2.start()
+
+import failover_orchestrator_v3 as orch  # noqa: E402
+
+_p1.stop()
+_p2.stop()
+
+
+def _state(**overrides):
+    """Build a baseline state dict, override fields as needed."""
+    base = {
+        "schema_version": 1,
+        "active_region": "us-east-1",
+        "state": "PRIMARY_ACTIVE",
+        "last_failover_ts": "1970-01-01T00:00:00Z",
+        "cooldown_minutes": 5,
+        "initiated_by": "INIT",
+        "reason": "Initial state",
+        "latch_engaged": False,
+        "consecutive_failures": 0,
+        "last_active_metric_ts": datetime.now(timezone.utc).isoformat(),
+        "aurora_promotion_pending": False,
+        "redis_promotion_pending": False,
+        "last_warning_notification_ts": "1970-01-01T00:00:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+def _unhealthy():
+    return {
+        "healthy": False,
+        "decision_reason": "HTTP 503",
+        "signals": [{"signal": "http_health", "healthy": False, "reason": "HTTP 503"}],
+    }
+
+
+def _get_subject(mock_sns):
+    return mock_sns.publish.call_args.kwargs.get("Subject") or \
+        mock_sns.publish.call_args[1].get("Subject")
+
+
+def _get_body(mock_sns):
+    return mock_sns.publish.call_args.kwargs.get("Message") or \
+        mock_sns.publish.call_args[1].get("Message")
+
+
+# ---------------------------------------------------------------------------
+# 1. First-failure notification: INFO / AWARENESS
+# ---------------------------------------------------------------------------
+
+class TestFirstFailureAwareness:
+    """v1.7.2: first failure is INFO/awareness, not WARNING."""
+
+    @patch.object(orch, "update_failover_state")
+    @patch.object(orch, "publish_region_health_metric")
+    @patch.object(orch, "try_increment_failures", return_value=True)
+    @patch.object(orch, "evaluate_region_health")
+    @patch.object(orch, "sns")
+    def test_first_failure_is_info_severity(
+        self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd
+    ):
+        """First failure (cf going 0→1) sends INFO with AWARENESS framing."""
+        mock_health.return_value = _unhealthy()
+        state = _state(consecutive_failures=0)
+
+        orch._handle_active_region(state, "us-east-1", 0, "1970-01-01T00:00:00Z")
+
+        subject = _get_subject(mock_sns)
+        # v1.7.2 change: severity is INFO (was WARNING in v1.6/v1.7).
+        assert "INFO" in subject
+        assert "AWARENESS" in subject.upper()
+        assert "no action needed" in subject.lower()
+        assert "1 of 3" in subject
+
+        body = _get_body(mock_sns)
+        assert "FIRST failure" in body
+        assert "awareness" in body.lower()
+        # "no action needed yet" tells operator they don't need to pager-respond.
+        assert "no action needed" in body.lower() or "no action required" in body.lower()
+
+    @patch.object(orch, "update_failover_state")
+    @patch.object(orch, "publish_region_health_metric")
+    @patch.object(orch, "try_increment_failures", return_value=True)
+    @patch.object(orch, "evaluate_region_health")
+    @patch.object(orch, "sns")
+    def test_second_failure_is_warning_severity(
+        self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd
+    ):
+        """Second failure (cf going 1→2) escalates to WARNING. The ladder is
+        intentional: first = INFO/awareness, second = WARNING/sustained,
+        third = CRITICAL/failover."""
+        mock_health.return_value = _unhealthy()
+        state = _state(consecutive_failures=1)
+
+        orch._handle_active_region(state, "us-east-1", 1, "1970-01-01T00:00:00Z")
+
+        subject = _get_subject(mock_sns)
+        assert "WARNING" in subject
+        assert "2 of 3" in subject
+        # No AWARENESS framing on sustained failures.
+        assert "AWARENESS" not in subject.upper()
+
+
+# ---------------------------------------------------------------------------
+# 2. "All stable on secondary" notification
+# ---------------------------------------------------------------------------
+
+class TestAllStableOnSecondary:
+    """v1.7.2: when state transitions WAITING_AURORA_PROMOTION → SECONDARY_ACTIVE,
+    fire a single INFO email summarising the new steady state."""
+
+    @patch.object(orch, "update_failover_state")
+    @patch.object(orch, "publish_region_health_metric")
+    @patch.object(orch, "try_increment_failures", return_value=False)
+    @patch.object(orch, "evaluate_region_health")
+    @patch.object(orch, "sns")
+    def test_transition_to_secondary_active_sends_info(
+        self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd
+    ):
+        """When _handle_active_region runs in WAITING_AURORA_PROMOTION with all
+        flags cleared, it transitions to SECONDARY_ACTIVE and sends the new
+        'all stable' notification."""
+        # Make health evaluation return healthy so we don't fall into the
+        # cf-increment branch — we want the WAITING→SECONDARY_ACTIVE branch.
+        mock_health.return_value = {
+            "healthy": True,
+            "decision_reason": "all good",
+            "signals": [],
+        }
+        state = _state(
+            active_region="us-east-2",
+            state="WAITING_AURORA_PROMOTION",
+            aurora_promotion_pending=False,
+            redis_promotion_pending=False,
+            latch_engaged=True,
+        )
+
+        with patch.object(orch, "CURRENT_REGION", "us-east-2"):
+            orch._handle_active_region(state, "us-east-2", 0, "1970-01-01T00:00:00Z")
+
+        # SNS publish should fire at least once with the new "all stable" message.
+        stable_calls = [
+            c for c in mock_sns.publish.call_args_list
+            if "all stable" in c[1].get("Subject", "").lower()
+            or "failover complete" in c[1].get("Subject", "").lower()
+        ]
+        assert len(stable_calls) == 1, "Expected exactly one 'all stable on secondary' email"
+        subject = stable_calls[0][1]["Subject"]
+        assert "INFO" in subject
+        assert "us-east-2" in subject
+        assert "stable" in subject.lower() or "complete" in subject.lower()
+
+        body = stable_calls[0][1]["Message"]
+        # Body explains the system is in steady state, latch engaged, no action needed.
+        assert "us-east-2" in body
+        assert "us-east-1" in body  # the failed-over-from region
+        assert "latch" in body.lower()
+        assert "no action" in body.lower()
+
+    @patch.object(orch, "update_failover_state")
+    @patch.object(orch, "publish_region_health_metric")
+    @patch.object(orch, "try_increment_failures", return_value=False)
+    @patch.object(orch, "evaluate_region_health")
+    @patch.object(orch, "sns")
+    def test_transition_does_not_block_on_notification_failure(
+        self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd
+    ):
+        """If SNS publish fails for any reason, the state transition still
+        happens. Notification is best-effort; the state machine keeps moving."""
+        mock_health.return_value = {"healthy": True, "decision_reason": "ok", "signals": []}
+        mock_sns.publish.side_effect = RuntimeError("SNS down")
+        state = _state(
+            active_region="us-east-2",
+            state="WAITING_AURORA_PROMOTION",
+            aurora_promotion_pending=False,
+            redis_promotion_pending=False,
+            latch_engaged=True,
+        )
+
+        with patch.object(orch, "CURRENT_REGION", "us-east-2"):
+            # Must not raise — failure is logged but state transition proceeds.
+            orch._handle_active_region(state, "us-east-2", 0, "1970-01-01T00:00:00Z")
+
+        # The state-transition update_failover_state still fired.
+        assert mock_upd.called
+        # Look for the call that wrote state=SECONDARY_ACTIVE.
+        state_writes = [
+            c for c in mock_upd.call_args_list
+            if c[0][0].get("state") == "SECONDARY_ACTIVE"
+        ]
+        assert len(state_writes) == 1, "State transition must still happen even if SNS fails"
+
+    @patch.object(orch, "update_failover_state")
+    @patch.object(orch, "publish_region_health_metric")
+    @patch.object(orch, "try_increment_failures", return_value=False)
+    @patch.object(orch, "evaluate_region_health")
+    @patch.object(orch, "sns")
+    def test_no_transition_when_promotion_still_pending(
+        self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd
+    ):
+        """If aurora_promotion_pending or redis_promotion_pending is still True,
+        no transition happens and no 'all stable' email fires."""
+        mock_health.return_value = {"healthy": True, "decision_reason": "ok", "signals": []}
+        state = _state(
+            active_region="us-east-2",
+            state="WAITING_AURORA_PROMOTION",
+            aurora_promotion_pending=True,  # ← still pending
+            redis_promotion_pending=False,
+            latch_engaged=True,
+        )
+
+        with patch.object(orch, "CURRENT_REGION", "us-east-2"):
+            orch._handle_active_region(state, "us-east-2", 0, "1970-01-01T00:00:00Z")
+
+        # No state=SECONDARY_ACTIVE write.
+        state_writes = [
+            c for c in mock_upd.call_args_list
+            if c[0][0].get("state") == "SECONDARY_ACTIVE"
+        ]
+        assert len(state_writes) == 0
+        # No "all stable" email.
+        stable_calls = [
+            c for c in mock_sns.publish.call_args_list
+            if "stable" in c[1].get("Subject", "").lower()
+        ]
+        assert len(stable_calls) == 0


### PR DESCRIPTION
## Summary

Three changes from the v1.7 GO/NO-GO drill bundled as v1.7.2.

### F11 — `InvalidGlobalReplicationGroupState` retry in failback

ElastiCache Global Datastore can stay in a transient "modifying" state for several minutes after a recent failover. Surfaced during the v1.7 clean E2E drill: invoking failback within ~5 min of a failover hit `InvalidGlobalReplicationGroupState` and returned 500 to the operator.

Now retries the API call up to 5 times with 30s backoff before giving up. Same shape as the existing "already primary" idempotency.

### Notification UX overhaul

Per user request from the v1.7 GO/NO-GO sign-off:

| Notification | Was | Now |
|---|---|---|
| First failure (cf 0→1) | WARNING "FIRST health failure" | **INFO "AWARENESS: ... no action needed yet"** |
| Sustained (cf 1→2) | WARNING "sustained" | unchanged (still WARNING) |
| Failover trigger (cf=3) | CRITICAL "Failover triggered" | unchanged (still CRITICAL) |
| State → SECONDARY_ACTIVE | (silent) | **NEW: INFO "All stable on <region> — failover complete"** |
| Failback complete | CRITICAL "Failback COMPLETE" | **INFO "All back to normal"** |

Clean severity ladder: INFO/awareness → WARNING/sustained → CRITICAL/action-required → INFO/normal-restored. The first-failure email no longer pager-responds operators on a transient blip; the operator now gets explicit confirmations at both ends of the incident lifecycle.

## Tests

- **454 passing**, 30 skipped (was 446)
- 3 new F11 tests in `tests/test_v171_failback_wait.py`
- 5 new tests in `tests/test_v172_notifications.py`
- 4 prior tests updated to match new severity/wording contract

## Drill validation plan

After this merges, the C2 scenario drill (Aurora manual + no ElastiCache, 1hr operator delay) will exercise:
- The new "all stable on secondary" notification (after operator runs Aurora switchover manually and orchestrator detects writer flip)
- The new "all back to normal" failback notification
- F11 idempotency on the failback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)