### PR TITLE
feat(#100): scenario-aware dashboard generator + drift validator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,9 @@ Runtime dependencies: `boto3`, `botocore` (provided by Lambda runtime). Portal a
 | `portal/lock.py` | DynamoDB-based test locking (prevents concurrent tests). |
 | `tools/publish_version.py` | Publish Lambda version and create/update alias. Used by CI/CD and manually. |
 | `tools/setup_s3_state_backend.py` | Infrastructure setup script for S3 CRR backend. |
-| `tools/generate_dashboard.py` | CloudWatch dashboard generator. |
+| `tools/generate_dashboard.py` | Scenario-aware CloudWatch dashboard generator. Reads per-app YAML; conditionally renders Aurora / ElastiCache / API GW rows; consumes the issue #98 metrics for state-machine, lifecycle, and duration panels. (issue #100) |
+| `tools/dashboard_config.example.yaml` | Per-app YAML schema for `generate_dashboard.py` — scenario flags + resource IDs. |
+| `tools/validate_dashboard.py` | Drift check: diffs deployed dashboard JSON against generator output. Exit 1 on drift. (issue #100) |
 | `.github/workflows/test.yml` | GitHub Actions: run pytest on every PR to main. |
 | `.github/workflows/deploy.yml` | GitHub Actions: publish Lambda version on tag push. |
 | `tests/test_orchestrator.py` | Regression tests for core orchestrator logic (52 tests). |
@@ -149,6 +151,7 @@ Runtime dependencies: `boto3`, `botocore` (provided by Lambda runtime). Portal a
 | `tests/test_aurora_advisor.py` | Unit tests for Aurora promotion advisor, all phases (32 tests). |
 | `tests/test_elasticache.py` | Unit tests for ElastiCache Global Datastore failover support (25 tests). |
 | `tests/test_sns_notifications_failover.py` | SNS notification validation (v1.4.3) across all config variants: S3/DDB, ElastiCache on/off, API GW on/off, active/passive + active/active, AI disabled (50 tests). |
+| `tests/test_generate_dashboard.py` | Scenario snapshot tests for `tools/generate_dashboard.py` (31 tests, issue #100). |
 | `cfn/network.yaml` | CloudFormation: VPC, subnets, NAT Gateway. |
 | `cfn/app.yaml` | CloudFormation: ECS, ALB, security groups, VPC endpoints. |
 | `cfn/aurora.yaml` | CloudFormation: Aurora Global Database cluster. |

--- a/tests/test_generate_dashboard.py
+++ b/tests/test_generate_dashboard.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Tests for tools/generate_dashboard.py — verifies the scenario-aware
+generator emits the right widget set for each deployment shape (issue #100)."""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add tools/ to path so we can import generate_dashboard.
+_TOOLS = Path(__file__).resolve().parent.parent / "tools"
+sys.path.insert(0, str(_TOOLS))
+
+import generate_dashboard as gd  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Config fixtures
+# ---------------------------------------------------------------------------
+
+def _base_cfg(**overrides) -> dict:
+    """Build a complete config with all required fields populated.
+
+    Tests override scenario flags + any flag-conditional resource fields
+    needed for the variant under test.
+    """
+    cfg = {
+        "dashboard_name":        "test-dashboard",
+        "account_id":            "123456789012",
+        "app_name":              "test-app",
+        "orchestrator_function": "test-orchestrator",
+        "failback_function":     "test-failback",
+        "primary_region":        "us-east-1",
+        "secondary_region":      "us-east-2",
+        "cw_namespace":          "Custom/TestApp",
+        "cw_metric":             "RegionActiveStatus",
+        "ecs_cluster":           "test-cluster",
+        "ecs_service":           "test-svc",
+        "primary_alb_suffix":    "app/test-alb/abc",
+        "secondary_alb_suffix":  "app/test-alb/def",
+        "primary_tg_suffix":     "targetgroup/test-tg/abc",
+        "secondary_tg_suffix":   "targetgroup/test-tg/def",
+        "primary_alarm_name":    "test-region-inactive-us-east-1",
+        "secondary_alarm_name":  "test-region-inactive-us-east-2",
+        "primary_r53_hc_id":     "uuid-1",
+        "secondary_r53_hc_id":   "uuid-2",
+        # Scenario defaults
+        "routing_mode":   "failover",
+        "aurora_present": False,
+        "aurora_auto":    False,
+        "redis_present":  False,
+        "redis_auto":     False,
+        "api_gw_present": False,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def _aurora_cfg(**overrides):
+    cfg = _base_cfg(
+        aurora_present=True,
+        primary_aurora_cluster="test-aurora-w1",
+        secondary_aurora_cluster="test-aurora-w2",
+    )
+    cfg.update(overrides)
+    return cfg
+
+
+def _aurora_redis_cfg(**overrides):
+    cfg = _aurora_cfg(
+        redis_present=True,
+        primary_redis_rg="test-redis-w1",
+        secondary_redis_rg="test-redis-w2",
+    )
+    cfg.update(overrides)
+    return cfg
+
+
+def _full_cfg(**overrides):
+    cfg = _aurora_redis_cfg(
+        api_gw_present=True,
+        api_gw_name="test-api",
+    )
+    cfg.update(overrides)
+    return cfg
+
+
+def _widget_titles(dashboard) -> list:
+    out = []
+    for w in dashboard["widgets"]:
+        props = w.get("properties", {})
+        if "title" in props:
+            out.append(props["title"])
+        elif "markdown" in props:
+            # Title row uses markdown — extract the first heading line.
+            first = props["markdown"].split("\n")[0]
+            out.append(first)
+    return out
+
+
+def _all_metric_names(dashboard) -> set:
+    """Collect every MetricName referenced across all metric widgets."""
+    names = set()
+    for w in dashboard["widgets"]:
+        if w.get("type") != "metric":
+            continue
+        for spec in w["properties"].get("metrics", []):
+            if isinstance(spec, list) and len(spec) >= 2:
+                names.add(spec[1])
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+class TestConfigValidation:
+    def test_aurora_present_requires_aurora_resource_fields(self, tmp_path):
+        cfg = _base_cfg(aurora_present=True)
+        # Don't add aurora cluster fields → must fail at load.
+        cfg_path = tmp_path / "c.yaml"
+        cfg_path.write_text(_yaml_dump(cfg))
+        with pytest.raises(SystemExit):
+            gd.load_config(str(cfg_path))
+
+    def test_redis_present_requires_redis_resource_fields(self, tmp_path):
+        cfg = _aurora_cfg(redis_present=True)
+        # Don't add redis RG fields → must fail.
+        cfg_path = tmp_path / "c.yaml"
+        cfg_path.write_text(_yaml_dump(cfg))
+        with pytest.raises(SystemExit):
+            gd.load_config(str(cfg_path))
+
+    def test_api_gw_present_requires_api_gw_name(self, tmp_path):
+        cfg = _aurora_cfg(api_gw_present=True)
+        cfg_path = tmp_path / "c.yaml"
+        cfg_path.write_text(_yaml_dump(cfg))
+        with pytest.raises(SystemExit):
+            gd.load_config(str(cfg_path))
+
+    def test_routing_mode_must_be_valid(self, tmp_path):
+        cfg = _aurora_cfg(routing_mode="bogus")
+        cfg_path = tmp_path / "c.yaml"
+        cfg_path.write_text(_yaml_dump(cfg))
+        with pytest.raises(SystemExit):
+            gd.load_config(str(cfg_path))
+
+    def test_replace_placeholder_caught(self, tmp_path):
+        cfg = _aurora_cfg(primary_aurora_cluster="REPLACE-CLUSTER-NAME")
+        cfg_path = tmp_path / "c.yaml"
+        cfg_path.write_text(_yaml_dump(cfg))
+        with pytest.raises(SystemExit):
+            gd.load_config(str(cfg_path))
+
+    def test_scenario_defaults_applied_when_absent(self, tmp_path):
+        """Legacy YAML (no scenario flags) loads cleanly with the back-compat
+        defaults: routing=failover, aurora_present=True. The resource fields
+        for Aurora MUST be present in such a YAML — that was already required
+        in the pre-#100 schema, and the default-True for aurora_present is
+        designed to keep that legacy YAML working unchanged."""
+        cfg = _aurora_cfg()  # has Aurora cluster fields
+        for k in ["routing_mode", "aurora_present", "aurora_auto",
+                  "redis_present", "redis_auto", "api_gw_present"]:
+            cfg.pop(k, None)
+        cfg_path = tmp_path / "c.yaml"
+        cfg_path.write_text(_yaml_dump(cfg))
+        loaded = gd.load_config(str(cfg_path))
+        assert loaded["routing_mode"] == "failover"
+        assert loaded["aurora_present"] is True  # legacy default
+        assert loaded["redis_present"] is False
+        assert loaded["api_gw_present"] is False
+
+
+def _yaml_dump(cfg: dict) -> str:
+    """Lightweight YAML emitter — avoids requiring pyyaml when only writing
+    test configs. Quotes every string so booleans/ints stay distinct."""
+    lines = []
+    for k, v in cfg.items():
+        if isinstance(v, bool):
+            lines.append(f"{k}: {str(v).lower()}")
+        elif isinstance(v, (int, float)):
+            lines.append(f"{k}: {v}")
+        else:
+            lines.append(f'{k}: "{v}"')
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Scenario snapshot tests — what shows up for each deployment shape
+# ---------------------------------------------------------------------------
+
+class TestAppOnlyStack:
+    """No Aurora, no Redis, no API GW. App-only / stateless service."""
+
+    def test_no_aurora_widget(self):
+        d = gd.build_dashboard(_base_cfg())
+        titles = _widget_titles(d)
+        assert not any("Aurora" in t for t in titles), titles
+
+    def test_no_elasticache_widget(self):
+        d = gd.build_dashboard(_base_cfg())
+        titles = _widget_titles(d)
+        assert not any("ElastiCache" in t for t in titles)
+
+    def test_no_api_gw_widget(self):
+        d = gd.build_dashboard(_base_cfg())
+        titles = _widget_titles(d)
+        assert not any("API Gateway" in t for t in titles)
+
+    def test_per_signal_panel_excludes_data_tier_signals(self):
+        d = gd.build_dashboard(_base_cfg())
+        names = _all_metric_names(d)
+        assert "SignalAurora" not in names
+        assert "SignalElasticache" not in names
+        assert "SignalApiGw" not in names
+        # Always-on signals still present.
+        assert "SignalHttp" in names
+        assert "SignalAlb" in names
+        assert "SignalEcs" in names
+
+    def test_promotion_durations_row_omitted_when_no_tier(self):
+        d = gd.build_dashboard(_base_cfg())
+        titles = _widget_titles(d)
+        assert not any("Promotion durations" in t for t in titles)
+
+    def test_lifecycle_counters_row_present_with_failover_only(self):
+        d = gd.build_dashboard(_base_cfg())
+        titles = _widget_titles(d)
+        assert any("Lifecycle counters" in t for t in titles)
+        # No promotion counters because no data tier.
+        names = _all_metric_names(d)
+        assert "FailoversTriggered" in names
+        assert "FailbacksCompleted" in names
+        assert "PromotionsAttempted" not in names
+
+    def test_scenario_tag_in_title_says_aurora_absent(self):
+        d = gd.build_dashboard(_base_cfg())
+        title_md = d["widgets"][0]["properties"]["markdown"]
+        assert "Aurora-absent" in title_md
+        assert "Redis-absent" in title_md
+        assert "APIgw-absent" in title_md
+
+
+class TestAuroraOnlyManual:
+    """Aurora present + manual promote, no Redis."""
+
+    def test_aurora_widget_present(self):
+        d = gd.build_dashboard(_aurora_cfg())
+        titles = _widget_titles(d)
+        assert any("Aurora" in t for t in titles)
+
+    def test_no_elasticache_widget(self):
+        d = gd.build_dashboard(_aurora_cfg())
+        titles = _widget_titles(d)
+        assert not any("ElastiCache" in t for t in titles)
+
+    def test_per_signal_includes_aurora_excludes_redis(self):
+        d = gd.build_dashboard(_aurora_cfg())
+        names = _all_metric_names(d)
+        assert "SignalAurora" in names
+        assert "SignalElasticache" not in names
+
+    def test_promotion_durations_row_renders_aurora_only(self):
+        d = gd.build_dashboard(_aurora_cfg())
+        names = _all_metric_names(d)
+        assert "AuroraPromotionDurationSeconds" in names
+        assert "RedisPromotionDurationSeconds" not in names
+
+    def test_promotion_counters_split_by_tier_aurora_only(self):
+        d = gd.build_dashboard(_aurora_cfg())
+        # Aurora promotion counters present; Redis counters absent.
+        # Find the lifecycle widget that has Tier=Aurora dim.
+        promo_dims_seen = []
+        for w in d["widgets"]:
+            for spec in w.get("properties", {}).get("metrics", []):
+                if isinstance(spec, list) and "Tier" in spec:
+                    tier_idx = spec.index("Tier")
+                    promo_dims_seen.append(spec[tier_idx + 1])
+        assert "Aurora" in promo_dims_seen
+        assert "Redis" not in promo_dims_seen
+
+    def test_scenario_tag_aurora_manual(self):
+        d = gd.build_dashboard(_aurora_cfg())
+        title_md = d["widgets"][0]["properties"]["markdown"]
+        assert "Aurora-manual" in title_md
+
+
+class TestAuroraAutoRedisManual:
+    """Aurora auto-promote, Redis present + manual."""
+
+    def test_both_data_tier_widgets_present(self):
+        d = gd.build_dashboard(_aurora_redis_cfg(aurora_auto=True))
+        titles = _widget_titles(d)
+        assert any("Aurora" in t for t in titles)
+        assert any("ElastiCache" in t for t in titles)
+
+    def test_per_signal_includes_both_data_tiers(self):
+        d = gd.build_dashboard(_aurora_redis_cfg(aurora_auto=True))
+        names = _all_metric_names(d)
+        assert "SignalAurora" in names
+        assert "SignalElasticache" in names
+
+    def test_promotion_duration_metrics_for_both_tiers(self):
+        d = gd.build_dashboard(_aurora_redis_cfg(aurora_auto=True))
+        names = _all_metric_names(d)
+        assert "AuroraPromotionDurationSeconds" in names
+        assert "RedisPromotionDurationSeconds" in names
+
+    def test_scenario_tag(self):
+        d = gd.build_dashboard(_aurora_redis_cfg(aurora_auto=True))
+        title_md = d["widgets"][0]["properties"]["markdown"]
+        assert "Aurora-auto" in title_md
+        assert "Redis-manual" in title_md
+
+
+class TestActiveActiveVariant:
+    """ROUTING_MODE=active-active changes the RegionActiveStatus framing."""
+
+    def test_routing_mode_in_scenario_tag(self):
+        d = gd.build_dashboard(_aurora_redis_cfg(routing_mode="active-active",
+                                                  aurora_auto=True, redis_auto=True))
+        title_md = d["widgets"][0]["properties"]["markdown"]
+        assert "active-active" in title_md
+
+    def test_metric_dimensions_carry_active_active_routing_mode(self):
+        d = gd.build_dashboard(_aurora_redis_cfg(routing_mode="active-active",
+                                                  aurora_auto=True, redis_auto=True))
+        # Pick the LatchEngaged metric and confirm RoutingMode dim.
+        found = False
+        for w in d["widgets"]:
+            for spec in w.get("properties", {}).get("metrics", []):
+                if (isinstance(spec, list) and len(spec) >= 2
+                        and spec[1] == "LatchEngaged"):
+                    assert "RoutingMode" in spec
+                    rm_idx = spec.index("RoutingMode")
+                    assert spec[rm_idx + 1] == "active-active"
+                    found = True
+        assert found, "LatchEngaged metric not found in dashboard"
+
+
+class TestFullStack:
+    """All scenario flags true — superset for assertion variety."""
+
+    def test_all_data_tier_rows_present(self):
+        d = gd.build_dashboard(_full_cfg(aurora_auto=True, redis_auto=True))
+        titles = _widget_titles(d)
+        assert any("Aurora" in t for t in titles)
+        assert any("ElastiCache" in t for t in titles)
+        assert any("API Gateway" in t for t in titles)
+
+    def test_all_per_signal_metrics_present(self):
+        d = gd.build_dashboard(_full_cfg(aurora_auto=True, redis_auto=True))
+        names = _all_metric_names(d)
+        for sig in ["SignalHttp", "SignalAlb", "SignalEcs",
+                    "SignalApiGw", "SignalAurora", "SignalElasticache"]:
+            assert sig in names, f"Missing {sig}"
+
+    def test_app_name_appears_in_metric_dims(self):
+        d = gd.build_dashboard(_full_cfg(app_name="my-app",
+                                          aurora_auto=True, redis_auto=True))
+        any_app_dim = False
+        for w in d["widgets"]:
+            for spec in w.get("properties", {}).get("metrics", []):
+                if isinstance(spec, list) and "AppName" in spec:
+                    idx = spec.index("AppName")
+                    if spec[idx + 1] == "my-app":
+                        any_app_dim = True
+        assert any_app_dim, "AppName=my-app dimension never appears in any metric"
+
+    def test_dashboard_widgets_render_as_valid_json(self):
+        d = gd.build_dashboard(_full_cfg(aurora_auto=True, redis_auto=True))
+        # If json.dumps fails the dashboard couldn't actually be deployed.
+        json.dumps(d)
+
+
+class TestThresholdAnnotation:
+    def test_consecutive_failures_threshold_default_3(self):
+        d = gd.build_dashboard(_aurora_cfg())
+        # Find the consecutive failures widget — its annotation marks 3.
+        found = False
+        for w in d["widgets"]:
+            title = w.get("properties", {}).get("title", "")
+            if "Consecutive failures" in title:
+                anns = w["properties"].get("annotations", {}).get("horizontal", [])
+                assert any(a["value"] == 3 for a in anns)
+                found = True
+        assert found, "Consecutive failures widget not generated"
+
+    def test_consecutive_failures_threshold_overrideable(self):
+        d = gd.build_dashboard(_aurora_cfg(consecutive_failures_threshold=5))
+        for w in d["widgets"]:
+            title = w.get("properties", {}).get("title", "")
+            if "Consecutive failures" in title:
+                anns = w["properties"].get("annotations", {}).get("horizontal", [])
+                assert any(a["value"] == 5 for a in anns)
+                return
+        pytest.fail("Consecutive failures widget not generated")

--- a/tools/dashboard_config.example.yaml
+++ b/tools/dashboard_config.example.yaml
@@ -1,53 +1,90 @@
 # ============================================================
-# Failover Dashboard Config
-# Copy this file, fill in every value, then run:
-#   python3 generate_dashboard.py --config your-app.yaml --deploy
+# Vigil Failover Dashboard Config (issue #100)
+# ============================================================
+# Copy this file per app, fill every value, then run:
+#   python3 tools/generate_dashboard.py --config <your-app>.yaml --deploy
+#
+# Conditional fields (Aurora / ElastiCache / API GW resources) are only
+# required when the matching scenario flag is true. The generator validates
+# this at load time — placeholders containing "REPLACE" trip the check.
 # ============================================================
 
-# Dashboard name created in CloudWatch
-dashboard_name: "my-app-failover"
+# --- Identity --------------------------------------------------------------
+dashboard_name:        "my-app-failover"        # CloudWatch dashboard name
+account_id:            "123456789012"           # 12-digit AWS account
+app_name:              "my-app"                 # filters Vigil metrics by AppName
 
-# AWS account ID (12 digits)
-account_id: "123456789012"
+# --- Lambdas (deployed in both regions, same name in each) ----------------
+orchestrator_function: "my-app-orchestrator"
+failback_function:     "my-app-failback"
 
-# App / orchestrator identity
-app_name: "my-app"                      # human-readable label used in widget titles
-orchestrator_function: "my-app-orchestrator"  # Lambda function name (same in both regions)
+# --- Regions ---------------------------------------------------------------
+primary_region:        "us-east-1"
+secondary_region:      "us-east-2"
 
-# Regions
-primary_region: "us-east-1"
-secondary_region: "us-east-2"
+# --- Vigil custom metric (published by observability.py) -------------------
+cw_namespace:          "Custom/MyApp"           # Lambda env: CW_NAMESPACE
+cw_metric:             "RegionActiveStatus"     # Lambda env: CW_METRIC_NAME
 
-# CloudWatch custom metric (published by the orchestrator Lambda)
-cw_namespace: "Custom/MyApp"            # Lambda env var: CW_NAMESPACE
-cw_metric: "RegionActiveStatus"         # Lambda env var: CW_METRIC_NAME
+# --- Scenario flags --------------------------------------------------------
+# These drive conditional widget rendering and the title's scenario tag.
+# Defaults shown match the legacy active/passive Aurora-only behavior of the
+# pre-#100 generator. Override per-app to match the actual deployment shape.
+routing_mode:          "failover"               # "failover" or "active-active"
+aurora_present:        true                     # Aurora cluster wired into the orchestrator
+aurora_auto:           false                    # AURORA_AUTO_PROMOTE=true
+redis_present:         false                    # ElastiCache Global Datastore wired in
+redis_auto:            false                    # ELASTICACHE_AUTO_PROMOTE=true
+api_gw_present:        false                    # API Gateway is in the data path
 
-# ECS (same cluster and service name expected in both regions)
-ecs_cluster: "my-app-cluster"           # Lambda env var: ECS_CLUSTER_NAME
-ecs_service: "my-app-svc"               # Lambda env var: ECS_SERVICE_NAME
+# --- ECS (same cluster + service name in both regions) ---------------------
+ecs_cluster:           "my-app-cluster"         # Lambda env: ECS_CLUSTER_NAME
+ecs_service:           "my-app-svc"             # Lambda env: ECS_SERVICE_NAME
 
-# Internal ALB ARN suffixes  (the part after "arn:aws:elasticloadbalancing:<region>:<account>:loadbalancer/")
+# --- Internal ALB ARN suffixes --------------------------------------------
+# Suffix = the part after `arn:aws:elasticloadbalancing:<region>:<account>:loadbalancer/`
 # Example: app/my-app-int-alb/1a2b3c4d5e6f7890
-# Find with: aws elbv2 describe-load-balancers --region <region> --query 'LoadBalancers[?contains(LoadBalancerName,`my-app`)].LoadBalancerArn'
-primary_alb_suffix: "app/my-app-int-alb/REPLACE"
-secondary_alb_suffix: "app/my-app-int-alb/REPLACE"
+# Find with:
+#   aws elbv2 describe-load-balancers --region <region> \
+#     --query 'LoadBalancers[?contains(LoadBalancerName,`my-app`)].LoadBalancerArn'
+primary_alb_suffix:    "app/my-app-int-alb/REPLACE"
+secondary_alb_suffix:  "app/my-app-int-alb/REPLACE"
 
-# Target group ARN suffixes  (the part after "arn:aws:elasticloadbalancing:<region>:<account>:loadbalancer/")
-# Example: targetgroup/my-app-fargate-tg/1a2b3c4d5e6f7890
-# Find with: aws elbv2 describe-target-groups --region <region> --query 'TargetGroups[?contains(TargetGroupName,`my-app`)].TargetGroupArn'
-primary_tg_suffix: "targetgroup/my-app-fargate-tg/REPLACE"
-secondary_tg_suffix: "targetgroup/my-app-fargate-tg/REPLACE"
+# --- Target group ARN suffixes --------------------------------------------
+# Same suffix convention as ALB. Example: targetgroup/my-app-fargate-tg/1a2b...
+# Find with:
+#   aws elbv2 describe-target-groups --region <region> \
+#     --query 'TargetGroups[?contains(TargetGroupName,`my-app`)].TargetGroupArn'
+primary_tg_suffix:     "targetgroup/my-app-fargate-tg/REPLACE"
+secondary_tg_suffix:   "targetgroup/my-app-fargate-tg/REPLACE"
 
-# Aurora cluster identifiers  (Lambda env var: AURORA_CLUSTER_ID in each region)
-primary_aurora_cluster: "my-app-aurora-primary"
-secondary_aurora_cluster: "my-app-aurora-secondary"
+# --- Aurora (only required when aurora_present: true) ---------------------
+primary_aurora_cluster:   "my-app-aurora-w1"   # Lambda env: AURORA_CLUSTER_ID
+secondary_aurora_cluster: "my-app-aurora-w2"
 
-# CloudWatch alarm names for the orchestrator  (pattern: {app-name}-region-inactive-{region})
-# These back the Route 53 health checks. Created by the orchestrator CFN/setup.
-primary_alarm_name: "my-app-region-inactive-us-east-1"
-secondary_alarm_name: "my-app-region-inactive-us-east-2"
+# --- ElastiCache (only required when redis_present: true) -----------------
+# Local-region replication group IDs. Lambda env: ELASTICACHE_REPLICATION_GROUP_ID.
+primary_redis_rg:      "my-app-redis-w1"
+secondary_redis_rg:    "my-app-redis-w2"
 
-# Route 53 health check IDs  (UUIDs, not ARNs)
-# Find with: aws route53 list-health-checks --query 'HealthChecks[*].{Id:Id,Alarm:HealthCheckConfig.AlarmIdentifier.Name}'
-primary_r53_hc_id: "REPLACE-UUID-HERE"
-secondary_r53_hc_id: "REPLACE-UUID-HERE"
+# --- API Gateway (only required when api_gw_present: true) ----------------
+# The API GW name (not ID). Used for the AWS/ApiGateway 5xx + latency widget.
+api_gw_name:           "my-app-api"
+
+# --- CloudWatch alarm names backing R53 health checks ---------------------
+# Pattern: {app-name}-region-inactive-{region}. Created by the orchestrator
+# CFN/setup. R53 health checks reference these alarms by name.
+primary_alarm_name:    "my-app-region-inactive-us-east-1"
+secondary_alarm_name:  "my-app-region-inactive-us-east-2"
+
+# --- Route 53 health check IDs (UUIDs, not ARNs) --------------------------
+# Find with:
+#   aws route53 list-health-checks \
+#     --query 'HealthChecks[*].{Id:Id,Alarm:HealthCheckConfig.AlarmIdentifier.Name}'
+primary_r53_hc_id:     "REPLACE-UUID-HERE"
+secondary_r53_hc_id:   "REPLACE-UUID-HERE"
+
+# --- Optional ---------------------------------------------------------------
+# Threshold annotation on the ConsecutiveFailures widget (issue #98 metric).
+# Defaults to 3, matching the orchestrator's default CONSECUTIVE_FAILURES_THRESHOLD.
+# consecutive_failures_threshold: 3

--- a/tools/generate_dashboard.py
+++ b/tools/generate_dashboard.py
@@ -1,21 +1,31 @@
 #!/usr/bin/env python3
-"""
-generate_dashboard.py — CloudWatch failover dashboard generator
+"""generate_dashboard.py — scenario-aware CloudWatch failover dashboard generator.
+
+Reads a per-app YAML config and emits a CloudWatch dashboard tailored to the
+app's deployment shape. Conditionally includes Aurora / ElastiCache / API GW
+widget rows so the dashboard for an app-only stack doesn't show empty Aurora
+graphs, and the dashboard for a no-Redis stack doesn't have a barren Redis row.
+
+Consumes the metrics published by ``observability.py`` (issue #98):
+
+  * Always-on:    LatchEngaged, AuroraPromotionPending, RedisPromotionPending,
+                  ConsecutiveFailures, Signal* (per signal)
+  * Event-driven: FailoversTriggered, FailbacksCompleted, Promotions*,
+                  *PromotionDurationSeconds
+
+Every metric carries ``Region`` + ``AppName`` + ``RoutingMode`` dimensions so a
+multi-app dashboard could filter or group across them. This generator pins
+``AppName=app_name`` and ``RoutingMode=routing_mode`` from the YAML so each app's
+dashboard shows only that app's data.
 
 Usage:
-    # Generate JSON and print to stdout
-    python3 generate_dashboard.py --config my-app.yaml
-
-    # Write JSON to a file
-    python3 generate_dashboard.py --config my-app.yaml --output my-app-dashboard.json
-
-    # Deploy directly to CloudWatch
-    python3 generate_dashboard.py --config my-app.yaml --deploy
-
-    # Deploy to a specific region (default: primary_region from config)
+    python3 generate_dashboard.py --config my-app.yaml             # print JSON
+    python3 generate_dashboard.py --config my-app.yaml --output o.json
+    python3 generate_dashboard.py --config my-app.yaml --deploy   # put_dashboard
     python3 generate_dashboard.py --config my-app.yaml --deploy --deploy-region us-east-1
+    python3 generate_dashboard.py --config my-app.yaml --deploy --profile tbed
 
-See dashboard_config.example.yaml for the config file format and field descriptions.
+See ``dashboard_config.example.yaml`` for the full schema.
 """
 
 import argparse
@@ -32,11 +42,13 @@ except ImportError:
 # Config loading + validation
 # ---------------------------------------------------------------------------
 
+# Always required (every deployment shape needs these).
 REQUIRED_FIELDS = [
     "dashboard_name",
     "account_id",
     "app_name",
     "orchestrator_function",
+    "failback_function",
     "primary_region",
     "secondary_region",
     "cw_namespace",
@@ -47,27 +59,63 @@ REQUIRED_FIELDS = [
     "secondary_alb_suffix",
     "primary_tg_suffix",
     "secondary_tg_suffix",
-    "primary_aurora_cluster",
-    "secondary_aurora_cluster",
     "primary_alarm_name",
     "secondary_alarm_name",
     "primary_r53_hc_id",
     "secondary_r53_hc_id",
 ]
 
+# Required only when the matching scenario flag is true.
+CONDITIONAL_FIELDS = {
+    "aurora_present":  ["primary_aurora_cluster", "secondary_aurora_cluster"],
+    "redis_present":   ["primary_redis_rg", "secondary_redis_rg"],
+    "api_gw_present":  ["api_gw_name"],
+}
+
+# Defaults applied when the flag is absent (back-compat with the pre-#100 schema
+# which didn't have scenario flags). Default to active/passive, Aurora-only —
+# matches the original example YAML's implicit shape.
+SCENARIO_DEFAULTS = {
+    "routing_mode":    "failover",
+    "aurora_present":  True,
+    "aurora_auto":     False,
+    "redis_present":   False,
+    "redis_auto":      False,
+    "api_gw_present":  False,
+}
+
 
 def load_config(path: str) -> dict:
     with open(path) as f:
-        cfg = yaml.safe_load(f)
+        cfg = yaml.safe_load(f) or {}
+
+    for k, v in SCENARIO_DEFAULTS.items():
+        cfg.setdefault(k, v)
 
     errors = []
     for field in REQUIRED_FIELDS:
         val = cfg.get(field, "")
         if not val or "REPLACE" in str(val):
-            errors.append(f"  - '{field}' is missing or still set to the placeholder value")
+            errors.append(f"  - '{field}' is missing or still the placeholder value")
+
+    for flag, fields in CONDITIONAL_FIELDS.items():
+        if cfg.get(flag):
+            for field in fields:
+                val = cfg.get(field, "")
+                if not val or "REPLACE" in str(val):
+                    errors.append(
+                        f"  - '{field}' is required because '{flag}' is true, "
+                        f"but it's missing/placeholder"
+                    )
+
+    if cfg.get("routing_mode") not in ("failover", "active-active"):
+        errors.append(
+            f"  - 'routing_mode' must be 'failover' or 'active-active', "
+            f"got {cfg.get('routing_mode')!r}"
+        )
 
     if errors:
-        print(f"[error] Config file '{path}' has unfilled values:")
+        print(f"[error] Config file '{path}' has problems:")
         for e in errors:
             print(e)
         sys.exit(1)
@@ -76,180 +124,7 @@ def load_config(path: str) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Dashboard builder
-# ---------------------------------------------------------------------------
-
-def build_dashboard(c: dict) -> dict:
-    p   = c["primary_region"]
-    s   = c["secondary_region"]
-    app = c["app_name"]
-    ns  = c["cw_namespace"]
-    acct = c["account_id"]
-
-    primary_alarm_arn   = f"arn:aws:cloudwatch:{p}:{acct}:alarm:{c['primary_alarm_name']}"
-    secondary_alarm_arn = f"arn:aws:cloudwatch:{s}:{acct}:alarm:{c['secondary_alarm_name']}"
-
-    widgets = []
-    y = 0
-
-    # ── Title ────────────────────────────────────────────────────────────────
-    widgets.append(_text(
-        f"# {app} — Failover Dashboard\n"
-        f"Regions: **{p} (PRIMARY)** | **{s} (SECONDARY)**",
-        x=0, y=y, w=24, h=1,
-    ))
-    y += 1
-
-    # ── Alarm status ─────────────────────────────────────────────────────────
-    widgets.append(_alarm(
-        f"🔴 Orchestrator Alarm — {p} (PRIMARY)",
-        [primary_alarm_arn], x=0, y=y, w=12, h=2,
-    ))
-    widgets.append(_alarm(
-        f"🔵 Orchestrator Alarm — {s} (SECONDARY)",
-        [secondary_alarm_arn], x=12, y=y, w=12, h=2,
-    ))
-    y += 2
-
-    # ── RegionActiveStatus ───────────────────────────────────────────────────
-    widgets.append(_metric(
-        f"RegionActiveStatus — {p} (1=healthy, 0=failed)",
-        region=p,
-        metrics=[[ns, c["cw_metric"], "Region", p,
-                  {"color": "#2ca02c", "label": f"{p} Active"}]],
-        x=0, y=y, w=12, h=4,
-        yaxis={"left": {"min": -0.1, "max": 1.5}},
-        annotations={"horizontal": [
-            {"value": 1, "color": "#2ca02c", "label": "Healthy"},
-            {"value": 0, "color": "#d62728", "label": "Failed"},
-        ]},
-    ))
-    widgets.append(_metric(
-        f"RegionActiveStatus — {s} (1=healthy, 0=failed)",
-        region=s,
-        metrics=[[ns, c["cw_metric"], "Region", s,
-                  {"color": "#1f77b4", "label": f"{s} Active"}]],
-        x=12, y=y, w=12, h=4,
-        yaxis={"left": {"min": -0.1, "max": 1.5}},
-        annotations={"horizontal": [
-            {"value": 1, "color": "#2ca02c", "label": "Healthy"},
-            {"value": 0, "color": "#d62728", "label": "Failed"},
-        ]},
-    ))
-    y += 4
-
-    # ── ECS + ALB (primary row, then secondary row) ──────────────────────────
-    for region, color, alb, tg in [
-        (p, "#2ca02c", c["primary_alb_suffix"],   c["primary_tg_suffix"]),
-        (s, "#1f77b4", c["secondary_alb_suffix"],  c["secondary_tg_suffix"]),
-    ]:
-        widgets.append(_metric(
-            f"ECS Running Tasks — {region}",
-            region=region,
-            metrics=[
-                ["ECS/ContainerInsights", "RunningTaskCount",
-                 "ServiceName", c["ecs_service"], "ClusterName", c["ecs_cluster"],
-                 {"color": color, "label": "Running"}],
-                ["ECS/ContainerInsights", "DesiredTaskCount",
-                 "ServiceName", c["ecs_service"], "ClusterName", c["ecs_cluster"],
-                 {"color": "#aec7e8", "label": "Desired"}],
-            ],
-            x=0, y=y, w=8, h=4,
-            yaxis={"left": {"min": 0}},
-        ))
-        widgets.append(_metric(
-            f"ALB Healthy Hosts — {region}",
-            region=region,
-            metrics=[
-                ["AWS/ApplicationELB", "HealthyHostCount",
-                 "TargetGroup", tg, "LoadBalancer", alb,
-                 {"color": color, "label": "Healthy Hosts"}],
-                ["AWS/ApplicationELB", "UnHealthyHostCount",
-                 "TargetGroup", tg, "LoadBalancer", alb,
-                 {"color": "#d62728", "label": "Unhealthy Hosts"}],
-            ],
-            x=8, y=y, w=8, h=4,
-            yaxis={"left": {"min": 0}},
-        ))
-        widgets.append(_metric(
-            f"ALB Request Count & 5xx — {region}",
-            region=region,
-            metrics=[
-                ["AWS/ApplicationELB", "RequestCount", "LoadBalancer", alb,
-                 {"color": color, "label": "Requests", "stat": "Sum"}],
-                ["AWS/ApplicationELB", "HTTPCode_Target_5XX_Count", "LoadBalancer", alb,
-                 {"color": "#d62728", "label": "5xx Errors", "stat": "Sum"}],
-            ],
-            x=16, y=y, w=8, h=4,
-            yaxis={"left": {"min": 0}},
-            stat="Sum",
-        ))
-        y += 4
-
-    # ── Aurora ───────────────────────────────────────────────────────────────
-    for region, color, cluster, xpos in [
-        (p, "#2ca02c", c["primary_aurora_cluster"],   0),
-        (s, "#1f77b4", c["secondary_aurora_cluster"], 12),
-    ]:
-        widgets.append(_metric(
-            f"Aurora DB Connections — {region} ({cluster})",
-            region=region,
-            metrics=[
-                ["AWS/RDS", "DatabaseConnections", "DBClusterIdentifier", cluster,
-                 {"color": color, "label": "Connections"}],
-                ["AWS/RDS", "CommitLatency", "DBClusterIdentifier", cluster,
-                 {"color": "#ff7f0e", "label": "Commit Latency (ms)", "yAxis": "right"}],
-            ],
-            x=xpos, y=y, w=12, h=4,
-            yaxis={"left": {"min": 0}, "right": {"min": 0}},
-        ))
-    y += 4
-
-    # ── Orchestrator Lambda ───────────────────────────────────────────────────
-    fn = c["orchestrator_function"]
-    for region, color, xpos in [(p, "#2ca02c", 0), (s, "#1f77b4", 12)]:
-        widgets.append(_metric(
-            f"Orchestrator Lambda — {region}",
-            region=region,
-            metrics=[
-                ["AWS/Lambda", "Invocations", "FunctionName", fn,
-                 {"color": color, "label": "Invocations", "stat": "Sum"}],
-                ["AWS/Lambda", "Errors", "FunctionName", fn,
-                 {"color": "#d62728", "label": "Errors", "stat": "Sum"}],
-                ["AWS/Lambda", "Duration", "FunctionName", fn,
-                 {"color": "#ff7f0e", "label": "Duration (ms)", "yAxis": "right"}],
-            ],
-            x=xpos, y=y, w=12, h=4,
-            yaxis={"left": {"min": 0}, "right": {"min": 0}},
-            stat="Sum",
-        ))
-    y += 4
-
-    # ── Route 53 health checks ────────────────────────────────────────────────
-    for region, color, hc_id, xpos in [
-        (p, "#2ca02c", c["primary_r53_hc_id"],   0),
-        (s, "#1f77b4", c["secondary_r53_hc_id"], 12),
-    ]:
-        widgets.append(_metric(
-            f"Route 53 Health Check — {region} (1=healthy)",
-            region="us-east-1",   # Route 53 metrics always live in us-east-1
-            metrics=[
-                ["AWS/Route53", "HealthCheckStatus", "HealthCheckId", hc_id,
-                 {"color": color, "label": "HC Status (1=healthy)"}],
-                ["AWS/Route53", "HealthCheckPercentageHealthy", "HealthCheckId", hc_id,
-                 {"color": "#aec7e8", "label": "% Healthy Checkers", "yAxis": "right"}],
-            ],
-            x=xpos, y=y, w=12, h=4,
-            stat="Minimum",
-            yaxis={"left": {"min": 0, "max": 1.2}, "right": {"min": 0, "max": 110}},
-        ))
-    y += 4
-
-    return {"widgets": widgets}
-
-
-# ---------------------------------------------------------------------------
-# Widget helpers
+# Widget primitives
 # ---------------------------------------------------------------------------
 
 def _text(markdown, x, y, w, h):
@@ -263,11 +138,12 @@ def _alarm(title, alarm_arns, x, y, w, h):
 
 
 def _metric(title, region, metrics, x, y, w, h,
-            period=60, stat="Average", yaxis=None, annotations=None):
+            period=60, stat="Average", yaxis=None, annotations=None,
+            view="timeSeries", stacked=False):
     props = {
         "title": title,
-        "view": "timeSeries",
-        "stacked": False,
+        "view": view,
+        "stacked": stacked,
         "region": region,
         "metrics": metrics,
         "period": period,
@@ -282,29 +158,493 @@ def _metric(title, region, metrics, x, y, w, h,
 
 
 # ---------------------------------------------------------------------------
+# Metric specs that consume observability.py output
+# ---------------------------------------------------------------------------
+
+def _vigil_metric(c: dict, name: str, region: str, color: str = None,
+                  label: str = None, extra_dims: dict = None,
+                  stat: str = None) -> list:
+    """Build a metric spec for an observability.py-published metric.
+
+    Auto-attaches the Region+AppName+RoutingMode key the helpers always emit,
+    plus any ``extra_dims`` (e.g., ``Tier=Aurora``). Use this anywhere we want
+    to graph one of the issue #98 metrics.
+    """
+    spec = [
+        c["cw_namespace"], name,
+        "Region",      region,
+        "AppName",     c["app_name"],
+        "RoutingMode", c["routing_mode"],
+    ]
+    if extra_dims:
+        for k, v in extra_dims.items():
+            spec += [str(k), str(v)]
+    opts = {}
+    if color:
+        opts["color"] = color
+    if label:
+        opts["label"] = label
+    if stat:
+        opts["stat"] = stat
+    if opts:
+        spec.append(opts)
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# Row builders
+# ---------------------------------------------------------------------------
+
+def _scenario_tag(c: dict) -> str:
+    aurora = "auto" if c["aurora_auto"] else ("manual" if c["aurora_present"] else "absent")
+    redis = "auto" if c["redis_auto"] else ("manual" if c["redis_present"] else "absent")
+    apigw = "present" if c["api_gw_present"] else "absent"
+    return (
+        f"[Scenario: {c['routing_mode']} · Aurora-{aurora} · "
+        f"Redis-{redis} · APIgw-{apigw}]"
+    )
+
+
+def _row_title(c, y):
+    p, s, app = c["primary_region"], c["secondary_region"], c["app_name"]
+    return [_text(
+        f"# {app} — Failover Dashboard\n"
+        f"Regions: **{p} (PRIMARY)** | **{s} (SECONDARY)**\n\n"
+        f"{_scenario_tag(c)}",
+        x=0, y=y, w=24, h=2,
+    )], 2
+
+
+def _row_alarms(c, y):
+    p, s, acct = c["primary_region"], c["secondary_region"], c["account_id"]
+    p_arn = f"arn:aws:cloudwatch:{p}:{acct}:alarm:{c['primary_alarm_name']}"
+    s_arn = f"arn:aws:cloudwatch:{s}:{acct}:alarm:{c['secondary_alarm_name']}"
+    return [
+        _alarm(f"Orchestrator Alarm — {p} (PRIMARY)",   [p_arn], x=0,  y=y, w=12, h=2),
+        _alarm(f"Orchestrator Alarm — {s} (SECONDARY)", [s_arn], x=12, y=y, w=12, h=2),
+    ], 2
+
+
+def _row_region_active_status(c, y):
+    p, s, ns, metric = c["primary_region"], c["secondary_region"], c["cw_namespace"], c["cw_metric"]
+    yaxis = {"left": {"min": -0.1, "max": 1.5}}
+    threshold_label = (
+        "Healthy" if c["routing_mode"] == "active-active"
+        else "Active region"
+    )
+    annotations = {"horizontal": [
+        {"value": 1, "color": "#2ca02c", "label": threshold_label},
+        {"value": 0, "color": "#d62728", "label": "Failed"},
+    ]}
+    return [
+        _metric(
+            f"RegionActiveStatus — {p}",
+            region=p,
+            metrics=[[ns, metric, "Region", p,
+                      {"color": "#2ca02c", "label": f"{p}"}]],
+            x=0, y=y, w=12, h=4, yaxis=yaxis, annotations=annotations,
+        ),
+        _metric(
+            f"RegionActiveStatus — {s}",
+            region=s,
+            metrics=[[ns, metric, "Region", s,
+                      {"color": "#1f77b4", "label": f"{s}"}]],
+            x=12, y=y, w=12, h=4, yaxis=yaxis, annotations=annotations,
+        ),
+    ], 4
+
+
+def _row_per_signal(c, y):
+    """Per-signal 1/0 metric panel. One sparkline per configured signal.
+
+    Always includes HTTP, ALB, ECS. Conditionally adds API GW, Aurora,
+    ElastiCache. Drawn for the primary region only — the per-signal data is
+    the most operationally meaningful for the active region (passive region
+    publishes its own signals via the same metric stream so a multi-region
+    view can be built later if needed).
+    """
+    p = c["primary_region"]
+    signals = [("SignalHttp", "HTTP",       "#2ca02c"),
+               ("SignalAlb",  "ALB hosts",  "#1f77b4"),
+               ("SignalEcs",  "ECS tasks",  "#ff7f0e")]
+    if c["api_gw_present"]:
+        signals.append(("SignalApiGw", "API GW", "#9467bd"))
+    if c["aurora_present"]:
+        signals.append(("SignalAurora", "Aurora", "#8c564b"))
+    if c["redis_present"]:
+        signals.append(("SignalElasticache", "Redis", "#e377c2"))
+
+    metrics = [
+        _vigil_metric(c, name, p, color=color, label=label)
+        for name, label, color in signals
+    ]
+    return [_metric(
+        f"Per-signal health — {p} (1=OK, 0=FAIL)",
+        region=p,
+        metrics=metrics,
+        x=0, y=y, w=24, h=4,
+        yaxis={"left": {"min": -0.1, "max": 1.5}},
+        annotations={"horizontal": [{"value": 1, "color": "#2ca02c", "label": "OK"}]},
+    )], 4
+
+
+def _row_ecs_alb(c, y):
+    """ECS RunningTasks + ALB HealthyHosts + 5xx — one row per region."""
+    widgets = []
+    for region, color, alb, tg in [
+        (c["primary_region"],   "#2ca02c", c["primary_alb_suffix"],   c["primary_tg_suffix"]),
+        (c["secondary_region"], "#1f77b4", c["secondary_alb_suffix"], c["secondary_tg_suffix"]),
+    ]:
+        widgets += [
+            _metric(
+                f"ECS Running Tasks — {region}",
+                region=region,
+                metrics=[
+                    ["ECS/ContainerInsights", "RunningTaskCount",
+                     "ServiceName", c["ecs_service"], "ClusterName", c["ecs_cluster"],
+                     {"color": color, "label": "Running"}],
+                    ["ECS/ContainerInsights", "DesiredTaskCount",
+                     "ServiceName", c["ecs_service"], "ClusterName", c["ecs_cluster"],
+                     {"color": "#aec7e8", "label": "Desired"}],
+                ],
+                x=0, y=y, w=8, h=4, yaxis={"left": {"min": 0}},
+            ),
+            _metric(
+                f"ALB Healthy Hosts — {region}",
+                region=region,
+                metrics=[
+                    ["AWS/ApplicationELB", "HealthyHostCount",
+                     "TargetGroup", tg, "LoadBalancer", alb,
+                     {"color": color, "label": "Healthy"}],
+                    ["AWS/ApplicationELB", "UnHealthyHostCount",
+                     "TargetGroup", tg, "LoadBalancer", alb,
+                     {"color": "#d62728", "label": "Unhealthy"}],
+                ],
+                x=8, y=y, w=8, h=4, yaxis={"left": {"min": 0}},
+            ),
+            _metric(
+                f"ALB Requests / 5xx — {region}",
+                region=region,
+                metrics=[
+                    ["AWS/ApplicationELB", "RequestCount", "LoadBalancer", alb,
+                     {"color": color, "label": "Requests", "stat": "Sum"}],
+                    ["AWS/ApplicationELB", "HTTPCode_Target_5XX_Count", "LoadBalancer", alb,
+                     {"color": "#d62728", "label": "5xx", "stat": "Sum"}],
+                ],
+                x=16, y=y, w=8, h=4, yaxis={"left": {"min": 0}}, stat="Sum",
+            ),
+        ]
+        y += 4
+    return widgets, 8  # 4 per region × 2 regions
+
+
+def _row_aurora(c, y):
+    widgets = []
+    for region, color, cluster, xpos in [
+        (c["primary_region"],   "#2ca02c", c["primary_aurora_cluster"],   0),
+        (c["secondary_region"], "#1f77b4", c["secondary_aurora_cluster"], 12),
+    ]:
+        widgets.append(_metric(
+            f"Aurora — {region} ({cluster})",
+            region=region,
+            metrics=[
+                ["AWS/RDS", "DatabaseConnections", "DBClusterIdentifier", cluster,
+                 {"color": color, "label": "Connections"}],
+                ["AWS/RDS", "CommitLatency", "DBClusterIdentifier", cluster,
+                 {"color": "#ff7f0e", "label": "Commit ms", "yAxis": "right"}],
+                ["AWS/RDS", "AuroraGlobalDBReplicationLag", "DBClusterIdentifier", cluster,
+                 {"color": "#9467bd", "label": "Repl lag ms", "yAxis": "right"}],
+            ],
+            x=xpos, y=y, w=12, h=4,
+            yaxis={"left": {"min": 0}, "right": {"min": 0}},
+        ))
+    return widgets, 4
+
+
+def _row_elasticache(c, y):
+    widgets = []
+    for region, color, rg, xpos in [
+        (c["primary_region"],   "#2ca02c", c["primary_redis_rg"],   0),
+        (c["secondary_region"], "#1f77b4", c["secondary_redis_rg"], 12),
+    ]:
+        widgets.append(_metric(
+            f"ElastiCache — {region} ({rg})",
+            region=region,
+            metrics=[
+                ["AWS/ElastiCache", "GlobalDatastoreReplicationLag", "ReplicationGroupId", rg,
+                 {"color": color, "label": "Repl lag ms"}],
+                ["AWS/ElastiCache", "EngineCPUUtilization", "ReplicationGroupId", rg,
+                 {"color": "#ff7f0e", "label": "Engine CPU %", "yAxis": "right"}],
+                ["AWS/ElastiCache", "DatabaseMemoryUsagePercentage", "ReplicationGroupId", rg,
+                 {"color": "#9467bd", "label": "Memory %", "yAxis": "right"}],
+            ],
+            x=xpos, y=y, w=12, h=4,
+            yaxis={"left": {"min": 0}, "right": {"min": 0, "max": 100}},
+        ))
+    return widgets, 4
+
+
+def _row_api_gw(c, y):
+    apigw = c["api_gw_name"]
+    widgets = []
+    for region, color, xpos in [
+        (c["primary_region"],   "#2ca02c", 0),
+        (c["secondary_region"], "#1f77b4", 12),
+    ]:
+        widgets.append(_metric(
+            f"API Gateway — {region} ({apigw})",
+            region=region,
+            metrics=[
+                ["AWS/ApiGateway", "Count",  "ApiName", apigw,
+                 {"color": color, "label": "Total requests", "stat": "Sum"}],
+                ["AWS/ApiGateway", "5XXError", "ApiName", apigw,
+                 {"color": "#d62728", "label": "5xx", "stat": "Sum"}],
+                ["AWS/ApiGateway", "Latency", "ApiName", apigw,
+                 {"color": "#ff7f0e", "label": "Latency ms", "yAxis": "right"}],
+            ],
+            x=xpos, y=y, w=12, h=4, stat="Sum",
+        ))
+    return widgets, 4
+
+
+def _row_lambda(c, y):
+    widgets = []
+    for fn_field, fn_label in [("orchestrator_function", "orchestrator"),
+                                ("failback_function",     "failback")]:
+        for region, color, xpos in [
+            (c["primary_region"],   "#2ca02c", 0 if fn_field == "orchestrator_function" else 12),
+            (c["secondary_region"], "#1f77b4", 0 if fn_field == "orchestrator_function" else 12),
+        ]:
+            pass  # placeholder — handled below
+    # Cleaner: 4 widgets across 2 regions × 2 functions, but to keep visual
+    # parity with the other rows we render orchestrator left, failback right
+    # within each region row.
+    widgets = []
+    for fn_field, fn_label, xpos in [
+        ("orchestrator_function", "orchestrator", 0),
+        ("failback_function",     "failback",     12),
+    ]:
+        fn = c[fn_field]
+        # Combine both regions on one widget per function so the chart density
+        # stays manageable (was per-region in v1; that's 4 widgets vs the
+        # dashboard's 24-col width).
+        widgets.append(_metric(
+            f"Lambda {fn_label} ({fn}) — both regions",
+            region=c["primary_region"],
+            metrics=[
+                ["AWS/Lambda", "Invocations", "FunctionName", fn,
+                 {"color": "#2ca02c", "label": f"{c['primary_region']} invocations",
+                  "stat": "Sum", "region": c["primary_region"]}],
+                ["AWS/Lambda", "Invocations", "FunctionName", fn,
+                 {"color": "#1f77b4", "label": f"{c['secondary_region']} invocations",
+                  "stat": "Sum", "region": c["secondary_region"]}],
+                ["AWS/Lambda", "Errors", "FunctionName", fn,
+                 {"color": "#d62728", "label": "Errors (both)", "stat": "Sum"}],
+                ["AWS/Lambda", "Duration", "FunctionName", fn,
+                 {"color": "#ff7f0e", "label": "Duration ms", "yAxis": "right"}],
+            ],
+            x=xpos, y=y, w=12, h=4, stat="Sum",
+        ))
+    return widgets, 4
+
+
+def _row_route53(c, y):
+    widgets = []
+    for region, color, hc_id, xpos in [
+        (c["primary_region"],   "#2ca02c", c["primary_r53_hc_id"],   0),
+        (c["secondary_region"], "#1f77b4", c["secondary_r53_hc_id"], 12),
+    ]:
+        widgets.append(_metric(
+            f"Route 53 Health Check — {region} (1=healthy)",
+            # Route 53 metrics always live in us-east-1.
+            region="us-east-1",
+            metrics=[
+                ["AWS/Route53", "HealthCheckStatus", "HealthCheckId", hc_id,
+                 {"color": color, "label": "Status"}],
+                ["AWS/Route53", "HealthCheckPercentageHealthy", "HealthCheckId", hc_id,
+                 {"color": "#aec7e8", "label": "% checkers", "yAxis": "right"}],
+            ],
+            x=xpos, y=y, w=12, h=4, stat="Minimum",
+            yaxis={"left": {"min": 0, "max": 1.2}, "right": {"min": 0, "max": 110}},
+        ))
+    return widgets, 4
+
+
+def _row_state_machine(c, y):
+    """State machine widgets consuming the issue #98 metrics."""
+    p = c["primary_region"]
+    threshold = c.get("consecutive_failures_threshold", 3)
+    widgets = [
+        _metric(
+            "Latch + promotion pending — primary",
+            region=p,
+            metrics=[
+                _vigil_metric(c, "LatchEngaged",          p, color="#d62728", label="Latch"),
+                _vigil_metric(c, "AuroraPromotionPending", p, color="#ff7f0e", label="Aurora pending"),
+                _vigil_metric(c, "RedisPromotionPending",  p, color="#9467bd", label="Redis pending"),
+            ],
+            x=0, y=y, w=12, h=4,
+            yaxis={"left": {"min": -0.1, "max": 1.5}},
+            annotations={"horizontal": [
+                {"value": 1, "color": "#d62728", "label": "ENGAGED / pending"},
+            ]},
+        ),
+        _metric(
+            f"Consecutive failures — primary (threshold={threshold})",
+            region=p,
+            metrics=[
+                _vigil_metric(c, "ConsecutiveFailures", p, color="#ff7f0e", label="Failures"),
+            ],
+            x=12, y=y, w=12, h=4,
+            yaxis={"left": {"min": 0}},
+            annotations={"horizontal": [
+                {"value": threshold, "color": "#d62728", "label": f"Failover threshold ({threshold})"},
+            ]},
+        ),
+    ]
+    return widgets, 4
+
+
+def _row_lifecycle_counters(c, y):
+    """Cumulative event counters consuming the issue #98 metrics."""
+    p = c["primary_region"]
+    failover_metrics = [
+        _vigil_metric(c, "FailoversTriggered",  p, color="#d62728",
+                       label="Failovers", stat="Sum"),
+        _vigil_metric(c, "FailbacksCompleted",  p, color="#2ca02c",
+                       label="Failbacks", stat="Sum"),
+    ]
+    promotion_metrics = []
+    if c["aurora_present"]:
+        promotion_metrics += [
+            _vigil_metric(c, "PromotionsAttempted", p, color="#1f77b4",
+                           label="Aurora attempted",
+                           extra_dims={"Tier": "Aurora"}, stat="Sum"),
+            _vigil_metric(c, "PromotionsSucceeded", p, color="#2ca02c",
+                           label="Aurora succeeded",
+                           extra_dims={"Tier": "Aurora"}, stat="Sum"),
+            _vigil_metric(c, "PromotionsFailed",    p, color="#d62728",
+                           label="Aurora failed",
+                           extra_dims={"Tier": "Aurora"}, stat="Sum"),
+        ]
+    if c["redis_present"]:
+        promotion_metrics += [
+            _vigil_metric(c, "PromotionsAttempted", p, color="#aec7e8",
+                           label="Redis attempted",
+                           extra_dims={"Tier": "Redis"}, stat="Sum"),
+            _vigil_metric(c, "PromotionsSucceeded", p, color="#98df8a",
+                           label="Redis succeeded",
+                           extra_dims={"Tier": "Redis"}, stat="Sum"),
+            _vigil_metric(c, "PromotionsFailed",    p, color="#ff9896",
+                           label="Redis failed",
+                           extra_dims={"Tier": "Redis"}, stat="Sum"),
+        ]
+    widgets = [
+        _metric(
+            "Lifecycle counters — failover/failback (Sum over period)",
+            region=p, metrics=failover_metrics,
+            x=0, y=y, w=12, h=4, stat="Sum",
+        ),
+    ]
+    if promotion_metrics:
+        widgets.append(_metric(
+            "Promotion counters — attempted / succeeded / failed (Sum)",
+            region=p, metrics=promotion_metrics,
+            x=12, y=y, w=12, h=4, stat="Sum",
+        ))
+    else:
+        widgets.append(_text(
+            "No data tier configured (app-only stack) — promotion counters omitted.",
+            x=12, y=y, w=12, h=4,
+        ))
+    return widgets, 4
+
+
+def _row_promotion_durations(c, y):
+    """AuroraPromotionDurationSeconds + RedisPromotionDurationSeconds.
+
+    Only rendered when at least one tier is present. Returns (widgets, height).
+    """
+    if not (c["aurora_present"] or c["redis_present"]):
+        return [], 0
+    p = c["primary_region"]
+    metrics = []
+    if c["aurora_present"]:
+        metrics.append(_vigil_metric(
+            c, "AuroraPromotionDurationSeconds", p,
+            color="#1f77b4", label="Aurora",
+            extra_dims={"Tier": "Aurora"},
+        ))
+    if c["redis_present"]:
+        metrics.append(_vigil_metric(
+            c, "RedisPromotionDurationSeconds", p,
+            color="#9467bd", label="Redis",
+            extra_dims={"Tier": "Redis"},
+        ))
+    return [_metric(
+        "Promotion durations — Aurora / Redis (seconds)",
+        region=p, metrics=metrics,
+        x=0, y=y, w=24, h=4,
+        yaxis={"left": {"min": 0}}, stat="Maximum",
+    )], 4
+
+
+# ---------------------------------------------------------------------------
+# Dashboard assembly
+# ---------------------------------------------------------------------------
+
+def build_dashboard(c: dict) -> dict:
+    """Compose the full dashboard from conditional rows."""
+    widgets: list = []
+    y = 0
+
+    builders = [
+        _row_title,
+        _row_alarms,
+        _row_region_active_status,
+        _row_per_signal,
+        _row_ecs_alb,
+    ]
+    if c["aurora_present"]:
+        builders.append(_row_aurora)
+    if c["redis_present"]:
+        builders.append(_row_elasticache)
+    if c["api_gw_present"]:
+        builders.append(_row_api_gw)
+    builders += [
+        _row_lambda,
+        _row_route53,
+        _row_state_machine,
+        _row_lifecycle_counters,
+        _row_promotion_durations,
+    ]
+
+    for build in builders:
+        row_widgets, h = build(c, y)
+        widgets.extend(row_widgets)
+        y += h
+
+    return {"widgets": widgets}
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Generate a CloudWatch failover dashboard from a YAML config file."
+        description="Generate a scenario-aware CloudWatch failover dashboard from YAML.",
     )
-    parser.add_argument(
-        "--config", required=True, metavar="FILE",
-        help="Path to the YAML config file (copy dashboard_config.example.yaml to start).",
-    )
-    parser.add_argument(
-        "--output", metavar="FILE",
-        help="Write dashboard JSON to this file (default: print to stdout).",
-    )
-    parser.add_argument(
-        "--deploy", action="store_true",
-        help="Deploy the dashboard to CloudWatch after generating it.",
-    )
-    parser.add_argument(
-        "--deploy-region", metavar="REGION",
-        help="AWS region for the dashboard (default: primary_region from config).",
-    )
+    parser.add_argument("--config", required=True, metavar="FILE",
+                        help="Path to YAML config (copy dashboard_config.example.yaml).")
+    parser.add_argument("--output", metavar="FILE",
+                        help="Write JSON to a file (default: stdout).")
+    parser.add_argument("--deploy", action="store_true",
+                        help="Deploy the dashboard via cloudwatch:PutDashboard.")
+    parser.add_argument("--deploy-region", metavar="REGION",
+                        help="Region for the dashboard (default: primary_region).")
+    parser.add_argument("--profile", metavar="NAME",
+                        help="AWS profile for --deploy.")
     args = parser.parse_args()
 
     cfg  = load_config(args.config)
@@ -323,17 +663,19 @@ def main():
             import boto3
         except ImportError:
             sys.exit("boto3 is required for --deploy: pip install boto3")
-
+        session = (boto3.Session(profile_name=args.profile)
+                   if args.profile else boto3.Session())
         deploy_region = args.deploy_region or cfg["primary_region"]
         dashboard_name = cfg["dashboard_name"]
         print(f"\nDeploying '{dashboard_name}' to {deploy_region}...", file=sys.stderr)
-        boto3.client("cloudwatch", region_name=deploy_region).put_dashboard(
+        session.client("cloudwatch", region_name=deploy_region).put_dashboard(
             DashboardName=dashboard_name,
             DashboardBody=json.dumps(body),
         )
-        print(f"Done. Open at:", file=sys.stderr)
+        print("Done. Open at:", file=sys.stderr)
         print(f"  https://{deploy_region}.console.aws.amazon.com/cloudwatch/home"
-              f"?region={deploy_region}#dashboards:name={dashboard_name}", file=sys.stderr)
+              f"?region={deploy_region}#dashboards:name={dashboard_name}",
+              file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/tools/validate_dashboard.py
+++ b/tools/validate_dashboard.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""validate_dashboard.py — drift check between generator output and deployed dashboard.
+
+Fetches a deployed CloudWatch dashboard via ``cloudwatch:GetDashboard``,
+regenerates the dashboard from a YAML config, and reports whether they match.
+
+Useful as a pre-deploy gate or as a CI guardrail: any time someone hand-edits
+the dashboard in the AWS console, this script flags the divergence so the
+config can be updated to match (or the manual edit reverted).
+
+Exit code 0 = no drift. Exit code 1 = drift detected. Exit code 2 = error
+(network, missing dashboard, etc.).
+
+Usage:
+    python3 tools/validate_dashboard.py --config <yaml>
+    python3 tools/validate_dashboard.py --config <yaml> --region us-east-1
+    python3 tools/validate_dashboard.py --config <yaml> --profile tbed
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Reuse the generator's loader + builder.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import generate_dashboard as gd  # noqa: E402
+
+
+def _normalize(d: dict) -> dict:
+    """Normalize a dashboard JSON for stable diffing.
+
+    CloudWatch may add cosmetic fields (period defaults, view defaults) on
+    GetDashboard. We canonicalize both sides so non-meaningful differences
+    don't show up as drift. Keep this conservative — only strip fields we
+    actively know are noise.
+    """
+    if not isinstance(d, dict):
+        return d
+    widgets = d.get("widgets", [])
+    return {"widgets": [_normalize_widget(w) for w in widgets]}
+
+
+def _normalize_widget(w: dict) -> dict:
+    """Drop fields that CW adds/strips during put/get round-trip."""
+    out = dict(w)
+    props = dict(out.get("properties", {}))
+    # CloudWatch returns these even when not set on PUT.
+    for k in ("liveData", "setPeriodToTimeRange", "sparkline", "trend"):
+        props.pop(k, None)
+    out["properties"] = props
+    return out
+
+
+def _print_diff_summary(local: dict, remote: dict) -> None:
+    """Best-effort human-readable diff so the operator sees what changed."""
+    local_titles = [w.get("properties", {}).get("title")
+                    or w.get("properties", {}).get("markdown", "")[:40]
+                    for w in local.get("widgets", [])]
+    remote_titles = [w.get("properties", {}).get("title")
+                     or w.get("properties", {}).get("markdown", "")[:40]
+                     for w in remote.get("widgets", [])]
+    if local_titles != remote_titles:
+        print("Widget titles differ:", file=sys.stderr)
+        print(f"  local  ({len(local_titles)}): {local_titles}", file=sys.stderr)
+        print(f"  remote ({len(remote_titles)}): {remote_titles}", file=sys.stderr)
+    else:
+        # Same titles, deeper field diff. Print the first widget that differs.
+        for i, (lw, rw) in enumerate(zip(local["widgets"], remote["widgets"])):
+            if lw != rw:
+                print(f"\nWidget {i} ({local_titles[i]!r}) differs:", file=sys.stderr)
+                print(f"  local : {json.dumps(lw, indent=2, sort_keys=True)}",
+                      file=sys.stderr)
+                print(f"  remote: {json.dumps(rw, indent=2, sort_keys=True)}",
+                      file=sys.stderr)
+                return
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True, metavar="FILE",
+                        help="Path to YAML config (same as generate_dashboard.py).")
+    parser.add_argument("--region", metavar="REGION",
+                        help="Region where the dashboard is deployed (default: primary_region).")
+    parser.add_argument("--profile", metavar="NAME", help="AWS profile.")
+    args = parser.parse_args()
+
+    cfg = gd.load_config(args.config)
+    expected = _normalize(gd.build_dashboard(cfg))
+    region = args.region or cfg["primary_region"]
+    name = cfg["dashboard_name"]
+
+    try:
+        import boto3
+    except ImportError:
+        sys.exit("boto3 is required: pip install boto3")
+    session = boto3.Session(profile_name=args.profile) if args.profile else boto3.Session()
+    cw = session.client("cloudwatch", region_name=region)
+
+    try:
+        resp = cw.get_dashboard(DashboardName=name)
+    except cw.exceptions.ResourceNotFound:
+        print(f"[error] Dashboard '{name}' does not exist in {region}.", file=sys.stderr)
+        print(f"        Run: python3 tools/generate_dashboard.py --config {args.config} --deploy",
+              file=sys.stderr)
+        sys.exit(2)
+    except Exception as e:
+        print(f"[error] Failed to fetch dashboard: {type(e).__name__}: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    deployed = _normalize(json.loads(resp["DashboardBody"]))
+
+    if expected == deployed:
+        print(f"OK — dashboard '{name}' in {region} matches generator output.")
+        sys.exit(0)
+
+    print(f"DRIFT — dashboard '{name}' in {region} differs from generator output.",
+          file=sys.stderr)
+    _print_diff_summary(expected, deployed)
+    print("\nFix: re-run with --deploy to overwrite, OR update the YAML config "
+          "to match the manual changes.", file=sys.stderr)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

PR-B of two for the dashboards work. Rewrites \`tools/generate_dashboard.py\` to consume the metrics PR-A adds and adapt to each app's deployment shape — single template, per-app YAML, conditional rows. Solves the user's matrix-testing need: one dashboard per app, accurate to that app's actual config.

## What changed

- **Scenario flags in YAML**: \`routing_mode\`, \`aurora_present\`, \`aurora_auto\`, \`redis_present\`, \`redis_auto\`, \`api_gw_present\`. Conditional validation: only requires Aurora resource fields when \`aurora_present=true\`, etc.
- **Conditional widget rows**: skip Aurora / ElastiCache / API GW rows when those flags are false. Per-signal panel only renders configured signals (no \`SignalElasticache\` for app-only stacks).
- **New rows that consume #98 metrics**:
  - Per-signal panel (HTTP / ALB / ECS / [APIgw] / [Aurora] / [ElastiCache])
  - State machine panel (LatchEngaged + *PromotionPending + ConsecutiveFailures with threshold annotation)
  - Lifecycle counters (FailoversTriggered, FailbacksCompleted, Promotions{Attempted,Succeeded,Failed} split by Tier)
  - Promotion durations (Aurora + Redis seconds)
- **Active/active variant** for the RegionActiveStatus framing.
- **Title scenario tag**: \`[Scenario: failover · Aurora-manual · Redis-absent · APIgw-absent]\`
- **All Vigil metrics pinned to AppName + RoutingMode** so per-app dashboards filter cleanly even when many apps share one CW namespace.
- **\`tools/validate_dashboard.py\`** — drift check (fetches deployed JSON, regenerates, diffs). Exit 1 on drift. Modeled on \`tools/validate_r53_alarm_wiring.py\`.
- **31 new tests** in \`tests/test_generate_dashboard.py\` covering 5 scenario combos, config validation, scenario defaults, threshold annotation, dimension propagation.

## Back-compat

Legacy YAMLs (no scenario flags) still work — defaults are \`routing_mode=failover\`, \`aurora_present=true\` matching the pre-#100 behavior.

## Depends on

- #98 (PR-A) — must be merged + deployed first so the new state-machine / lifecycle / duration widgets have data to graph. Pre-#98 those widgets render but show \"no data\".

## Test plan

- [x] \`python3 -m pytest tests/ -v\` → 485 passed (was 454 baseline + 31 new in test_generate_dashboard.py).
- [ ] Build a config for fo-v16-drill (Aurora-only, active/passive, \`redis_present=false\`, \`api_gw_present=false\`) and \`--deploy\` it to us-east-1 (after #98 deploys).
- [ ] Open the dashboard URL. Confirm:
  - ElastiCache + API GW rows absent
  - Per-signal panel renders only HTTP / ALB / ECS / Aurora
  - State machine, counters, duration panels render with live data
  - Title shows \`[Scenario: failover · Aurora-manual · Redis-absent · APIgw-absent]\`
- [ ] \`aws ecs update-service --desired-count 1\` on fo-v16-drill: dashboard should show SignalEcs flip 1→0, ConsecutiveFailures climb to 3, FailoversTriggered tick +1.
- [ ] Drift check: \`python3 tools/validate_dashboard.py --config fo-v16-drill.yaml --region us-east-1 --profile tbed\` exits 0.
- [ ] Generate a hypothetical C9 (Aurora-auto + Redis-auto) config to \`/tmp/c9.json\` and visually verify ElastiCache row, both promotion-pending widgets, and both duration widgets all render.

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)