### PR TITLE
feat(#98): observability metrics for state, signals, lifecycle, durations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | v1.4.2 | `v1.4.2` | + CFN resource naming fix: restore `fo-${Env}` prefix in `cfn/failover.yaml` |
 | v1.4.3 | `v1.4.3` | + Comprehensive SNS notification validation: 50 tests across all config variants (S3/DDB, ElastiCache on/off, API GW on/off, active/passive + active/active) |
 | v1.5 | `v1.5` | + Three-state CW staleness logic: network-layer CW failures now inconclusive (cw_stale=None) instead of confirming; heartbeat alone requires 2× deep staleness to fire failover when CW unreachable. Fixes false-failover on borderline heartbeat + transient CW timeout. |
+| v1.6 | `v1.6` | + Notification template (`compose_message`) + WARNING throttle 10→5min + config-aware failback gates + retry caps + R53 validator |
+| v1.7 | `v1.7` | + Per-region health keys fix S3-backend F7/F8 races |
+| v1.7.1 | `v1.7.1` | + Wait for promotion completion in failback Lambda (F10) |
+| v1.7.2 | `v1.7.2` | + F11: retry + notification UX (first-fail awareness, all-stable-on-secondary, all-back-to-normal) |
+| v1.8 | (issue #98) | + Comprehensive observability: `observability.py` publishes 4 state metrics + 6 per-signal metrics + 5 lifecycle counters + 2 promotion duration histograms, all with Region/AppName/RoutingMode dimensions |
 
 ### Demo Environment (v2.0 Platform)
 
@@ -88,7 +93,7 @@ python3 tools/publish_version.py --alias active --copy-from v1-2
 # Returns: {"ready": true/false, "checks": {"state_backend": ..., "cloudwatch_metric": ..., "sns_topic": ...}}
 
 # Package and deploy orchestrator Lambda (production)
-zip failover_orchestrator_v3.zip failover_orchestrator_v3.py state_backend.py notifications.py ai/__init__.py ai/config.py ai/llm_client.py ai/collector.py ai/rca_analyzer.py ai/stability_collector.py ai/aurora_advisor.py
+zip failover_orchestrator_v3.zip failover_orchestrator_v3.py state_backend.py notifications.py observability.py ai/__init__.py ai/config.py ai/llm_client.py ai/collector.py ai/rca_analyzer.py ai/stability_collector.py ai/aurora_advisor.py
 aws lambda update-function-code \
   --function-name failover-orchestrator-prod \
   --zip-file fileb://failover_orchestrator_v3.zip \
@@ -96,7 +101,7 @@ aws lambda update-function-code \
 # Repeat for us-west-2
 
 # Package and deploy failback Lambda (production)
-zip manual_failback_v2.zip manual_failback_v2.py state_backend.py notifications.py ai/__init__.py ai/config.py ai/llm_client.py ai/stability_collector.py ai/failback_readiness.py
+zip manual_failback_v2.zip manual_failback_v2.py state_backend.py notifications.py observability.py ai/__init__.py ai/config.py ai/llm_client.py ai/stability_collector.py ai/failback_readiness.py
 aws lambda update-function-code \
   --function-name failover-manual-failback-prod \
   --zip-file fileb://manual_failback_v2.zip \
@@ -121,6 +126,7 @@ Runtime dependencies: `boto3`, `botocore` (provided by Lambda runtime). Portal a
 | `failover_orchestrator_v3.py` | Main Lambda (~2,100 lines). Deployed in both regions. Evaluates health, publishes Route 53 metrics, triggers failover. |
 | `manual_failback_v2.py` | Failback Lambda. Operator-triggered to return traffic to primary. |
 | `state_backend.py` | State backend abstraction: DynamoDB Global Table or S3 CRR. |
+| `observability.py` | Shared CW metric helpers: state machine, per-signal, lifecycle counters, promotion durations. Auto-attaches Region+AppName+RoutingMode dims. |
 | `failover_cli.py` | Interactive CLI for operators: live health monitoring, failure simulation, state inspection. |
 | `failover_dashboard_local.py` | Flask web dashboard reading state from backend. |
 | `ai/config.py` | AI configuration: provider, model, timeouts, feature toggles. |
@@ -141,6 +147,7 @@ Runtime dependencies: `boto3`, `botocore` (provided by Lambda runtime). Portal a
 | `.github/workflows/deploy.yml` | GitHub Actions: publish Lambda version on tag push. |
 | `tests/test_orchestrator.py` | Regression tests for core orchestrator logic (52 tests). |
 | `tests/test_state_backend.py` | Unit + integration + CRR replication tests for state backends. |
+| `tests/test_observability.py` | Unit tests for `observability.py` metric helpers (19 tests, issue #98). |
 | `tests/test_e2e_s3_backend.py` | End-to-end scenario tests for S3 backend. |
 | `tests/test_rca.py` | Unit + integration tests for AI RCA module (32 tests). |
 | `tests/test_llm_client.py` | Unit tests for shared LLM client (14 tests). |
@@ -421,9 +428,9 @@ python3 tools/setup_s3_state_backend.py
 #    STATE_BUCKET=failover-state-<region>-<account-id>
 #    STATE_PREFIX=failover-state/
 
-# 3. Include state_backend.py and notifications.py in the Lambda deployment zip:
-zip failover_orchestrator_v3.zip failover_orchestrator_v3.py state_backend.py notifications.py
-zip manual_failback_v2.zip manual_failback_v2.py state_backend.py notifications.py ai/__init__.py ai/config.py ai/llm_client.py ai/stability_collector.py ai/failback_readiness.py
+# 3. Include state_backend.py, notifications.py, and observability.py in the Lambda deployment zip:
+zip failover_orchestrator_v3.zip failover_orchestrator_v3.py state_backend.py notifications.py observability.py
+zip manual_failback_v2.zip manual_failback_v2.py state_backend.py notifications.py observability.py ai/__init__.py ai/config.py ai/llm_client.py ai/stability_collector.py ai/failback_readiness.py
 ```
 
 ### Trade-offs vs DynamoDB

--- a/failover_orchestrator_v3.py
+++ b/failover_orchestrator_v3.py
@@ -64,6 +64,12 @@ from notifications import (
     SEVERITY_WARNING,
     SEVERITY_CRITICAL,
 )
+from observability import (
+    publish_state_metrics,
+    publish_signal_metrics,
+    increment_counter,
+    record_duration_seconds,
+)
 
 # AI modules are imported lazily inside functions to support v1.0 mode
 # (where AI_RCA_ENABLED=false and AI modules may not be needed)
@@ -1461,6 +1467,7 @@ def _handle_active_active(state: dict) -> dict:
 
     # Evaluate health
     health = evaluate_region_health()
+    publish_signal_metrics(health, CURRENT_REGION)
     logger.info(
         f"Active-active health: healthy={health['healthy']}, "
         f"failures={consecutive_failures}, reason={health.get('decision_reason', 'N/A')}"
@@ -1981,85 +1988,98 @@ def handler(event, context):
     if event.get("preflight", False):
         return _run_preflight_checks(include_r53=event.get("include_r53", False))
 
-    # Re-read dynamic config (portal may have changed env vars)
-    _reload_dynamic_config()
+    # Issue #98 — every non-preflight invocation publishes the 4 state-machine
+    # metrics in a finally block so the dashboard sees post-mutation state on
+    # every return path. Wrapped in its own try/except inside finally so a CW
+    # outage never crashes the handler.
+    try:
+        # Re-read dynamic config (portal may have changed env vars)
+        _reload_dynamic_config()
 
-    logger.info(
-        f"Failover Orchestrator running in {CURRENT_REGION}, "
-        f"mode={FAILOVER_MODE}, routing={ROUTING_MODE}"
-    )
+        logger.info(
+            f"Failover Orchestrator running in {CURRENT_REGION}, "
+            f"mode={FAILOVER_MODE}, routing={ROUTING_MODE}"
+        )
 
-    # -----------------------------------------------------------------
-    # Reset state: operator invokes with reset_state=true
-    # -----------------------------------------------------------------
-    if event.get("reset_state", False):
-        logger.info("State reset requested via event payload")
-        return _reset_state()
+        # -----------------------------------------------------------------
+        # Reset state: operator invokes with reset_state=true
+        # -----------------------------------------------------------------
+        if event.get("reset_state", False):
+            logger.info("State reset requested via event payload")
+            return _reset_state()
 
-    state = get_failover_state()
+        state = get_failover_state()
 
-    # -----------------------------------------------------------------
-    # Active-active mode: skip failover logic, just evaluate own health
-    # -----------------------------------------------------------------
-    if ROUTING_MODE == "active-active":
-        return _handle_active_active(state)
+        # -----------------------------------------------------------------
+        # Active-active mode: skip failover logic, just evaluate own health
+        # -----------------------------------------------------------------
+        if ROUTING_MODE == "active-active":
+            return _handle_active_active(state)
 
-    # -----------------------------------------------------------------
-    # Manual failover trigger: operator invokes with execute_failover=true
-    # (failover mode only — not applicable to active-active)
-    # -----------------------------------------------------------------
-    if event.get("execute_failover", False):
-        logger.info("Manual failover execution requested via event payload")
-        return _execute_manual_failover()
-    active_region = state.get("active_region", PRIMARY_REGION)
-    current_state = state.get("state", "PRIMARY_ACTIVE")
-    latch_engaged = state.get("latch_engaged", False)
-    consecutive_failures = int(state.get("consecutive_failures", 0))
-    last_failover_ts = state.get("last_failover_ts", "1970-01-01T00:00:00Z")
-    aurora_promotion_pending = state.get("aurora_promotion_pending", False)
-    redis_promotion_pending = state.get("redis_promotion_pending", False)
+        # -----------------------------------------------------------------
+        # Manual failover trigger: operator invokes with execute_failover=true
+        # (failover mode only — not applicable to active-active)
+        # -----------------------------------------------------------------
+        if event.get("execute_failover", False):
+            logger.info("Manual failover execution requested via event payload")
+            return _execute_manual_failover()
+        active_region = state.get("active_region", PRIMARY_REGION)
+        current_state = state.get("state", "PRIMARY_ACTIVE")
+        latch_engaged = state.get("latch_engaged", False)
+        consecutive_failures = int(state.get("consecutive_failures", 0))
+        last_failover_ts = state.get("last_failover_ts", "1970-01-01T00:00:00Z")
+        aurora_promotion_pending = state.get("aurora_promotion_pending", False)
+        redis_promotion_pending = state.get("redis_promotion_pending", False)
 
-    logger.info(
-        f"State: active={active_region}, state={current_state}, "
-        f"latch={latch_engaged}, failures={consecutive_failures}, "
-        f"aurora_pending={aurora_promotion_pending}, "
-        f"redis_pending={redis_promotion_pending}, current_region={CURRENT_REGION}"
-    )
+        logger.info(
+            f"State: active={active_region}, state={current_state}, "
+            f"latch={latch_engaged}, failures={consecutive_failures}, "
+            f"aurora_pending={aurora_promotion_pending}, "
+            f"redis_pending={redis_promotion_pending}, current_region={CURRENT_REGION}"
+        )
 
-    # Skip if a failover or failback is already in progress
-    if current_state in ("FAILOVER_IN_PROGRESS", "FAILBACK_IN_PROGRESS"):
-        logger.info(f"State is {current_state}, skipping evaluation")
-        return {"statusCode": 200, "body": f"Skipping - {current_state}"}
+        # Skip if a failover or failback is already in progress
+        if current_state in ("FAILOVER_IN_PROGRESS", "FAILBACK_IN_PROGRESS"):
+            logger.info(f"State is {current_state}, skipping evaluation")
+            return {"statusCode": 200, "body": f"Skipping - {current_state}"}
 
-    # If data tier promotion is pending (Aurora and/or ElastiCache), handle
-    # reminders. Only the Lambda in the NEW active region handles this.
-    # The Lambda in the failed region falls through to passive handler.
-    any_promotion_pending = aurora_promotion_pending or redis_promotion_pending
-    if any_promotion_pending and current_state == "WAITING_AURORA_PROMOTION":
-        if CURRENT_REGION == active_region:
-            if aurora_promotion_pending:
-                _handle_aurora_promotion_reminder(state)
-            if redis_promotion_pending:
-                _handle_elasticache_promotion_reminder(state)
+        # If data tier promotion is pending (Aurora and/or ElastiCache), handle
+        # reminders. Only the Lambda in the NEW active region handles this.
+        # The Lambda in the failed region falls through to passive handler.
+        any_promotion_pending = aurora_promotion_pending or redis_promotion_pending
+        if any_promotion_pending and current_state == "WAITING_AURORA_PROMOTION":
+            if CURRENT_REGION == active_region:
+                if aurora_promotion_pending:
+                    _handle_aurora_promotion_reminder(state)
+                if redis_promotion_pending:
+                    _handle_elasticache_promotion_reminder(state)
 
-            # Re-read state to check if both flags are now cleared
-            state = get_failover_state()
-            aurora_still = state.get("aurora_promotion_pending", False)
-            redis_still = state.get("redis_promotion_pending", False)
+                # Re-read state to check if both flags are now cleared
+                state = get_failover_state()
+                aurora_still = state.get("aurora_promotion_pending", False)
+                redis_still = state.get("redis_promotion_pending", False)
 
-            if aurora_still or redis_still:
-                publish_region_health_metric(CURRENT_REGION, True)
-                return {"statusCode": 200, "body": "Waiting for data tier promotion"}
-            # Both cleared — fall through to _handle_active_region which
-            # transitions from WAITING_AURORA_PROMOTION to steady state
-        # If we're not the active region, fall through to passive handler
-        # which will publish 0 for us (latch is engaged)
+                if aurora_still or redis_still:
+                    publish_region_health_metric(CURRENT_REGION, True)
+                    return {"statusCode": 200, "body": "Waiting for data tier promotion"}
+                # Both cleared — fall through to _handle_active_region which
+                # transitions from WAITING_AURORA_PROMOTION to steady state
+            # If we're not the active region, fall through to passive handler
+            # which will publish 0 for us (latch is engaged)
 
-    if CURRENT_REGION != active_region:
-        return _handle_passive_region(state, active_region)
+        if CURRENT_REGION != active_region:
+            return _handle_passive_region(state, active_region)
 
-    return _handle_active_region(state, active_region,
-                                consecutive_failures, last_failover_ts)
+        return _handle_active_region(state, active_region,
+                                    consecutive_failures, last_failover_ts)
+    finally:
+        try:
+            publish_state_metrics(get_failover_state(), CURRENT_REGION)
+        except Exception as e:
+            logger.warning(
+                f"Failed to publish state metrics (non-fatal): "
+                f"{type(e).__name__}: {e}"
+            )
 
 
 def _execute_manual_failover() -> dict:
@@ -2119,6 +2139,8 @@ def _execute_manual_failover() -> dict:
         logger.info(msg)
         return {"statusCode": 200, "body": msg}
 
+    increment_counter("FailoversTriggered", CURRENT_REGION,
+                      dimensions={"Trigger": "MANUAL_EXECUTE"})
     _emit_failover_event(
         event_type="FAILOVER_INITIATED",
         source_region=active_region,
@@ -2863,6 +2885,11 @@ def _auto_promote_aurora(target_region: str, scenario: str) -> dict:
     if not target_arn:
         return {"success": False, "method": "none", "error": "Cannot construct target cluster ARN"}
 
+    # Issue #98: now that we've passed config validation, this counts as a real
+    # promotion attempt. Pre-flight failures (no global cluster id, no ARN) are
+    # NOT counted — they're operator misconfigurations, not promotion failures.
+    increment_counter("PromotionsAttempted", CURRENT_REGION, dimensions={"Tier": "Aurora"})
+
     # For app failure, try planned switchover first
     if scenario == "app_failure":
         logger.info(f"Attempting Aurora planned switchover to {target_region}")
@@ -2872,6 +2899,8 @@ def _auto_promote_aurora(target_region: str, scenario: str) -> dict:
                 TargetDbClusterIdentifier=target_arn,
             )
             logger.info(f"Aurora switchover initiated to {target_region}")
+            increment_counter("PromotionsSucceeded", CURRENT_REGION,
+                              dimensions={"Tier": "Aurora", "Method": "switchover"})
             return {"success": True, "method": "switchover", "error": ""}
         except ClientError as e:
             logger.warning(
@@ -2888,10 +2917,14 @@ def _auto_promote_aurora(target_region: str, scenario: str) -> dict:
             AllowDataLoss=True,
         )
         logger.info(f"Aurora failover initiated to {target_region}")
+        increment_counter("PromotionsSucceeded", CURRENT_REGION,
+                          dimensions={"Tier": "Aurora", "Method": "failover"})
         return {"success": True, "method": "failover", "error": ""}
     except ClientError as e:
         error_msg = f"Aurora failover failed: {e}"
         logger.error(error_msg)
+        increment_counter("PromotionsFailed", CURRENT_REGION,
+                          dimensions={"Tier": "Aurora", "Method": "failover"})
         return {"success": False, "method": "failover", "error": error_msg}
 
 
@@ -2973,6 +3006,9 @@ def _auto_promote_elasticache(target_region: str, scenario: str) -> dict:
         return {"success": False, "method": "none",
                 "error": f"Cannot determine ElastiCache replication group ID in {target_region}"}
 
+    # Issue #98: post-config-validation, this is a real promotion attempt.
+    increment_counter("PromotionsAttempted", CURRENT_REGION, dimensions={"Tier": "Redis"})
+
     logger.info(f"Attempting ElastiCache global failover to {target_region} (RG: {target_rg_id})")
     try:
         elasticache_client.failover_global_replication_group(
@@ -2981,10 +3017,14 @@ def _auto_promote_elasticache(target_region: str, scenario: str) -> dict:
             PrimaryReplicationGroupId=target_rg_id,
         )
         logger.info(f"ElastiCache failover initiated to {target_region}")
+        increment_counter("PromotionsSucceeded", CURRENT_REGION,
+                          dimensions={"Tier": "Redis", "Method": "failover"})
         return {"success": True, "method": "failover", "error": ""}
     except ClientError as e:
         error_msg = f"ElastiCache failover failed: {e}"
         logger.error(error_msg)
+        increment_counter("PromotionsFailed", CURRENT_REGION,
+                          dimensions={"Tier": "Redis", "Method": "failover"})
         return {"success": False, "method": "failover", "error": error_msg}
 
 
@@ -3038,6 +3078,7 @@ def _handle_passive_region(state: dict, active_region: str) -> dict:
     # v1.7: write to per-region key instead of merging into shared state.
     # Avoids the F7/F8 RMW race that blocked v1.6 in the bilateral-CRR drill.
     our_health = evaluate_region_health()
+    publish_signal_metrics(our_health, CURRENT_REGION)
     write_own_region_health(our_health["healthy"], signals=our_health.get("signals"))
 
     if latch_engaged:
@@ -3092,6 +3133,8 @@ def _handle_passive_region(state: dict, active_region: str) -> dict:
             )
             return {"statusCode": 200, "body": "Region failure already handled"}
 
+        increment_counter("FailoversTriggered", CURRENT_REGION,
+                          dimensions={"Trigger": "AUTO_PASSIVE"})
         _emit_failover_event(
             event_type="FAILOVER_INITIATED",
             source_region=active_region,
@@ -3346,6 +3389,7 @@ def _handle_passive_region(state: dict, active_region: str) -> dict:
         return {"statusCode": 200, "body": "Passive region, PASSIVE_PUBLISH_ZERO active"}
 
     our_health = evaluate_region_health()
+    publish_signal_metrics(our_health, CURRENT_REGION)
     publish_region_health_metric(CURRENT_REGION, our_health["healthy"])
 
     if not our_health["healthy"]:
@@ -3494,6 +3538,7 @@ def _handle_active_region(state: dict, active_region: str,
     })
 
     health = evaluate_region_health()
+    publish_signal_metrics(health, CURRENT_REGION)
     logger.info(f"Health evaluation: {json.dumps(health, default=str)}")
 
     if health["healthy"]:
@@ -3813,6 +3858,8 @@ def _handle_active_region(state: dict, active_region: str,
         logger.info("Another invocation already claimed the failover, yielding")
         return {"statusCode": 200, "body": "Failover already claimed by another invocation"}
 
+    increment_counter("FailoversTriggered", CURRENT_REGION,
+                      dimensions={"Trigger": "AUTO_ACTIVE"})
     _emit_failover_event(
         event_type="FAILOVER_INITIATED",
         source_region=active_region,

--- a/manual_failback_v2.py
+++ b/manual_failback_v2.py
@@ -53,6 +53,12 @@ from notifications import (
     SEVERITY_WARNING,
     SEVERITY_CRITICAL,
 )
+from observability import (
+    publish_state_metrics,
+    publish_signal_metrics,
+    increment_counter,
+    record_duration_seconds,
+)
 
 # AI modules imported lazily inside functions to support v1.0 mode
 
@@ -700,6 +706,10 @@ def wait_for_aurora_writer(target_region: str, timeout_seconds: int) -> dict:
                         logger.info(
                             f"Aurora writer is now in {target_region} after {elapsed}s"
                         )
+                        record_duration_seconds(
+                            "AuroraPromotionDurationSeconds", elapsed, CURRENT_REGION,
+                            dimensions={"Tier": "Aurora", "Source": "failback"},
+                        )
                         return {"success": True, "elapsed_seconds": elapsed, "error": ""}
         except ClientError as e:
             logger.warning(f"describe_global_clusters during wait: {e}")
@@ -833,6 +843,10 @@ def wait_for_redis_primary(target_region: str, timeout_seconds: int) -> dict:
                         elapsed = int(time.monotonic() - start)
                         logger.info(
                             f"ElastiCache primary is now in {target_region} after {elapsed}s"
+                        )
+                        record_duration_seconds(
+                            "RedisPromotionDurationSeconds", elapsed, CURRENT_REGION,
+                            dimensions={"Tier": "Redis", "Source": "failback"},
                         )
                         return {"success": True, "elapsed_seconds": elapsed, "error": ""}
         except ClientError as e:
@@ -1254,6 +1268,19 @@ def handler(event, context):
         )
         send_notification(subject, body)
         msg_for_return = body  # full body for any caller that logs it
+
+        # Issue #98: emit lifecycle metrics so the dashboard sees the latch
+        # release and the cumulative failback count immediately, without
+        # waiting for the orchestrator's next 60s cycle.
+        increment_counter("FailbacksCompleted", CURRENT_REGION,
+                          dimensions={"Operator": operator})
+        try:
+            publish_state_metrics(get_failover_state(), CURRENT_REGION)
+        except Exception as e:
+            logger.warning(
+                f"Failed to publish state metrics after failback (non-fatal): "
+                f"{type(e).__name__}: {e}"
+            )
 
         logger.info(f"FAILBACK COMPLETE: {active_region} -> {target_region}")
         return {"statusCode": 200, "body": msg_for_return}

--- a/observability.py
+++ b/observability.py
@@ -1,0 +1,172 @@
+"""Observability metrics for the Vigil failover/failback Lambdas.
+
+Provides four helpers used by both ``failover_orchestrator_v3.py`` and
+``manual_failback_v2.py`` to publish CloudWatch metrics:
+
+  * ``publish_state_metrics(state, region)`` — 4 state-machine metrics
+    (LatchEngaged, AuroraPromotionPending, RedisPromotionPending,
+    ConsecutiveFailures), batched into one ``put_metric_data`` call.
+
+  * ``publish_signal_metrics(health, region)`` — per-signal 1/0 metrics
+    (SignalHttp, SignalAlb, SignalEcs, SignalApiGw, SignalAurora,
+    SignalElasticache). Signals with ``skipped: True`` are omitted, so
+    deployments without ElastiCache (or API GW) don't pollute the metric
+    stream with bogus zeroes.
+
+  * ``increment_counter(metric_name, region, dimensions=None)`` —
+    single-datapoint Count metric for lifecycle events (failovers,
+    failbacks, promotion attempts/successes/failures).
+
+  * ``record_duration_seconds(metric_name, seconds, region, dimensions=None)``
+    — single-datapoint Seconds metric for promotion durations.
+
+Every metric carries three dimensions read at call time from os.environ:
+
+  * ``Region``   — caller-supplied (CURRENT_REGION in the orchestrator)
+  * ``AppName``  — APP_NAME env var, defaulting to ``"(unset)"``
+  * ``RoutingMode`` — ROUTING_MODE env var, defaulting to ``"failover"``
+
+Plus any caller-supplied extra dimensions (e.g., ``Tier=Aurora|Redis`` on
+promotion counters).
+
+All four helpers swallow exceptions and log a warning — metrics must never
+crash the handler. Both Lambda zips must include this file (see CLAUDE.md
+deploy commands).
+"""
+
+import logging
+import os
+from typing import Optional
+
+import boto3
+from botocore.config import Config as BotoConfig
+
+logger = logging.getLogger()
+
+_cw_clients: dict = {}
+_client_config = BotoConfig(
+    connect_timeout=5, read_timeout=10, retries={"max_attempts": 1}
+)
+
+# CloudWatch signal name -> dashboard metric name. Source-of-truth signal
+# names live in failover_orchestrator_v3.py's evaluate_*_health functions.
+_SIGNAL_NAME_MAP = {
+    "http_health":        "SignalHttp",
+    "alb_healthy_hosts":  "SignalAlb",
+    "ecs_running_tasks":  "SignalEcs",
+    "api_gw_5xx":         "SignalApiGw",
+    "aurora_status":      "SignalAurora",
+    "elasticache_status": "SignalElasticache",
+}
+
+
+def _get_cw_client(region: str):
+    if region not in _cw_clients:
+        _cw_clients[region] = boto3.client(
+            "cloudwatch", region_name=region, config=_client_config
+        )
+    return _cw_clients[region]
+
+
+def _common_dimensions(region: str, extra: Optional[dict] = None) -> list:
+    dims = [
+        {"Name": "Region",      "Value": region},
+        {"Name": "AppName",     "Value": os.environ.get("APP_NAME") or "(unset)"},
+        {"Name": "RoutingMode", "Value": os.environ.get("ROUTING_MODE", "failover")},
+    ]
+    if extra:
+        for k, v in extra.items():
+            dims.append({"Name": str(k), "Value": str(v)})
+    return dims
+
+
+def _put(region: str, metric_data: list) -> None:
+    if not metric_data:
+        return
+    namespace = os.environ.get("CW_NAMESPACE", "Custom/RegionFailover")
+    try:
+        _get_cw_client(region).put_metric_data(
+            Namespace=namespace, MetricData=metric_data,
+        )
+    except Exception as e:
+        logger.warning(
+            f"observability: put_metric_data failed (non-fatal): "
+            f"{type(e).__name__}: {e}"
+        )
+
+
+def publish_state_metrics(state: dict, region: str) -> None:
+    """Publish the 4 state-machine metrics in one batched put."""
+    if not isinstance(state, dict):
+        return
+    dims = _common_dimensions(region)
+    metric_data = [
+        {"MetricName": "LatchEngaged",
+         "Dimensions": dims,
+         "Value": 1.0 if state.get("latch_engaged") else 0.0,
+         "Unit": "None"},
+        {"MetricName": "AuroraPromotionPending",
+         "Dimensions": dims,
+         "Value": 1.0 if state.get("aurora_promotion_pending") else 0.0,
+         "Unit": "None"},
+        {"MetricName": "RedisPromotionPending",
+         "Dimensions": dims,
+         "Value": 1.0 if state.get("redis_promotion_pending") else 0.0,
+         "Unit": "None"},
+        {"MetricName": "ConsecutiveFailures",
+         "Dimensions": dims,
+         "Value": float(state.get("consecutive_failures") or 0),
+         "Unit": "Count"},
+    ]
+    _put(region, metric_data)
+
+
+def publish_signal_metrics(health: dict, region: str) -> None:
+    """Publish one 1/0 metric per non-skipped health signal.
+
+    Skipped signals (e.g., elasticache_status when Redis isn't configured)
+    are omitted so the metric stream stays clean per deployment shape.
+    """
+    if not isinstance(health, dict):
+        return
+    signals = health.get("signals") or []
+    dims = _common_dimensions(region)
+    metric_data = []
+    for s in signals:
+        if not isinstance(s, dict) or s.get("skipped"):
+            continue
+        metric_name = _SIGNAL_NAME_MAP.get(s.get("signal"))
+        if not metric_name:
+            continue
+        metric_data.append({
+            "MetricName": metric_name,
+            "Dimensions": dims,
+            "Value": 1.0 if s.get("healthy") else 0.0,
+            "Unit": "None",
+        })
+    _put(region, metric_data)
+
+
+def increment_counter(
+    metric_name: str, region: str, dimensions: Optional[dict] = None,
+) -> None:
+    """Publish +1 for a Count metric. Use for lifecycle events."""
+    _put(region, [{
+        "MetricName": metric_name,
+        "Dimensions": _common_dimensions(region, dimensions),
+        "Value": 1.0,
+        "Unit": "Count",
+    }])
+
+
+def record_duration_seconds(
+    metric_name: str, seconds: float, region: str,
+    dimensions: Optional[dict] = None,
+) -> None:
+    """Publish a Seconds-unit datapoint. Use for promotion durations."""
+    _put(region, [{
+        "MetricName": metric_name,
+        "Dimensions": _common_dimensions(region, dimensions),
+        "Value": float(seconds),
+        "Unit": "Seconds",
+    }])

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Unit tests for observability.py — the metric-emission helpers shared by
+the orchestrator and failback Lambdas (issue #98)."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_cw_client_cache():
+    """observability caches CW clients per region. Clear between tests so
+    each test starts fresh and patches don't leak."""
+    import observability
+    observability._cw_clients.clear()
+    yield
+    observability._cw_clients.clear()
+
+
+@pytest.fixture
+def mock_cw():
+    """Patch boto3.client('cloudwatch') and return the MagicMock so the test
+    can assert against put_metric_data calls."""
+    with patch("observability.boto3.client") as mock_factory:
+        client = MagicMock()
+        mock_factory.return_value = client
+        yield client
+
+
+def _put_calls(mock_cw):
+    """All MetricData lists passed to put_metric_data, flattened."""
+    return [c.kwargs.get("MetricData") or c[1].get("MetricData")
+            for c in mock_cw.put_metric_data.call_args_list]
+
+
+def _all_dims(metric):
+    """Return {dim_name: dim_value} for one metric datapoint."""
+    return {d["Name"]: d["Value"] for d in metric["Dimensions"]}
+
+
+# ---------------------------------------------------------------------------
+# publish_state_metrics
+# ---------------------------------------------------------------------------
+
+class TestPublishStateMetrics:
+    def test_emits_4_metrics_in_one_batched_put(self, mock_cw):
+        import observability
+        state = {
+            "latch_engaged": True,
+            "aurora_promotion_pending": False,
+            "redis_promotion_pending": True,
+            "consecutive_failures": 2,
+        }
+        observability.publish_state_metrics(state, "us-east-1")
+        assert mock_cw.put_metric_data.call_count == 1
+        metric_data = _put_calls(mock_cw)[0]
+        assert {m["MetricName"] for m in metric_data} == {
+            "LatchEngaged", "AuroraPromotionPending",
+            "RedisPromotionPending", "ConsecutiveFailures",
+        }
+
+    def test_values_match_state_fields(self, mock_cw):
+        import observability
+        observability.publish_state_metrics({
+            "latch_engaged": True,
+            "aurora_promotion_pending": True,
+            "redis_promotion_pending": False,
+            "consecutive_failures": 5,
+        }, "us-east-1")
+        by_name = {m["MetricName"]: m for m in _put_calls(mock_cw)[0]}
+        assert by_name["LatchEngaged"]["Value"] == 1.0
+        assert by_name["AuroraPromotionPending"]["Value"] == 1.0
+        assert by_name["RedisPromotionPending"]["Value"] == 0.0
+        assert by_name["ConsecutiveFailures"]["Value"] == 5.0
+        assert by_name["LatchEngaged"]["Unit"] == "None"
+        assert by_name["ConsecutiveFailures"]["Unit"] == "Count"
+
+    def test_attaches_three_dimensions_with_env_values(self, mock_cw):
+        import observability
+        with patch.dict(os.environ, {
+            "APP_NAME": "fo-v16-drill",
+            "ROUTING_MODE": "active-active",
+        }):
+            observability.publish_state_metrics({}, "us-west-2")
+        dims = _all_dims(_put_calls(mock_cw)[0][0])
+        assert dims == {
+            "Region": "us-west-2",
+            "AppName": "fo-v16-drill",
+            "RoutingMode": "active-active",
+        }
+
+    def test_app_name_defaults_when_env_unset(self, mock_cw):
+        import observability
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("APP_NAME", None)
+            observability.publish_state_metrics({}, "us-east-1")
+        dims = _all_dims(_put_calls(mock_cw)[0][0])
+        assert dims["AppName"] == "(unset)"
+
+    def test_routing_mode_defaults_to_failover(self, mock_cw):
+        import observability
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ROUTING_MODE", None)
+            observability.publish_state_metrics({}, "us-east-1")
+        dims = _all_dims(_put_calls(mock_cw)[0][0])
+        assert dims["RoutingMode"] == "failover"
+
+    def test_swallows_cw_exception(self, mock_cw, caplog):
+        import observability
+        mock_cw.put_metric_data.side_effect = RuntimeError("CW down")
+        # Must not raise.
+        observability.publish_state_metrics({"latch_engaged": False}, "us-east-1")
+        assert "put_metric_data failed" in caplog.text
+
+    def test_handles_non_dict_state_silently(self, mock_cw):
+        import observability
+        observability.publish_state_metrics(None, "us-east-1")
+        observability.publish_state_metrics("not a dict", "us-east-1")
+        assert mock_cw.put_metric_data.call_count == 0
+
+    def test_handles_missing_state_keys_as_falsy(self, mock_cw):
+        import observability
+        observability.publish_state_metrics({}, "us-east-1")
+        by_name = {m["MetricName"]: m for m in _put_calls(mock_cw)[0]}
+        assert by_name["LatchEngaged"]["Value"] == 0.0
+        assert by_name["AuroraPromotionPending"]["Value"] == 0.0
+        assert by_name["RedisPromotionPending"]["Value"] == 0.0
+        assert by_name["ConsecutiveFailures"]["Value"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# publish_signal_metrics
+# ---------------------------------------------------------------------------
+
+class TestPublishSignalMetrics:
+    def test_emits_one_metric_per_non_skipped_signal(self, mock_cw):
+        import observability
+        health = {
+            "healthy": False,
+            "signals": [
+                {"signal": "http_health",       "healthy": False},
+                {"signal": "alb_healthy_hosts", "healthy": True},
+                {"signal": "ecs_running_tasks", "healthy": True},
+                {"signal": "aurora_status",     "healthy": True},
+            ],
+        }
+        observability.publish_signal_metrics(health, "us-east-1")
+        assert mock_cw.put_metric_data.call_count == 1
+        metric_data = _put_calls(mock_cw)[0]
+        assert {m["MetricName"] for m in metric_data} == {
+            "SignalHttp", "SignalAlb", "SignalEcs", "SignalAurora",
+        }
+        by_name = {m["MetricName"]: m for m in metric_data}
+        assert by_name["SignalHttp"]["Value"] == 0.0
+        assert by_name["SignalAlb"]["Value"] == 1.0
+
+    def test_skipped_signals_are_omitted(self, mock_cw):
+        import observability
+        health = {
+            "signals": [
+                {"signal": "http_health",        "healthy": True},
+                {"signal": "elasticache_status", "skipped": True,
+                 "reason": "Not configured"},
+                {"signal": "api_gw_5xx",         "skipped": True,
+                 "reason": "Not configured"},
+            ],
+        }
+        observability.publish_signal_metrics(health, "us-east-1")
+        metric_data = _put_calls(mock_cw)[0]
+        names = {m["MetricName"] for m in metric_data}
+        assert "SignalElasticache" not in names
+        assert "SignalApiGw" not in names
+        assert "SignalHttp" in names
+
+    def test_no_publish_when_only_skipped_signals(self, mock_cw):
+        import observability
+        health = {
+            "signals": [
+                {"signal": "elasticache_status", "skipped": True},
+                {"signal": "api_gw_5xx",         "skipped": True},
+            ],
+        }
+        observability.publish_signal_metrics(health, "us-east-1")
+        # Empty MetricData → no put call.
+        assert mock_cw.put_metric_data.call_count == 0
+
+    def test_unknown_signal_name_is_ignored(self, mock_cw):
+        import observability
+        health = {
+            "signals": [
+                {"signal": "http_health",   "healthy": True},
+                {"signal": "invented_thing", "healthy": False},
+            ],
+        }
+        observability.publish_signal_metrics(health, "us-east-1")
+        metric_data = _put_calls(mock_cw)[0]
+        names = {m["MetricName"] for m in metric_data}
+        assert names == {"SignalHttp"}
+
+    def test_handles_missing_signals_list(self, mock_cw):
+        import observability
+        observability.publish_signal_metrics({}, "us-east-1")
+        observability.publish_signal_metrics({"signals": None}, "us-east-1")
+        observability.publish_signal_metrics(None, "us-east-1")
+        assert mock_cw.put_metric_data.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# increment_counter
+# ---------------------------------------------------------------------------
+
+class TestIncrementCounter:
+    def test_publishes_count_value_1(self, mock_cw):
+        import observability
+        observability.increment_counter("FailoversTriggered", "us-east-1")
+        metric_data = _put_calls(mock_cw)[0]
+        assert len(metric_data) == 1
+        assert metric_data[0]["MetricName"] == "FailoversTriggered"
+        assert metric_data[0]["Value"] == 1.0
+        assert metric_data[0]["Unit"] == "Count"
+
+    def test_extra_dimensions_appear_in_addition_to_common(self, mock_cw):
+        import observability
+        with patch.dict(os.environ, {"APP_NAME": "x", "ROUTING_MODE": "failover"}):
+            observability.increment_counter(
+                "PromotionsSucceeded", "us-east-1", dimensions={"Tier": "Aurora"},
+            )
+        dims = _all_dims(_put_calls(mock_cw)[0][0])
+        assert dims == {
+            "Region": "us-east-1",
+            "AppName": "x",
+            "RoutingMode": "failover",
+            "Tier": "Aurora",
+        }
+
+    def test_swallows_exception(self, mock_cw):
+        import observability
+        mock_cw.put_metric_data.side_effect = RuntimeError("nope")
+        observability.increment_counter("anything", "us-east-1")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# record_duration_seconds
+# ---------------------------------------------------------------------------
+
+class TestRecordDurationSeconds:
+    def test_publishes_seconds_unit(self, mock_cw):
+        import observability
+        observability.record_duration_seconds(
+            "AuroraPromotionDurationSeconds", 47.5, "us-east-1",
+            dimensions={"Tier": "Aurora"},
+        )
+        metric_data = _put_calls(mock_cw)[0]
+        assert metric_data[0]["MetricName"] == "AuroraPromotionDurationSeconds"
+        assert metric_data[0]["Value"] == 47.5
+        assert metric_data[0]["Unit"] == "Seconds"
+        dims = _all_dims(metric_data[0])
+        assert dims["Tier"] == "Aurora"
+        assert dims["Region"] == "us-east-1"
+
+
+# ---------------------------------------------------------------------------
+# Namespace
+# ---------------------------------------------------------------------------
+
+class TestNamespace:
+    def test_uses_cw_namespace_env_var(self, mock_cw):
+        import observability
+        with patch.dict(os.environ, {"CW_NAMESPACE": "Custom/MyApp"}):
+            observability.publish_state_metrics({"latch_engaged": False}, "us-east-1")
+        call = mock_cw.put_metric_data.call_args
+        assert (call.kwargs.get("Namespace") or call[1].get("Namespace")) == "Custom/MyApp"
+
+    def test_default_namespace_when_unset(self, mock_cw):
+        import observability
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CW_NAMESPACE", None)
+            observability.publish_state_metrics({"latch_engaged": False}, "us-east-1")
+        call = mock_cw.put_metric_data.call_args
+        assert (call.kwargs.get("Namespace") or call[1].get("Namespace")) == "Custom/RegionFailover"


### PR DESCRIPTION
## Summary

PR-A of two for the dashboards work. The orchestrator currently publishes one CloudWatch metric (\`RegionActiveStatus\`); the state machine, per-signal evaluations, lifecycle events, and promotion timings live only in S3/DynamoDB and Lambda logs. This PR adds 16 new metrics so PR-B's dashboards can graph them.

## What changed

**New \`observability.py\`** — 4 helpers used by both Lambdas: \`publish_state_metrics\`, \`publish_signal_metrics\`, \`increment_counter\`, \`record_duration_seconds\`. All auto-attach \`Region + AppName + RoutingMode\` dimensions and swallow CW exceptions.

**Orchestrator wiring** (\`failover_orchestrator_v3.py\`):
- \`handler()\` try/finally publishes 4 state metrics every cycle (skipped on preflight)
- \`publish_signal_metrics\` after each \`evaluate_region_health()\` call (4 sites)
- \`FailoversTriggered\` counter at all 3 \`try_claim_failover\` success paths
- \`_auto_promote_aurora\` / \`_auto_promote_elasticache\`: Attempted/Succeeded/Failed counters with \`Tier\` + \`Method\` dimensions

**Failback wiring** (\`manual_failback_v2.py\`):
- \`wait_for_aurora_writer\` / \`wait_for_redis_primary\` record duration on success
- Success path increments \`FailbacksCompleted\` and publishes state metrics so the dashboard sees the latch release immediately

**Metric inventory (16 new):**

| Category | Metrics |
|----------|---------|
| State (always-on) | LatchEngaged, AuroraPromotionPending, RedisPromotionPending, ConsecutiveFailures |
| Per-signal (always-on, skipped when not configured) | SignalHttp, SignalAlb, SignalEcs, SignalApiGw, SignalAurora, SignalElasticache |
| Lifecycle (event-driven) | FailoversTriggered, FailbacksCompleted, PromotionsAttempted, PromotionsSucceeded, PromotionsFailed |
| Durations (event-driven) | AuroraPromotionDurationSeconds, RedisPromotionDurationSeconds |

## Test plan

- [x] \`python3 -m pytest tests/ -v\` → 473 passed, 30 skipped (was 454 baseline + 19 new in test_observability.py).
- [x] Unit tests cover: batching, dimension auto-attachment, exception swallowing, default AppName=(unset), skip-when-not-configured for signals, namespace handling.
- [ ] Deploy to fo-fo-v16-drill-orchestrator and fo-fo-v16-drill-failback (us-east-1, tbed). Wait one minute.
- [ ] \`aws cloudwatch list-metrics --namespace <CW_NAMESPACE>\` shows the new metric names. Per-signal entries reflect the actual config (no SignalElasticache for fo-v16-drill since Redis isn't wired into the env).
- [ ] Pick LatchEngaged, confirm dimensions include AppName + RoutingMode + Region.
- [ ] \`aws ecs update-service --desired-count 1\` on fo-v16-drill: within 3 minutes SignalEcs flips 1.0→0.0 while others stay 1.0; ConsecutiveFailures climbs 0→1→2→3.
- [ ] CLAUDE.md zip command updated; deploy zip includes observability.py.

## Follow-up

PR-B (separate) — scenario-aware dashboard generator that consumes these metrics. Won't be useful until this PR is merged + deployed.

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)