### PR TITLE
fix(#96): config-aware data-tier names in notification bodies

### DIFF
--- a/failover_orchestrator_v3.py
+++ b/failover_orchestrator_v3.py
@@ -3438,10 +3438,13 @@ def _handle_active_region(state: dict, active_region: str,
             origin_region = PRIMARY_REGION if active_region == SECONDARY_REGION else SECONDARY_REGION
             cfg = detect_data_tier_config()
             data_tier_summary = []
+            tier_names = []
             if cfg.get("aurora_present"):
                 data_tier_summary.append(f"Aurora writer: {active_region}")
+                tier_names.append("Aurora")
             if cfg.get("redis_present"):
                 data_tier_summary.append(f"Redis primary: {active_region}")
+                tier_names.append("ElastiCache")
             ctx = {
                 "Active region": active_region,
                 "Failed-over from": origin_region,
@@ -3450,6 +3453,12 @@ def _handle_active_region(state: dict, active_region: str,
             }
             if data_tier_summary:
                 ctx["Data tier"] = " · ".join(data_tier_summary)
+            if len(tier_names) == 0:
+                tier_clause = "the failover completed successfully"
+            elif len(tier_names) == 1:
+                tier_clause = f"the {tier_names[0]} promotion completed successfully"
+            else:
+                tier_clause = f"the {' and '.join(tier_names)} promotions completed successfully"
             subject, body = compose_message(
                 severity=SEVERITY_INFO,
                 what=(
@@ -3457,12 +3466,11 @@ def _handle_active_region(state: dict, active_region: str,
                     f"app fully running on the secondary"
                 ),
                 why=(
-                    f"The orchestrator confirmed Aurora and ElastiCache promotions "
-                    f"completed successfully. Traffic has moved from {origin_region} "
-                    f"to {active_region}, the data tier is in the right place, and "
-                    f"the system is in steady state ({new_state}). The latch is "
-                    f"engaged to prevent flip-flop — running in {active_region} until "
-                    f"manual failback."
+                    f"The orchestrator confirmed {tier_clause}. "
+                    f"Traffic has moved from {origin_region} to {active_region}, "
+                    f"the data tier is in the right place, and the system is in "
+                    f"steady state ({new_state}). The latch is engaged to prevent "
+                    f"flip-flop — running in {active_region} until manual failback."
                 ),
                 next_step=(
                     f"No action required. Confirm Route 53 traffic is flowing to "
@@ -4046,14 +4054,23 @@ def _handle_active_region(state: dict, active_region: str,
             )
             next_step = "\n".join(next_step_parts) + (ai_appendix or "")
 
+            manual_tier_names = []
+            if cfg.get("aurora_present") and not cfg.get("aurora_auto"):
+                manual_tier_names.append("Aurora")
+            if cfg.get("redis_present") and not cfg.get("redis_auto"):
+                manual_tier_names.append("ElastiCache")
+            if not manual_tier_names:
+                manual_tier_phrase = "the failed data-tier promotion"
+            else:
+                manual_tier_phrase = " and ".join(manual_tier_names)
             subject, body = compose_message(
                 severity=SEVERITY_CRITICAL,
                 what=f"Failover triggered — promote data tier in {target_region} now",
                 why=(
                     f"{health.get('decision_reason', 'health check failed')}. "
                     f"DNS was moved automatically but data-tier auto-promote is "
-                    f"disabled (or failed), so the operator must promote Aurora "
-                    f"and/or ElastiCache manually before the new active region "
+                    f"disabled (or failed), so the operator must promote "
+                    f"{manual_tier_phrase} manually before the new active region "
                     f"can serve writes."
                 ),
                 next_step=next_step,

--- a/manual_failback_v2.py
+++ b/manual_failback_v2.py
@@ -1209,9 +1209,11 @@ def handler(event, context):
 
         logger.info("  4d: Sending confirmation notification...")
         cfg = detect_data_tier_config()
-        # Journey: failback is the inverse of failover. All earlier journey
-        # steps map to "✓" and the lifecycle is back at PRIMARY_ACTIVE.
-        journey = ["[✓] Failback requested", "[✓] Aurora switchover (operator)"]
+        # Journey: failback is the inverse of failover. Skip the Aurora step
+        # when Aurora is not configured (app-only / Redis-only stacks).
+        journey = ["[✓] Failback requested"]
+        if cfg["aurora_present"]:
+            journey.append("[✓] Aurora switchover (operator)")
         if cfg["redis_present"]:
             journey.append("[✓] Redis switchover (operator)")
         journey.append("[✓] Latch released — system back to PRIMARY_ACTIVE")
@@ -1225,6 +1227,11 @@ def handler(event, context):
             f"5–10 minutes to confirm the underlying issue is fully resolved."
             + (readiness_appendix or "")
         )
+        validations = ["HTTP 200", "ECS healthy"]
+        if cfg["aurora_present"]:
+            validations.append(f"Aurora writer in {target_region}")
+        if cfg["redis_present"]:
+            validations.append(f"Redis primary in {target_region}")
         subject, body = compose_message(
             severity=SEVERITY_INFO,
             what=(
@@ -1234,11 +1241,10 @@ def handler(event, context):
             why=(
                 f"Operator {operator} initiated and completed manual failback "
                 f"from {active_region} back to {target_region}. The orchestrator "
-                f"validated target health (HTTP 200, ECS healthy, Aurora writer in "
-                f"{target_region}, Redis primary in {target_region} where applicable), "
-                f"released the latch, and updated state to PRIMARY_ACTIVE. The "
-                f"system is in steady state with {target_region} fully serving "
-                f"traffic and the failover safety net armed."
+                f"validated target health ({', '.join(validations)}), released "
+                f"the latch, and updated state to PRIMARY_ACTIVE. The system is "
+                f"in steady state with {target_region} fully serving traffic and "
+                f"the failover safety net armed."
             ),
             next_step=next_step,
             context={

--- a/tests/test_sns_notifications_failover.py
+++ b/tests/test_sns_notifications_failover.py
@@ -648,7 +648,11 @@ class TestSNSFailoverExecution:
     def test_failover_no_ec_excludes_elasticache_commands(
         self, mock_sns, mock_health, mock_pub, mock_upd
     ):
-        """Without ElastiCache (C2 config): v1.6 message has no Redis content."""
+        """Without ElastiCache (C2 config): v1.6 message has no Redis content.
+
+        Issue #96: also assert ElastiCache is absent from the WHY paragraph.
+        Pre-fix this test passed because it only checked for 'Redis', but
+        the WHY text actually used 'Aurora and/or ElastiCache' verbatim."""
         self._run_failover(mock_sns, mock_health, mock_pub, mock_upd, elasticache=False)
 
         failover_calls = [
@@ -658,9 +662,12 @@ class TestSNSFailoverExecution:
         assert len(failover_calls) == 1
         message = failover_calls[-1][1]["Message"]
 
-        # No ElastiCache in body; no Redis row in journey.
+        # No ElastiCache or Redis in body; no Redis row in journey.
         assert "failover-global-replication-group" not in message
         assert "Redis" not in message
+        assert "ElastiCache" not in message
+        # WHY paragraph names only Aurora as the manual-promote target.
+        assert "promote Aurora manually" in message
         # Aurora commands and journey row still present.
         assert "switchover-global-cluster" in message or "aurora" in message.lower()
         assert "Aurora — operator action required" in message
@@ -1918,6 +1925,115 @@ class TestSNSFailback:
         assert subject.startswith("[Vigil] INFO:")
         assert "back to normal" in subject.lower()
         assert "us-east-1" in subject
+
+    # ----- v1.7.3 (issue #96): config-aware "all back to normal" body ----
+
+    @patch.object(failback, "create_backend")
+    @patch.object(failback, "publish_region_health_metric")
+    @patch.object(failback, "update_failover_state")
+    @patch.object(failback, "get_failover_state")
+    @patch.object(failback, "sns")
+    def test_failback_complete_aurora_only_omits_redis(
+        self, mock_sns, mock_get_state, mock_upd, mock_pub, mock_cb
+    ):
+        """Issue #96: Aurora-only stack — 'all back to normal' body must NOT
+        mention Redis/ElastiCache anywhere (was hedged with 'where applicable')."""
+        mock_cb.return_value = MagicMock()
+        mock_get_state.return_value = _make_failback_state()
+
+        with patch.dict(os.environ, {
+            "AURORA_CLUSTER_ID": "test-aurora-e1",
+            "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID": "",
+        }):
+            result = failback.handler(self._run_failback(), None)
+
+        assert result["statusCode"] == 200
+        complete_calls = [
+            c for c in mock_sns.publish.call_args_list
+            if "back to normal" in c[1].get("Subject", "").lower()
+        ]
+        assert len(complete_calls) == 1
+        body = complete_calls[0][1]["Message"]
+        assert "Aurora writer in us-east-1" in body
+        assert "Redis" not in body
+        assert "ElastiCache" not in body
+        # Journey must not have a Redis switchover step.
+        assert "Redis switchover" not in body
+        # Aurora switchover step is still present.
+        assert "Aurora switchover" in body
+
+    @patch.object(failback, "create_backend")
+    @patch.object(failback, "publish_region_health_metric")
+    @patch.object(failback, "update_failover_state")
+    @patch.object(failback, "get_failover_state")
+    @patch.object(failback, "sns")
+    def test_failback_complete_aurora_and_redis_lists_both(
+        self, mock_sns, mock_get_state, mock_upd, mock_pub, mock_cb
+    ):
+        """Issue #96: both tiers configured — body lists Aurora writer AND
+        Redis primary explicitly; journey has both switchover steps."""
+        mock_cb.return_value = MagicMock()
+        mock_get_state.return_value = _make_failback_state()
+
+        with patch.dict(os.environ, {
+            "AURORA_CLUSTER_ID": "test-aurora-e1",
+            "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID": "test-redis-global",
+        }):
+            result = failback.handler(
+                self._run_failback({"redis_confirmed": True}), None
+            )
+
+        assert result["statusCode"] == 200
+        complete_calls = [
+            c for c in mock_sns.publish.call_args_list
+            if "back to normal" in c[1].get("Subject", "").lower()
+        ]
+        assert len(complete_calls) == 1
+        body = complete_calls[0][1]["Message"]
+        assert "Aurora writer in us-east-1" in body
+        assert "Redis primary in us-east-1" in body
+        assert "Aurora switchover" in body
+        assert "Redis switchover" in body
+        # The hedging "where applicable" wording must be gone.
+        assert "where applicable" not in body
+
+    @patch.object(failback, "create_backend")
+    @patch.object(failback, "publish_region_health_metric")
+    @patch.object(failback, "update_failover_state")
+    @patch.object(failback, "get_failover_state")
+    @patch.object(failback, "sns")
+    def test_failback_complete_app_only_no_data_tier_terms(
+        self, mock_sns, mock_get_state, mock_upd, mock_pub, mock_cb
+    ):
+        """Issue #96: app-only stack — no Aurora, no Redis — body's validation
+        list must contain only 'HTTP 200, ECS healthy' and journey must skip
+        both data-tier switchover steps."""
+        mock_cb.return_value = MagicMock()
+        mock_get_state.return_value = _make_failback_state()
+
+        with patch.dict(os.environ, {
+            "AURORA_CLUSTER_ID": "",
+            "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID": "",
+        }):
+            result = failback.handler({
+                "target_region": "us-east-1",
+                "operator": "test-operator",
+                "skip_health_check": True,
+                "skip_readiness_check": True,
+            }, None)
+
+        assert result["statusCode"] == 200
+        complete_calls = [
+            c for c in mock_sns.publish.call_args_list
+            if "back to normal" in c[1].get("Subject", "").lower()
+        ]
+        assert len(complete_calls) == 1
+        body = complete_calls[0][1]["Message"]
+        assert "HTTP 200" in body
+        assert "ECS healthy" in body
+        assert "Aurora" not in body
+        assert "Redis" not in body
+        assert "ElastiCache" not in body
 
 
 # ===========================================================================

--- a/tests/test_v172_notifications.py
+++ b/tests/test_v172_notifications.py
@@ -270,3 +270,98 @@ class TestAllStableOnSecondary:
             if "stable" in c[1].get("Subject", "").lower()
         ]
         assert len(stable_calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# 4. v1.7.3 (issue #96): "all stable" body must reflect actual tier config
+# ---------------------------------------------------------------------------
+
+class TestAllStableConfigAware:
+    """Issue #96: when ElastiCache is not configured the 'all stable' email
+    must NOT mention ElastiCache/Redis in its WHY paragraph. Was hardcoded
+    to 'Aurora and ElastiCache promotions completed successfully' regardless
+    of what the deployment actually had — confusing for app-only or Aurora-
+    only stacks."""
+
+    def _drive_transition(self, mock_sns, mock_health):
+        mock_health.return_value = {"healthy": True, "decision_reason": "ok", "signals": []}
+        state = _state(
+            active_region="us-east-2",
+            state="WAITING_AURORA_PROMOTION",
+            aurora_promotion_pending=False,
+            redis_promotion_pending=False,
+            latch_engaged=True,
+        )
+        with patch.object(orch, "CURRENT_REGION", "us-east-2"):
+            orch._handle_active_region(state, "us-east-2", 0, "1970-01-01T00:00:00Z")
+        stable_calls = [
+            c for c in mock_sns.publish.call_args_list
+            if "stable" in c[1].get("Subject", "").lower()
+            or "failover complete" in c[1].get("Subject", "").lower()
+        ]
+        assert len(stable_calls) == 1
+        return stable_calls[0][1]["Message"]
+
+    @patch.object(orch, "update_failover_state")
+    @patch.object(orch, "publish_region_health_metric")
+    @patch.object(orch, "try_increment_failures", return_value=False)
+    @patch.object(orch, "evaluate_region_health")
+    @patch.object(orch, "sns")
+    def test_aurora_and_redis_mentions_both(
+        self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd
+    ):
+        """Both tiers configured: WHY paragraph names both."""
+        with patch.dict(os.environ, {
+            "AURORA_CLUSTER_ID": "test-aurora-e1",
+            "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID": "test-redis-global",
+        }):
+            body = self._drive_transition(mock_sns, mock_health)
+        assert "Aurora and ElastiCache promotions completed successfully" in body
+        # CONTEXT block has both data-tier lines.
+        assert "Aurora writer: us-east-2" in body
+        assert "Redis primary: us-east-2" in body
+
+    @patch.object(orch, "update_failover_state")
+    @patch.object(orch, "publish_region_health_metric")
+    @patch.object(orch, "try_increment_failures", return_value=False)
+    @patch.object(orch, "evaluate_region_health")
+    @patch.object(orch, "sns")
+    def test_aurora_only_omits_elasticache(
+        self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd
+    ):
+        """Aurora-only stack (no ElastiCache): WHY must say 'Aurora promotion
+        completed' singular and must NOT mention ElastiCache or Redis. CONTEXT
+        Data-tier line must omit the Redis row."""
+        with patch.dict(os.environ, {
+            "AURORA_CLUSTER_ID": "test-aurora-e1",
+            "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID": "",
+        }):
+            body = self._drive_transition(mock_sns, mock_health)
+        assert "Aurora promotion completed successfully" in body
+        assert "ElastiCache" not in body
+        assert "Redis" not in body
+
+    @patch.object(orch, "update_failover_state")
+    @patch.object(orch, "publish_region_health_metric")
+    @patch.object(orch, "try_increment_failures", return_value=False)
+    @patch.object(orch, "evaluate_region_health")
+    @patch.object(orch, "sns")
+    def test_no_data_tier_uses_generic_phrase(
+        self, mock_sns, mock_health, mock_inc, mock_pub, mock_upd
+    ):
+        """App-only stack (no Aurora, no ElastiCache): WHY uses a generic
+        'failover completed successfully' phrase and the CONTEXT block has
+        no Data-tier line at all."""
+        with patch.dict(os.environ, {
+            "AURORA_CLUSTER_ID": "",
+            "ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID": "",
+        }):
+            body = self._drive_transition(mock_sns, mock_health)
+        assert "the failover completed successfully" in body
+        assert "Aurora" not in body
+        assert "ElastiCache" not in body
+        assert "Redis" not in body
+        # The CONTEXT block must NOT have a "Data tier :" row (compose_message
+        # renders k/v pairs as "  <label> : <value>"). The journey line
+        # "[✓] Data tier promoted" is unrelated and is allowed to remain.
+        assert "Data tier  :" not in body and "Data tier :" not in body


### PR DESCRIPTION
## Summary

- 'All stable on secondary', 'promote data tier now', and 'all back to normal' emails were referring to ElastiCache/Redis even on stacks that don't have it configured. Confusing for operators on app-only or Aurora-only deployments.
- Three WHY paragraphs and one validation list now read from `detect_data_tier_config()` and only name the tiers actually present.
- Failback journey skips Aurora/Redis switchover steps that didn't apply.

## Changes

- `failover_orchestrator_v3.py:3437-3500` — 'all stable on secondary' WHY uses singular/plural based on Aurora/Redis presence; falls back to 'failover completed successfully' for app-only stacks.
- `failover_orchestrator_v3.py:4049-4070` — 'promote data tier now' WHY only names tiers that are present AND have auto-promote disabled.
- `manual_failback_v2.py:1210-1257` — 'all back to normal' validation list and journey are config-aware; the hedging 'where applicable' phrasing is gone.

## Test plan

- [x] `python3 -m pytest tests/ -v` → 460 passed, 30 skipped (was 454/30).
- [x] New: `TestAllStableConfigAware` (3 tests) — Aurora-only, Aurora+Redis, app-only.
- [x] New: `TestSNSFailback` config-aware (3 tests) — Aurora-only, Aurora+Redis, app-only.
- [x] Strengthened `test_failover_no_ec_excludes_elasticache_commands` to also assert 'ElastiCache' absent (it only checked 'Redis' and missed the original bug).
- [ ] Manual smoke after merge: deploy to fo-v16-drill (us-east-1, tbed) and trigger a transition with `ELASTICACHE_GLOBAL_REPLICATION_GROUP_ID=""` to confirm the email body reads correctly in a real inbox.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)