### PR TITLE
fix(#106): add TgArnSuffix to cfn/failover.yaml

### DIFF
--- a/cfn/failover.yaml
+++ b/cfn/failover.yaml
@@ -27,6 +27,10 @@ Parameters:
     Type: String
     Description: ALB ARN suffix (from ALB ARN after /app/)
     Default: ''
+  TgArnSuffix:
+    Type: String
+    Description: ALB target group ARN suffix (from TG ARN after /targetgroup/). Required alongside AlbArnSuffix for the orchestrator's HealthyHostCount signal — when either is empty the ALB check is SKIPPED.
+    Default: ''
   EcsClusterName:
     Type: String
   EcsServiceName:
@@ -233,6 +237,7 @@ Resources:
           HEALTH_CHECK_TIMEOUT_SECONDS: '5'
           HEALTH_CHECK_DISABLE_SSL_VERIFY: 'false'
           ALB_ARN_SUFFIX: !Ref AlbArnSuffix
+          TG_ARN_SUFFIX: !Ref TgArnSuffix
           ECS_CLUSTER_NAME: !Ref EcsClusterName
           ECS_SERVICE_NAME: !Ref EcsServiceName
           AURORA_CLUSTER_ID: !Ref AuroraClusterId


### PR DESCRIPTION
## Summary

Adds a `TgArnSuffix` parameter and `TG_ARN_SUFFIX` env var to `cfn/failover.yaml` so the ALB health signal survives stack redeploys. Discovered while smoke-testing the fo-v16-drill dashboard right after PR #99 deployed — `SignalAlb` was missing because `evaluate_alb_health` requires both ALB and TG suffixes, but the template only had ALB.

The fo-v16-drill Lambdas were already patched directly via `update-function-configuration`. This PR ensures the next `update-stack` doesn't wipe that patch.

## Test plan

- [x] cfn-lint validation clean (0 errors).
- [ ] On next fo-v16-drill stack update, pass `--parameter-overrides TgArnSuffix=...` (per-region suffixes documented in the issue).
- [ ] After update-stack, confirm `SignalAlb` continues to flow.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)