### PR TITLE
fix(#102): RegionActiveStatus annotation + promotion-duration title

### DIFF
--- a/tests/test_generate_dashboard.py
+++ b/tests/test_generate_dashboard.py
@@ -397,3 +397,87 @@ class TestThresholdAnnotation:
                 assert any(a["value"] == 5 for a in anns)
                 return
         pytest.fail("Consecutive failures widget not generated")
+
+
+# ---------------------------------------------------------------------------
+# Issue #102 — RegionActiveStatus annotations + promotion duration title
+# ---------------------------------------------------------------------------
+
+class TestRegionActiveStatusAnnotation:
+    """Was 'Failed' on value=0 — misleading for latched failed-over-from
+    regions where 0 is intentional. Now 'Inactive (passive or failed)'
+    plus a LatchEngaged overlay so an operator immediately sees whether
+    the 0 is by design (latch) or unwanted."""
+
+    def _ras_widgets(self, c):
+        d = gd.build_dashboard(c)
+        return [w for w in d["widgets"]
+                if "RegionActiveStatus" in w.get("properties", {}).get("title", "")]
+
+    def test_annotation_label_is_not_failed(self):
+        widgets = self._ras_widgets(_aurora_cfg())
+        assert len(widgets) == 2  # primary + secondary
+        for w in widgets:
+            anns = w["properties"]["annotations"]["horizontal"]
+            zero_label = next(a["label"] for a in anns if a["value"] == 0)
+            assert zero_label != "Failed"
+            assert "passive" in zero_label.lower() or "inactive" in zero_label.lower()
+
+    def test_widget_includes_latch_engaged_overlay(self):
+        for w in self._ras_widgets(_aurora_cfg()):
+            metric_names = [
+                spec[1] for spec in w["properties"]["metrics"]
+                if isinstance(spec, list) and len(spec) >= 2
+            ]
+            assert "RegionActiveStatus" in metric_names
+            assert "LatchEngaged" in metric_names, \
+                "LatchEngaged overlay missing from RegionActiveStatus widget"
+
+    def test_latch_overlay_uses_correct_per_region_dim(self):
+        for w in self._ras_widgets(_aurora_cfg()):
+            title = w["properties"]["title"]
+            expected_region = title.split("— ")[1].strip()
+            for spec in w["properties"]["metrics"]:
+                if isinstance(spec, list) and len(spec) >= 2 and spec[1] == "LatchEngaged":
+                    region_idx = spec.index("Region")
+                    assert spec[region_idx + 1] == expected_region
+
+
+class TestPromotionDurationsTitle:
+    """Was hardcoded 'Aurora / Redis (seconds)' regardless of which tiers
+    were configured. Now reflects the actual deployment shape."""
+
+    def _duration_widget(self, c):
+        d = gd.build_dashboard(c)
+        for w in d["widgets"]:
+            t = w.get("properties", {}).get("title", "")
+            if "Promotion durations" in t:
+                return w
+        return None
+
+    def test_aurora_only_title(self):
+        w = self._duration_widget(_aurora_cfg())
+        assert w is not None
+        assert w["properties"]["title"] == "Promotion durations — Aurora (seconds)"
+
+    def test_aurora_and_redis_title(self):
+        w = self._duration_widget(_aurora_redis_cfg(aurora_auto=True))
+        assert w is not None
+        assert w["properties"]["title"] == "Promotion durations — Aurora and Redis (seconds)"
+
+    def test_redis_only_title(self):
+        # Edge case: Redis-only (no Aurora). Build a config with redis_present
+        # but aurora_present=False — _aurora_redis_cfg layers on top of
+        # _aurora_cfg, so go through _base_cfg explicitly.
+        cfg = _base_cfg(
+            redis_present=True,
+            primary_redis_rg="test-redis-w1",
+            secondary_redis_rg="test-redis-w2",
+        )
+        w = self._duration_widget(cfg)
+        assert w is not None
+        assert w["properties"]["title"] == "Promotion durations — Redis (seconds)"
+
+    def test_app_only_no_widget(self):
+        w = self._duration_widget(_base_cfg())
+        assert w is None  # row is omitted entirely

--- a/tools/generate_dashboard.py
+++ b/tools/generate_dashboard.py
@@ -226,6 +226,15 @@ def _row_alarms(c, y):
 
 
 def _row_region_active_status(c, y):
+    """RegionActiveStatus per region, with LatchEngaged overlaid.
+
+    Issue #102: previously labeled value=0 as 'Failed', which is misleading on
+    a latched failed-over-from region — there RegionActiveStatus=0 is the v1.0
+    anti-flip-flop latch's intended behavior, not a real failure. Overlaying
+    LatchEngaged on the same widget lets an operator immediately distinguish
+    'passive because latched' (LatchEngaged=1, RegionActiveStatus=0) from
+    'unhealthy and lost the active role' (LatchEngaged=0, RegionActiveStatus=0).
+    """
     p, s, ns, metric = c["primary_region"], c["secondary_region"], c["cw_namespace"], c["cw_metric"]
     yaxis = {"left": {"min": -0.1, "max": 1.5}}
     threshold_label = (
@@ -234,21 +243,29 @@ def _row_region_active_status(c, y):
     )
     annotations = {"horizontal": [
         {"value": 1, "color": "#2ca02c", "label": threshold_label},
-        {"value": 0, "color": "#d62728", "label": "Failed"},
+        {"value": 0, "color": "#7f7f7f", "label": "Inactive (passive or failed)"},
     ]}
     return [
         _metric(
             f"RegionActiveStatus — {p}",
             region=p,
-            metrics=[[ns, metric, "Region", p,
-                      {"color": "#2ca02c", "label": f"{p}"}]],
+            metrics=[
+                [ns, metric, "Region", p,
+                 {"color": "#2ca02c", "label": f"{p} active"}],
+                _vigil_metric(c, "LatchEngaged", p,
+                              color="#d62728", label="Latch engaged"),
+            ],
             x=0, y=y, w=12, h=4, yaxis=yaxis, annotations=annotations,
         ),
         _metric(
             f"RegionActiveStatus — {s}",
             region=s,
-            metrics=[[ns, metric, "Region", s,
-                      {"color": "#1f77b4", "label": f"{s}"}]],
+            metrics=[
+                [ns, metric, "Region", s,
+                 {"color": "#1f77b4", "label": f"{s} active"}],
+                _vigil_metric(c, "LatchEngaged", s,
+                              color="#d62728", label="Latch engaged"),
+            ],
             x=12, y=y, w=12, h=4, yaxis=yaxis, annotations=annotations,
         ),
     ], 4
@@ -569,20 +586,24 @@ def _row_promotion_durations(c, y):
         return [], 0
     p = c["primary_region"]
     metrics = []
+    tier_names = []
     if c["aurora_present"]:
         metrics.append(_vigil_metric(
             c, "AuroraPromotionDurationSeconds", p,
             color="#1f77b4", label="Aurora",
             extra_dims={"Tier": "Aurora"},
         ))
+        tier_names.append("Aurora")
     if c["redis_present"]:
         metrics.append(_vigil_metric(
             c, "RedisPromotionDurationSeconds", p,
             color="#9467bd", label="Redis",
             extra_dims={"Tier": "Redis"},
         ))
+        tier_names.append("Redis")
+    title = f"Promotion durations — {' and '.join(tier_names)} (seconds)"
     return [_metric(
-        "Promotion durations — Aurora / Redis (seconds)",
+        title,
         region=p, metrics=metrics,
         x=0, y=y, w=24, h=4,
         yaxis={"left": {"min": 0}}, stat="Maximum",


### PR DESCRIPTION
## Summary

Two cosmetic dashboard fixes that surfaced as soon as the fo-v16-drill dashboard went live with \`state=SECONDARY_ACTIVE\` / \`latch=true\`.

1. **\"Failed\" annotation on RegionActiveStatus is misleading.** On a latched failed-over-from region, \`RegionActiveStatus=0\` is the v1.0 anti-flip-flop latch's intended behavior — not a failure. An operator opening the live dashboard saw a red \"Failed\" annotation on us-east-1 and asked \"why is us-east-1 down?\". Changed the label to \`Inactive (passive or failed)\` and overlaid \`LatchEngaged\` on the same widget so the answer is visually obvious: latch=1 → it's by design.

2. **\`_row_promotion_durations\` title hardcoded \"Aurora / Redis\".** The metrics inside were already config-aware (only renders configured tiers), but the title always said \"Aurora / Redis\" regardless. Same class of bug as #96. Now the title reflects what's actually on the chart: \"Aurora\", \"Redis\", or \"Aurora and Redis\".

## Test plan

- [x] \`python3 -m pytest tests/ -v\` → 511 passed (504 baseline + 7 new).
- [x] New \`TestRegionActiveStatusAnnotation\` (3 tests): label is not 'Failed', LatchEngaged overlay present, overlay's Region dim matches widget region.
- [x] New \`TestPromotionDurationsTitle\` (4 tests): Aurora-only, Redis-only, Aurora+Redis, app-only (row omitted).
- [ ] Redeploy fo-v16-drill dashboard after merge — verify the \"Failed\" annotation is gone and LatchEngaged shows red on us-east-1.

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)